### PR TITLE
feat(i18n): full Spanish parity for the docs + auto-translation pipeline

### DIFF
--- a/.i18n/translate.mjs
+++ b/.i18n/translate.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// Auto-translation pipeline (Phase 2 core) — runs on `claude -p` (the Claude
+// subscription you already pay for), NOT an API key. For each EN .mdx passed as
+// an argument it produces a sibling .es.mdx: a faithful, natural Spanish (Spain)
+// transcreation that preserves all code, commands, MDX structure, and the
+// canonical non-translatables, and stamps the drift-tracking translationHash.
+//
+// Usage:
+//   node .i18n/translate.mjs content/docs/reference/modes/pdf.mdx [more.mdx ...]
+//
+// It calls `claude -p` once per file (a headless one-shot), captures the
+// translated file on stdout, injects the i18n frontmatter contract fields, and
+// writes <name>.es.mdx next to the source. Glossary of non-translatables is read
+// from .i18n/nontranslatables.yml (owner: search-ops) and injected into every
+// prompt. Content-hash algorithm is shared with .i18n/hash.mjs.
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { contentHash } from './hash.mjs';
+
+const GLOSSARY = readFileSync(new URL('./nontranslatables.yml', import.meta.url), 'utf8');
+
+/** content/docs/<rel>.mdx  ->  /docs/<rel>  (index -> parent, so /docs). */
+function docsUrl(path) {
+  let rel = path.replace(/^.*content\/docs\//, '').replace(/\.mdx$/, '');
+  rel = rel.replace(/(^|\/)index$/, '');
+  return '/docs' + (rel ? '/' + rel : '');
+}
+
+function buildPrompt(en) {
+  return `You are translating one page of the career-ops documentation from English into natural Spanish (Spain). Output ONLY the translated .mdx file — start directly with the frontmatter \`---\` line, no preamble, no commentary, and do NOT wrap the whole file in a code fence.
+
+RULES
+1. Translate into fluent, natural Spanish of Spain. Translate the prose, the headings, and the frontmatter fields \`title\`, \`description\` and \`seoTitle\`. Keep every other frontmatter key (icon, date, etc.) exactly as-is.
+2. PRESERVE EXACTLY — never translate: fenced code blocks and their contents, inline \`code\`, shell commands, file names and paths (cv.md, DATA_CONTRACT.md, reports/, output/, config/profile.yml, data/applications.md, AGENTS.md, package names, npm/npx commands), and all URLs. In markdown links translate the visible text but keep the URL. In MDX component tags (<Tabs>, <Tab>, <Callout>, <Steps>, <Step>, <Accordions>, <Accordion>, <details>, <summary>, raw <div>…) keep the tag names and the identifier attributes (value="…", items order) unchanged; you MAY translate human-visible attribute text such as title="…". Keep heading levels and the overall MDX structure identical.
+3. NON-TRANSLATABLES — keep verbatim (this list is authoritative):
+${GLOSSARY}
+   Also keep verbatim: the brand "career-ops" / "CareerOps", the name "Santiago Fernández de Valderrama Aparicio" (with Aparicio), mode ids (apply, scan, pipeline, auto-pipeline, oferta, ofertas, contacto, deep, followup, interview-prep, pdf, project, patterns, tracker), CLI names (Claude Code, Codex, OpenCode, Antigravity CLI, Grok, Qwen, Kimi, GitHub Copilot, Gemini CLI), portals (Greenhouse, Ashby, Lever, Wellfound), technical terms (MIT, ATS, CLI, Open Agent Skill Standard), and domains. Terms that are the de-facto standard in Spanish tech speech stay in English (open source, commit, pull request, script, tracker). NEVER use @ or x as inclusive-gender marks.
+4. CANONICAL FACTS — never alter: the funnel is 740 evaluated → 68 applied → 12 interviews → 1 offer (NEVER 631 or 122; those are prohibited). Scoring is FIVE dimensions plus a holistic global score (NEVER six). The signature thesis "Companies use AI to filter candidates. I just gave candidates AI to choose companies." stays in LITERAL ENGLISH — never translate or reword it.
+5. The result must be a valid .mdx beginning with a \`---\` frontmatter block.
+
+ENGLISH FILE TO TRANSLATE:
+${en}`;
+}
+
+/** Insert the i18n contract fields into the model's frontmatter block. */
+function stampFrontmatter(es, enPath, enRaw) {
+  const hash = contentHash(enRaw);
+  const from = docsUrl(enPath);
+  const contract = `translationHash: ${hash}\nlocalized: true\ntranslatedFrom: ${from}`;
+  // strip an accidental wrapping code fence
+  es = es.replace(/^\s*```[a-z]*\n/, '').replace(/\n```\s*$/, '').trim();
+  const m = es.match(/^---\n([\s\S]*?)\n---/);
+  if (!m) throw new Error(`no frontmatter in translation of ${enPath}`);
+  const fm = m[1]
+    .split('\n')
+    .filter((l) => !/^(translationHash|localized|translatedFrom):/.test(l))
+    .join('\n');
+  return es.replace(m[0], `---\n${fm}\n${contract}\n---`);
+}
+
+for (const enPath of process.argv.slice(2)) {
+  const esPath = enPath.replace(/\.mdx$/, '.es.mdx');
+  const enRaw = readFileSync(enPath, 'utf8');
+  process.stdout.write(`→ ${enPath} … `);
+  const res = spawnSync('claude', ['-p', buildPrompt(enRaw)], {
+    encoding: 'utf8',
+    maxBuffer: 20 * 1024 * 1024,
+    timeout: 300000,
+  });
+  if (res.status !== 0 || !res.stdout) {
+    console.log(`FAIL (status ${res.status}) ${(res.stderr || '').slice(0, 200)}`);
+    continue;
+  }
+  try {
+    const es = stampFrontmatter(res.stdout, enPath, enRaw);
+    writeFileSync(esPath, es);
+    console.log(`ok → ${esPath}`);
+  } catch (e) {
+    console.log(`POST-FAIL ${e.message}`);
+  }
+}

--- a/content/docs/introduction/guides/apply-for-a-job.es.mdx
+++ b/content/docs/introduction/guides/apply-for-a-job.es.mdx
@@ -1,0 +1,147 @@
+---
+title: Presentar una candidatura
+description: Usa career-ops para rellenar formularios de candidatura con respuestas adaptadas a tu perfil y al puesto que buscas.
+seoTitle: "Cómo presentar una candidatura con career-ops — redacta respuestas ATS y adapta tu CV"
+icon: FileInput
+translationHash: f2922090f40c99ec
+localized: true
+translatedFrom: /docs/introduction/guides/apply-for-a-job
+---
+
+Esta guía explica cómo usar `/career-ops apply` para rellenar un formulario de candidatura con respuestas adaptadas a tu perfil, tus proof points y el puesto concreto al que te presentas.
+
+<Callout title="Antes de empezar">
+  Asegúrate de haber completado la guía [Escanear portales de empleo](./scan-job-portals.mdx). El comando `apply` depende de un informe de evaluación existente. Si no existe informe para el puesto, ejecuta primero el pipeline.
+</Callout>
+
+## Ejecuta el comando apply
+
+Abre tu CLI agéntica en la carpeta raíz de career-ops y escribe:
+
+<Tabs items={["Claude Code", "Codex", "OpenCode", "Qwen CLI"]}>
+  <Tab value="Claude Code">
+    ```bash
+    /career-ops apply {company_name}
+    ```
+  </Tab>
+  <Tab value="Codex">
+    ```bash
+    Run the /career-ops apply command with the {company_name} argument.
+    ```
+  </Tab>
+  <Tab value="OpenCode">
+    ```bash
+    Run the /career-ops apply command with the {company_name} argument.
+    ```
+  </Tab>
+  <Tab value="Qwen CLI">
+    ```bash
+    Run the /career-ops apply command with the {company_name} argument.
+    ```
+  </Tab>
+</Tabs>
+
+Por ejemplo:
+
+```bash title="Claude Code"
+/career-ops apply Anthropic
+```
+
+career-ops localiza el informe correspondiente en `reports/`, usa Playwright para abrir una ventana del navegador y lee el formulario. Después genera una respuesta para cada campo — lista para copiar y pegar. No necesitas abrir el navegador tú mismo.
+
+<Callout title="Nota">
+  Si Playwright no está disponible, career-ops recurre a WebFetch para leer el formulario. Consulta [Configurar Playwright](./set-up-playwright.mdx) si quieres activar la experiencia completa basada en navegador.
+</Callout>
+
+**Si ejecutas el comando `/career-ops apply` sin argumentos**, el sistema te pide que aportes el contexto manualmente:
+<div className="rounded-lg bg-radial-[at_bottom] from-blue-500/20 p-4 border bg-origin-border border-fd-primary/10 prose-no-margin dark:bg-black/20">
+  <div className="rounded-xl bg-fd-background p-3">
+    | Opción                          | Cómo                                                                                                  |
+    | ------------------------------- | ----------------------------------------------------------------------------------------------------- |
+    | Comparte una captura de pantalla | Haz una captura de pantalla del formulario y compártela en el chat. career-ops lee imágenes directamente. |
+    | Pega las preguntas              | Copia las preguntas del formulario como texto y pégalas en el chat.                                    |
+    | Indica la empresa y el puesto   | Escribe el nombre de la empresa y el título del puesto. career-ops busca la coincidencia en `reports/`. |
+    | Comparte la URL de la candidatura | Pega la URL y career-ops navega hasta el formulario.                                                 |
+  </div>
+</div>
+
+## Rellena el formulario
+
+El sistema devuelve una lista numerada de respuestas — una por campo del formulario — que refleja el orden del propio formulario. Recorre la lista de arriba abajo y pega cada respuesta en el campo correspondiente.
+
+La salida tiene dos partes:
+
+**Respuestas** — cada campo del formulario, en orden:
+
+```
+1. Name
+   Andres Urdaneta
+
+2. Email
+   andres@example.com
+
+...
+
+12. Cover Letter (optional)
+    I've spent 5+ years shipping production Rails applications...
+```
+
+Los campos simples como el nombre, el email y las preguntas de sí/no van primero. Los campos de texto libre, como la carta de presentación, van al final.
+
+**Key notes** — un bloque breve después de las respuestas con todo lo que conviene tener en cuenta antes de enviar:
+
+```
+Key notes:
+- No salary field — you'll negotiate at offer. Anchor to $160K–$175K at offer stage.
+- Add github.com/yourhandle to your resume PDF before uploading.
+- Cover letter is optional but the draft above is tight — worth including.
+```
+
+Cada respuesta se construye a partir de una parte concreta de tu informe de evaluación:
+
+<div className="rounded-lg bg-radial-[at_bottom] from-blue-500/20 p-4 border bg-origin-border border-fd-primary/10 prose-no-margin dark:bg-black/20">
+  <div className="rounded-xl bg-fd-background p-3">
+    | Tipo de campo                                | Fuente                                                    |
+    | -------------------------------------------- | --------------------------------------------------------- |
+    | Carta de presentación, «por qué este puesto» | Proof points del Bloque B + historias STAR del Bloque F   |
+    | Preguntas cortas de texto libre              | El proof point o la historia más relevante para esa pregunta |
+    | Desplegables, sí/no                          | Respuestas directas extraídas de tu perfil                |
+  </div>
+</div>
+
+<Callout title="Campos de subida de archivos">
+  Usa el archivo de `output/` generado al crear el informe. Si todavía no existe ningún PDF, ejecuta primero `/career-ops pdf` y vuelve después al formulario. Consulta [Generar un PDF](generate-a-pdf.md).
+</Callout>
+
+## Envía la candidatura
+
+Revisa todas las respuestas y envía el formulario tú mismo. career-ops no hace clic en Submit.
+
+Después de enviarla, confírmalo en el chat:
+
+> "Enviada."
+
+career-ops hará lo siguiente:
+
+<div className="rounded-lg bg-radial-[at_bottom] from-blue-500/20 p-4 border bg-origin-border border-fd-primary/10 prose-no-margin dark:bg-black/20">
+  <div className="rounded-xl bg-fd-background p-3">
+    <Steps>
+      <Step title="Actualizar el estado de la candidatura">
+        Actualiza `data/applications.md` — cambiando el estado de `Evaluated` a `Applied`
+      </Step>
+      <Step title="Guardar las respuestas en el informe">
+        Guarda las respuestas finales en la Sección G del informe para futuras consultas
+      </Step>
+    </Steps>
+  </div>
+</div>
+
+## Qué hacer después
+<div className="rounded-lg bg-radial-[at_bottom] from-blue-500/20 p-4 border bg-origin-border border-fd-primary/10 prose-no-margin dark:bg-black/20">
+  <div className="rounded-xl bg-fd-background p-3">
+    | Puntuación        | Siguiente paso                                                                                                                                                                                     |
+    | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+    | **4.0 o más**     | Ejecuta `/career-ops contacto`. career-ops encuentra a un hiring manager o a un miembro del equipo en LinkedIn y redacta un mensaje de contacto. Enviarlo antes de que revisen tu candidatura mejora tu visibilidad. |
+    | **Cualquier puntuación** | Ejecuta `/career-ops tracker` para ver el estado actual de todo lo que tienes en tu pipeline.                                                                                                |
+  </div>
+</div>

--- a/content/docs/introduction/guides/batch-evaluate-offers.es.mdx
+++ b/content/docs/introduction/guides/batch-evaluate-offers.es.mdx
@@ -1,0 +1,157 @@
+---
+title: Evalúa ofertas en lote
+description: Procesa 10 o más ofertas de empleo en una sola sesión con workers de IA en paralelo y PDFs personalizados.
+seoTitle: "Evalúa ofertas de empleo en lote con career-ops — puntúa muchas a la vez"
+icon: FileStack
+translationHash: 5abe712784127777
+localized: true
+translatedFrom: /docs/introduction/guides/batch-evaluate-offers
+---
+
+Usa esta guía cuando tengas 10 o más ofertas de empleo que revisar y quieras procesarlas todas en una sola sesión en lugar de una a una.
+
+Cada oferta recibe su propio worker de Claude. Ese worker lee tu CV, puntúa el encaje, redacta un informe completo y guarda un PDF adaptado — todo sin que muevas un dedo.
+
+## Paso 1: Añade tus ofertas al fichero de entrada
+
+El sistema de batch lee las URLs de las ofertas desde un fichero llamado **`batch/batch-input.tsv`**. Piensa en él como una lista de tareas para el evaluador.
+
+<div className="rounded-lg bg-radial-[at_bottom] from-blue-500/20 p-4 border bg-origin-border border-fd-primary/10 prose-no-margin dark:bg-black/20">
+  <div className="rounded-xl bg-fd-background p-3">
+    <Steps>
+      <Step>
+        Abre **`batch/batch-input.tsv`** en cualquier editor de texto.
+      </Step>
+      <Step>
+        Añade una fila por oferta. Cada fila tiene cuatro columnas separadas por un tabulador:
+
+        | Columna | Qué escribir |
+        |--------|---------------|
+        | `id` | Un número único para esta oferta (1, 2, 3, …) |
+        | `url` | La URL completa de la oferta de empleo |
+        | `source` | Dónde la encontraste (p. ej., `LinkedIn`, `Greenhouse`) |
+        | `notes` | Una nota opcional — déjala en blanco si no tienes ninguna |
+      </Step>
+      <Step>
+        Guarda el fichero.
+      </Step>
+    </Steps>
+  </div>
+</div>
+
+**Ejemplo:**
+
+```text title="batch-input.tsv"
+id	url	source	notes
+1	https://jobs.example.com/senior-engineer	LinkedIn	
+2	https://greenhouse.io/jobs/fullstack-dev	Greenhouse	priority
+3	https://builtinaustin.com/job/rails-dev	BuiltIn	
+```
+
+<Callout title="Consejo">
+  Cada ID debe ser un número único. No te saltes números ni los repitas.
+</Callout>
+
+## Paso 2: Previsualiza tu batch (recomendado)
+
+Antes de procesar nada, ejecuta una comprobación rápida para ver cuántas ofertas están en espera. Todavía no se evalúa nada — esto es solo una vista previa.
+
+```bash title="Terminal"
+./batch/batch-runner.sh --dry-run
+```
+
+Verás una lista de las ofertas pendientes con sus IDs. Si algo no cuadra, corrige el fichero de entrada ahora, antes de dedicar tiempo a una lista incorrecta.
+
+## Paso 3: Ejecuta el batch
+
+Cuando estés listo, arranca el batch. Puedes procesar las ofertas de una en una o varias a la vez.
+
+**De una en una (la opción más lenta, la que menos memoria consume):**
+
+```bash title="Terminal"
+./batch/batch-runner.sh
+```
+
+**De dos en dos (una buena opción por defecto):**
+
+```bash title="Terminal"
+./batch/batch-runner.sh --parallel 2
+```
+
+**De tres en tres (más rápido, pero más exigente con tu máquina):**
+
+```bash title="Terminal"
+./batch/batch-runner.sh --parallel 3
+```
+
+**Omite las ofertas que puntúen por debajo de un umbral (p. ej., por debajo de 4.0 sobre 5):**
+
+```bash title="Terminal"
+./batch/batch-runner.sh --parallel 2 --min-score 4.0
+```
+
+Observa la terminal mientras corre el batch. Cada línea te indica qué oferta se está procesando y si terminó o falló.
+
+## Paso 4: Lee los resultados según van llegando
+
+No necesitas esperar a que el batch termine. Los resultados aparecen a medida que se completa cada oferta.
+
+**Informes de evaluación completos** → `reports/`
+
+Cada informe es un fichero con un nombre del tipo `042-company-name-2026-04-14.md`. Ábrelo para ver:
+
+- Un resumen del puesto
+- Cómo de bien encaja tu CV con la oferta
+- Un análisis salarial
+- Un plan sugerido de preparación de la entrevista
+
+**Entradas de una línea para el tracker** → `batch/tracker-additions/`
+
+Cada oferta deja también aquí un fichero con un resumen breve. Estos se añaden a tu tracker principal en el Paso 6.
+
+## Paso 5: Reintenta las ofertas fallidas
+
+A veces un worker falla — por ejemplo, si la URL de una oferta dejó de cargar. Las ofertas fallidas aparecen en la terminal con un mensaje de error breve.
+
+**Reintenta solo las ofertas fallidas:**
+
+```bash title="Terminal"
+./batch/batch-runner.sh --retry-failed
+```
+
+**Reintenta con hasta 3 intentos en lugar de los 2 por defecto:**
+
+```bash title="Terminal"
+./batch/batch-runner.sh --retry-failed --max-retries 3
+```
+
+El batch omite cualquier oferta que ya terminó con éxito — así que volver a ejecutarlo es siempre seguro.
+
+## Paso 6: Fusiona los resultados en tu tracker
+
+Cuando el batch termine, ejecuta este comando para añadir todas las evaluaciones nuevas a `data/applications.md`:
+
+```bash title="Terminal"
+node merge-tracker.mjs
+```
+
+Este script:
+
+1. Lee los ficheros de resumen de `batch/tracker-additions/`
+2. Comprueba duplicados para que nunca acabes con dos filas para la misma oferta
+3. Añade las entradas nuevas a tu tracker de candidaturas
+4. Archiva los ficheros procesados en `batch/tracker-additions/merged/`
+
+**Para previsualizar los cambios sin escribir nada:**
+
+```bash title="Terminal"
+node merge-tracker.mjs --dry-run
+```
+
+## Qué hacer a continuación
+
+Abre **`data/applications.md`** para ver todas tus evaluaciones en una sola tabla. Desde ahí puedes:
+
+- Ordenar por puntuación para encontrar tus mejores encajes
+- Abrir los informes individuales en `reports/` para un análisis en profundidad
+- Iniciar el proceso de candidatura para tus mejores opciones con `/career-ops apply`

--- a/content/docs/introduction/guides/interview-modes.es.mdx
+++ b/content/docs/introduction/guides/interview-modes.es.mdx
@@ -1,0 +1,66 @@
+---
+title: Prepárate para las entrevistas
+description: Usa los modos de entrevista — plan, practice, debrief — para preparar una ronda de entrevista concreta, ensayarla con un entrevistador de IA y convertir cada entrevista real en inteligencia para la siguiente.
+seoTitle: "Preparación de entrevistas con career-ops — preparación ronda a ronda"
+icon: GraduationCap
+translationHash: 684f86b0ae8151c2
+localized: true
+translatedFrom: /docs/introduction/guides/interview-modes
+---
+
+Los modos de entrevista son el sistema de preparación de entrevistas de career-ops, incluido desde la v1.16.0: `interview/plan` construye un plan de preparación por bloques de tiempo para una ronda concreta, `interview/practice` ejecuta una entrevista simulada realista pregunta a pregunta, e `interview/debrief` captura lo que pasó de verdad para que la siguiente ronda empiece con ventaja. Juntos forman un bucle — planificar, practicar, entrevistar, hacer debrief, repetir — cuyo valor se acumula a lo largo de todo un proceso de selección.
+
+Complementan al [modo `interview-prep`](/es/docs/reference/modes/interview-prep), más antiguo, que construye tu base duradera (banco de historias, banco de preguntas). Los tres modos enfocados tratan sobre una *ronda concreta que tienes por delante*.
+
+<Callout title="Lo que necesitas antes">
+Un workspace con tu `cv.md` y tu `config/profile.yml` en su sitio (el [Inicio rápido](/es/docs) configura ambos). Los modos los leen para anclar cada plan y cada pieza de feedback en tu experiencia real — no en consejos genéricos de entrevista.
+</Callout>
+
+## El bucle de un vistazo
+
+| Modo | Cuándo | Qué obtienes |
+| --- | --- | --- |
+| `interview/plan` | En cuanto se agenda una ronda | Un plan de preparación por bloques de tiempo dimensionado a las horas que realmente tienes |
+| `interview/practice` | Antes de la ronda | Una entrevista simulada realista con feedback estructurado por respuesta |
+| `interview/debrief` | Justo después de la entrevista real | Una evaluación honesta pregunta a pregunta + un banco de preguntas actualizado |
+
+## Plan: convierte una fecha en una agenda
+
+Dale a `interview/plan` la descripción del puesto y la fecha y hora de la entrevista, además del tipo de ronda y el entrevistador si los conoces. Lee tu CV y tu perfil, ejecuta una evaluación honesta de encaje — fortalezas en las que anclarte, gaps que probablemente pondrán a prueba — y divide las horas que te quedan en bloques concretos de preparación.
+
+```txt title="Example"
+/career-ops interview/plan
+
+→ Inputs: JD (pasted), interview Thursday 14:00, HM screen with Ana (Eng Manager)
+→ Fit assessment: 4 strengths to anchor · 2 gaps ranked by test likelihood
+→ Plan (9 hours available):
+   Block 1 — Lock your narrative (~1.5h): timeline, "why us", strongest proof point
+   Block 2 — Gap: event-driven architectures (~3h)
+   Block 3 — Behavioral stories, STAR+R (~2h)
+   Block 4 — Mock run + comp answer (~1.5h)
+```
+
+El plan se calibra según la ronda: un screening con recruiter recibe logística y narrativa, no interioridades técnicas; una sesión en profundidad con un practitioner recibe profundidad en la habilidad central de la descripción del puesto. Si existe un banco de preguntas de una ronda anterior, todo aquello con lo que te atascaste recibe un bloque dedicado — los datos de rendimiento real pesan más que el riesgo inferido.
+
+## Practice: ensaya contra un entrevistador realista
+
+`interview/practice` interpreta al entrevistador — con su nombre y su rol si se los das — y hace una pregunta cada vez, sin salirse del personaje, con follow-ups naturales cuando un entrevistador real presionaría para profundizar. Tras cada respuesta recibes feedback estructurado: qué funcionó, qué afinar y una versión más sólida de tu respuesta anclada en tu CV real y en tu banco de historias.
+
+También hace seguimiento de la sesión igual que lo haría un entrevistador: si recurres a la misma historia dos veces, avisa de que tu repertorio de ejemplos parece escaso; si tu respuesta termina en el dominio equivocado para el puesto, te dice dónde deberías aterrizarla.
+
+<Callout>
+Practice es honesto sobre sus propios límites: si aún no has construido un banco de preguntas ni notas de preparación específicas del puesto, lo dice y se ofrece a ejecutar `interview-prep` o `interview/plan` primero, en vez de ejecutar en silencio una sesión genérica.
+</Callout>
+
+## Debrief: no pierdas nunca la inteligencia de una entrevista
+
+Ejecuta `interview/debrief` justo después de una entrevista real, con la memoria fresca. Te guía por cada pregunta que recuerdes, registra cómo reaccionó el entrevistador y produce una evaluación honesta pregunta a pregunta. Después hace el trabajo que se acumula:
+
+- **Actualiza el banco de preguntas** — cada pregunta marcada ✅ / 🟡 / 🔴 según tu rendimiento real, no según sensaciones.
+- **Cierra los gaps** — por cada 🔴, explica la respuesta correcta con un ejemplo resuelto y la conecta con una historia que ya tienes.
+- **Extrae historias nuevas** — si contaste algo en la sala que aún no está en tu banco de historias, lo convierte en una historia STAR+R sobre la marcha.
+- **Predice la siguiente ronda** — si conoces el formato, pronostica las preguntas probables a partir del rol del entrevistador y de lo que esta ronda ya cubrió.
+
+## Por qué funciona este bucle
+
+La preparación de entrevistas suele volver a cero con cada ronda. Los modos de entrevista la hacen acumulativa: lo que un entrevistador real preguntó de verdad se convierte en la señal de preparación de máxima prioridad para la siguiente ronda, guardada en ficheros Markdown planos (`interview-prep/question-bank.md`, `story-bank.md`) que son tuyos, en tu máquina, como todo lo demás en career-ops.

--- a/content/docs/introduction/guides/meta.es.json
+++ b/content/docs/introduction/guides/meta.es.json
@@ -1,0 +1,10 @@
+{
+  "title": "Guías",
+  "pages": [
+    "scan-job-portals",
+    "apply-for-a-job",
+    "batch-evaluate-offers",
+    "set-up-playwright",
+    "interview-modes"
+  ]
+}

--- a/content/docs/introduction/guides/scan-job-portals.es.mdx
+++ b/content/docs/introduction/guides/scan-job-portals.es.mdx
@@ -1,0 +1,303 @@
+---
+title: Escanea portales de empleo
+description: Configura y ejecuta el escáner de portales para encontrar nuevas ofertas de empleo automáticamente.
+seoTitle: "Escanea portales de empleo con career-ops — Greenhouse, Ashby, Lever, cero tokens"
+icon: ScanEye
+translationHash: 13f18941c14fa8c0
+localized: true
+translatedFrom: /docs/introduction/guides/scan-job-portals
+---
+
+Esta guía explica cómo configurar `portals.yml` y ejecutar el escáner de portales para encontrar nuevas ofertas de empleo automáticamente.
+
+<Callout title="Antes de empezar">
+  Asegúrate de haber completado la guía de [Inicio rápido](../../index.mdx). Necesitas tener `cv.md` y `modes/_profile.md` en su sitio para que el escaneo sea útil.
+</Callout>
+
+## Configura portals.yml
+
+`portals.yml` es el fichero que controla qué busca el escáner y dónde lo busca. Lo creas una vez a partir de la plantilla incluida y después lo editas para que coincida con los puestos que buscas.
+
+Ejecuta este comando desde la carpeta del proyecto:
+
+```bash title="Terminal"
+cp templates/portals.example.yml portals.yml
+```
+
+Abre `portals.yml` en cualquier editor de texto. El fichero tiene tres secciones. Los pasos siguientes recorren cada una de ellas.
+
+### Configura tu filtro de títulos
+
+El filtro de títulos es la forma en que el escáner decide si merece la pena mostrarte una oferta. Compara el título del puesto con dos listas de palabras clave.
+
+Busca la sección `title_filter` cerca del principio del fichero:
+
+```yaml title="portals.yml"
+title_filter:
+  positive:
+    - "AI"
+    - "ML"
+    - "Product Manager"
+  negative:
+    - "Junior"
+    - "Intern"
+  seniority_boost:
+    - "Senior"
+    - "Staff"
+    - "Lead"
+```
+
+**Sustituye la lista `positive`** por palabras clave que coincidan con los puestos que buscas. Una oferta debe coincidir con al menos una palabra clave de esta lista para pasar el filtro. La comprobación no distingue mayúsculas de minúsculas, así que `"AI"` también captura `"ai engineer"`.
+
+**Sustituye la lista `negative`** por palabras clave que descarten una oferta. Si alguna de ellas aparece en el título, la oferta se omite — aunque haya coincidido con una palabra clave positiva.
+
+**Deja `seniority_boost` tal cual** a menos que quieras añadir o quitar niveles de seniority. Estas palabras clave no filtran nada — solo hacen que las ofertas que coinciden aparezcan más arriba en los resultados.
+
+**Ejemplo:** si buscas puestos de ingeniería Rails, tu filtro podría tener este aspecto:
+
+```yaml title="portals.yml"
+title_filter:
+  positive:
+    - "Rails"
+    - "Ruby"
+    - "Full Stack"
+    - "Backend"
+  negative:
+    - "Junior"
+    - "Intern"
+    - "PHP"
+    - "Java"
+  seniority_boost:
+    - "Senior"
+    - "Staff"
+    - "Lead"
+```
+
+<Callout title="Consejo">
+  Empieza con una lista `positive` pequeña, de tres a cinco palabras clave. Siempre puedes añadir más después. Una lista larga hace más difícil ver por qué una oferta pasó el filtro o no.
+</Callout>
+
+### Añade empresas a seguir
+
+La sección `tracked_companies` es una lista de empresas concretas que quieres que el escáner compruebe en cada ejecución. El escáner va directamente a la página de empleo de cada empresa y lee los puestos abiertos.
+
+Busca la sección `tracked_companies` cerca del final del fichero. Cada entrada tiene este aspecto:
+
+```yaml title="portals.yml"
+tracked_companies:
+  - name: Anthropic
+    careers_url: https://job-boards.greenhouse.io/anthropic
+    api: https://boards-api.greenhouse.io/v1/boards/anthropic/jobs
+    enabled: true
+
+  - name: OpenAI
+    careers_url: https://openai.com/careers
+    enabled: true
+```
+
+**Para añadir una empresa**, copia una entrada existente y cambia los valores:
+
+<div className="rounded-lg bg-radial-[at_bottom] from-blue-500/20 p-4 border bg-origin-border border-fd-primary/10 prose-no-margin dark:bg-black/20">
+  <div className="rounded-xl bg-fd-background p-3">
+    | Campo         | Qué poner                                                                                            |
+    | ------------- | ---------------------------------------------------------------------------------------------------- |
+    | `name`        | El nombre de la empresa tal y como quieres que aparezca en los resultados                             |
+    | `careers_url` | La URL directa a la página de ofertas de empleo de la empresa                                         |
+    | `api`         | Opcional. La URL de la API de Greenhouse si la empresa usa Greenhouse. Omítelo si no estás seguro.    |
+    | `enabled`     | Ponlo a `true` para incluir la empresa o a `false` para omitirla sin borrar la entrada.               |
+  </div>
+</div>
+
+
+**Para encontrar la `careers_url` de una empresa**, ve a la web de la empresa, haz clic en Careers o Jobs, y copia la URL de la página que lista los puestos abiertos. Esa es la URL que debes usar.
+
+**Para desactivar una empresa sin borrarla**, pon `enabled: false`:
+
+```yaml title="portals.yml"
+  - name: Stripe
+    careers_url: https://stripe.com/jobs/search
+    enabled: false
+```
+
+<Callout title="Nota">
+  Toda empresa en `tracked_companies` debe tener una `careers_url`. Sin ella, el escáner no tiene ninguna página que visitar y omitirá esa entrada.
+</Callout>
+
+### Revisa las consultas de búsqueda
+
+La sección `search_queries` ejecuta búsquedas web más amplias para encontrar puestos en empresas que no están en tu lista de seguimiento. La plantilla incluye muchas consultas ya preparadas.
+
+No necesitas cambiar esta sección para empezar. Las consultas ya preparadas cubren los principales portales de empleo, incluyendo Greenhouse y Ashby, entre otros.
+
+Cuando estés listo para personalizarlas, cada consulta tiene este aspecto:
+
+```yaml title="portals.yml"
+search_queries:
+  - name: Greenhouse — Rails Engineer
+    query: 'site:job-boards.greenhouse.io "Rails Engineer" OR "Ruby on Rails" remote'
+    enabled: true
+```
+
+Para desactivar una consulta que no necesites, pon `enabled: false`. Para añadir una nueva, copia una entrada existente, dale un `name` nuevo y actualiza el texto de `query`.
+
+## Ejecuta un escaneo
+
+Hay dos formas de ejecutar un escaneo. Usa la que encaje con lo que necesitas.
+
+### Opción A — Ejecuta el script directamente
+
+```bash title="Terminal"
+npm run scan
+```
+
+Ejecútalo desde la carpeta del proyecto. El script lee `portals.yml`, consulta la API de cada empresa directamente y escribe las ofertas nuevas en `data/pipeline.md`. No consume tokens de IA y tarda unos 30 segundos.
+
+Esta opción solo funciona con empresas que usan Greenhouse, Ashby o Lever. Las empresas sin una de esas plataformas se omiten.
+
+**Previsualiza los resultados antes de guardarlos:**
+
+```bash title="Terminal"
+npm run scan -- --dry-run
+```
+
+Esto ejecuta el escaneo completo pero no escribe nada en disco. Úsalo para comprobar la configuración de tus filtros antes de guardar resultados.
+
+**Escanea una sola empresa:**
+
+```bash title="Terminal"
+npm run scan -- --company Anthropic
+```
+
+Sustituye `Anthropic` por cualquier nombre de empresa de tu lista `tracked_companies`. La coincidencia no distingue mayúsculas de minúsculas.
+
+### Opción B — Ejecuta el escaneo con IA dentro de Claude Code
+
+Abre Claude Code en la carpeta del proyecto y escribe:
+
+```bash title="Claude Code"
+/career-ops scan
+```
+
+Esta versión visita la página de empleo de cada empresa directamente usando un navegador, así que funciona incluso con empresas que no tienen API pública. También ejecuta las `search_queries` de tu `portals.yml` para encontrar puestos en empresas que no están en tu lista de seguimiento.
+
+Usa esta opción cuando:
+- Una empresa de tu lista no usa Greenhouse, Ashby ni Lever
+- Quieres descubrir empresas nuevas, no solo comprobar las conocidas
+- El escaneo con el script pasó por alto algo que esperabas ver
+
+<Callout title="Consejo">
+  La Opción B consume tokens de la API de Claude y tarda más que el script. Para una comprobación rápida diaria, la Opción A es más rápida.
+</Callout>
+
+## Lee el resultado del escaneo
+
+Cuando el escaneo termina, verás un resumen como este:
+
+```text title="Terminal"
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Portal Scan — 2026-04-13
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Companies scanned:     42
+Total jobs found:      318
+Filtered by title:     291 removed
+Duplicates:            4 skipped
+New offers added:      23
+
+New offers:
+  + Anthropic | AI Engineer | San Francisco, CA
+  + ElevenLabs | Solutions Architect | Remote
+  ...
+
+→ Run /career-ops pipeline to evaluate new offers.
+```
+
+Esto es lo que significa cada línea:
+
+<div className="rounded-lg bg-radial-[at_bottom] from-blue-500/20 p-4 border bg-origin-border border-fd-primary/10 prose-no-margin dark:bg-black/20">
+  <div className="rounded-xl bg-fd-background p-3">
+    | Línea | Qué te dice |
+    |---|---|
+    | **Companies scanned** | Cuántas empresas de `tracked_companies` se comprobaron |
+    | **Total jobs found** | Todos los puestos abiertos vistos en esas empresas, antes de aplicar ningún filtro |
+    | **Filtered by title** | Ofertas eliminadas porque el título no coincidía con tu `title_filter` |
+    | **Duplicates skipped** | Ofertas que ya estaban en tu pipeline o tracker — no se añaden de nuevo |
+    | **New offers added** | Ofertas que pasaron todos los filtros y son nuevas para ti |
+  </div>
+</div>
+
+
+Si **New offers added** es 0, puede que tu filtro de títulos sea demasiado estricto. Prueba a añadir una palabra clave a tu lista `positive` y vuelve a ejecutar el escaneo.
+
+**Adónde van las ofertas nuevas:** cada oferta nueva se añade como una línea en `data/pipeline.md`. Esa es la lista de ofertas pendientes de evaluar.
+
+**Qué hace `data/scan-history.tsv`:** cada URL que el escáner ve — tanto si se añadió, se filtró o se omitió — queda registrada aquí. Así es como el escáner evita mostrarte la misma oferta dos veces en escaneos futuros. No necesitas editar este fichero.
+
+## Evalúa las ofertas nuevas de un escaneo
+
+Después de que un escaneo añada ofertas nuevas a `data/pipeline.md` — tu lista de ofertas de empleo pendientes — ejecuta el comando pipeline para evaluar cada una contra tu perfil. Este paso usa Claude para leer la descripción del puesto, compararla con tu `cv.md` y `modes/_profile.md`, y producir un resumen con puntuación para cada puesto.
+
+Abre Claude Code en la carpeta del proyecto y escribe:
+
+```bash title="Terminal"
+/career-ops pipeline
+```
+
+Claude lee cada URL pendiente de `data/pipeline.md`, visita cada oferta publicada y la evalúa. Los resultados llegan por lotes. Cada lote muestra una tabla como esta:
+
+Lote 1 terminado (Anthropic, ElevenLabs, Mistral):
+
+<div className="rounded-lg bg-radial-[at_bottom] from-blue-500/20 p-4 border bg-origin-border border-fd-primary/10 prose-no-margin dark:bg-black/20">
+  <div className="rounded-xl bg-fd-background p-3">
+    | #   | Empresa    | Puesto              | Puntuación | Legitimidad                      |
+    | --- | ---------- | ------------------- | ---------- | -------------------------------- |
+    | 024 | Anthropic  | AI Engineer         | 4.8/5      | High Confidence                  |
+    | 025 | ElevenLabs | Solutions Architect | 4.1/5      | High Confidence — fast-growing   |
+    | 026 | Mistral AI | Product Manager     | 3.2/5      | Proceed w/ Caution — role closed |
+  </div>
+</div>
+
+
+Esto es lo que significa cada columna:
+
+<div className="rounded-lg bg-radial-[at_bottom] from-blue-500/20 p-4 border bg-origin-border border-fd-primary/10 prose-no-margin dark:bg-black/20">
+  <div className="rounded-xl bg-fd-background p-3">
+    | Columna         | Qué te dice                                                                                                                                                                                                    |
+    | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | **#**           | El número del informe. Úsalo para encontrar el informe completo en `reports/` — por ejemplo, el informe 024 es `reports/024-anthropic-2026-04-13.md`                                                             |
+    | **Puntuación**  | Cómo de bien encaja el puesto con tu perfil, de 1.0 a 5.0                                                                                                                                                        |
+    | **Legitimidad** | Si la oferta parece real y activa. "High Confidence" significa que la oferta está activa y los detalles cuadran. "Proceed w/ Caution" significa que algo levantó una alerta — lee la nota que la acompaña.        |
+  </div>
+</div>
+
+**Para leer la evaluación completa de un puesto**, tienes dos opciones:
+
+- **Abre el fichero del informe directamente** — encuéntralo en la carpeta `reports/` usando el número de la tabla.
+- **Usa el dashboard** — ejecuta `./dashboard/career-dashboard` desde la carpeta del proyecto para navegar por todos tus informes en una interfaz de terminal. Puedes filtrar por puntuación y estado, y abrir cualquier informe sin salir del terminal.
+
+## Qué hacer después
+
+Cuando `/career-ops pipeline` termina, cada oferta tiene una puntuación de 1.0 a 5.0. Puedes encontrar el informe completo de cualquier puesto en la carpeta `reports/`. La puntuación muestra cómo de bien encaja el puesto con tu perfil.
+
+Usa la puntuación como punto de partida:
+
+<div className="rounded-lg bg-radial-[at_bottom] from-blue-500/20 p-4 border bg-origin-border border-fd-primary/10 prose-no-margin dark:bg-black/20">
+  <div className="rounded-xl bg-fd-background p-3">
+    | Puntuación        | Acción recomendada                                                                                                                                |
+    | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | **4.5 o más**     | Encaje fuerte. Ejecuta `/career-ops apply` de inmediato.                                                                                             |
+    | **4.0 – 4.4**     | Buen encaje. Ejecuta `/career-ops apply`. También puedes ejecutar `/career-ops contacto` primero para contactar con alguien del equipo antes de enviar tu candidatura. |
+    | **3.5 – 3.9**     | Podría ir en cualquier dirección. Ejecuta `/career-ops deep` para saber más antes de decidir.                                                        |
+    | **Menos de 3.5**  | Descártala salvo que tengas una razón concreta para presentarte.                                                                                     |
+  </div>
+</div>
+
+Esto es lo que hace cada comando:
+
+- **`/career-ops apply`** — Abre el formulario de solicitud y escribe respuestas adaptadas a tu perfil. Se detiene antes de enviar para que puedas revisarlo todo primero.
+- **`/career-ops contacto`** — Encuentra a un hiring manager o miembro del equipo en LinkedIn y redacta un mensaje corto de contacto para que lo envíes tú.
+- **`/career-ops deep`** — Investiga la empresa y el puesto en profundidad. Úsalo cuando estés indeciso y quieras más información antes de decidir.
+- **`/career-ops tracker`** — Muestra el estado de cada puesto de tu pipeline. Ejecútalo siempre que quieras ver cómo van las cosas.
+
+<Callout title="Consejo">
+  No tienes que ir en orden. Si un puesto puntúa 4.8 pero nunca has oído hablar de la empresa, ejecuta `/career-ops deep` primero. Los comandos funcionan por sí solos — usa el que encaje con tu situación.
+</Callout>

--- a/content/docs/introduction/guides/set-up-playwright.es.mdx
+++ b/content/docs/introduction/guides/set-up-playwright.es.mdx
@@ -1,0 +1,141 @@
+---
+title: Configura Playwright
+description: Instala y configura Playwright para la automatización del navegador.
+seoTitle: "Configura Playwright para career-ops — scraping de ofertas y exportación del CV a PDF"
+icon: Globe
+translationHash: d900e7e8e58ee7f6
+localized: true
+translatedFrom: /docs/introduction/guides/set-up-playwright
+---
+
+Esta guía recorre los tres pasos de configuración que dan a career-ops sus capacidades de automatización del navegador:
+
+<div className="rounded-lg bg-radial-[at_bottom] from-blue-500/20 p-4 border bg-origin-border border-fd-primary/10 prose-no-margin dark:bg-black/20">
+  <div className="rounded-xl bg-fd-background p-3">
+    <Steps>
+      <Step title="Instala el paquete de Playwright">
+        Instala el paquete Node de Playwright
+      </Step>
+      <Step title="Descarga Chromium">
+        Descarga el navegador Chromium que Playwright controla
+      </Step>
+      <Step title="Configura el MCP de Playwright">
+        Configura el MCP de Playwright para que Claude pueda manejar el navegador durante el paso apply
+      </Step>
+    </Steps>
+  </div>
+</div>
+
+<Callout title="Antes de empezar">
+  Completa la guía de [inicio rápido](../../index.mdx). Node.js 20 LTS o posterior debe estar instalado y debes estar dentro de la carpeta raíz de career-ops.
+</Callout>
+
+---
+
+## Instala el paquete de Playwright
+
+Ejecuta `npm install` desde la carpeta raíz de career-ops:
+
+```bash title="Terminal"
+npm install
+```
+
+Esto instala Playwright y el resto de dependencias del proyecto declaradas en `package.json`. Sáltate este paso si ya lo ejecutaste durante la configuración inicial.
+
+## Descarga Chromium
+
+Playwright necesita su propia copia de Chromium para automatizar. El instalador normalmente la descarga automáticamente justo después de las dependencias; si `npm run doctor` indica que falta, descárgala ejecutando:
+
+```bash title="Terminal"
+npx playwright install chromium
+```
+
+Es un paso que se hace una sola vez. No necesitas repetirlo tras actualizaciones de `npm`.
+
+## Configura el MCP de Playwright
+
+El MCP de Playwright permite a Claude controlar el navegador directamente durante el paso `/career-ops apply` — navegar hasta los formularios de solicitud de empleo, leer las etiquetas de los campos y sugerir respuestas.
+
+### Registra el servidor MCP
+
+Ejecuta este comando desde cualquier ubicación para registrar el MCP de Playwright en Claude Code:
+
+```bash title="Terminal"
+claude mcp add playwright npx @playwright/mcp@latest
+```
+
+Este es el método de registro en un solo paso de la [documentación del MCP de Playwright](https://playwright.dev/docs/getting-started-mcp). Escribe la entrada del servidor en tu configuración de Claude automáticamente.
+
+### Configuración manual (alternativa)
+
+Si prefieres configurarlo a mano, añade la siguiente entrada a `.claude/settings.local.json` en la raíz de career-ops, o a tu configuración global de Claude:
+
+```json title=".claude/settings.local.json"
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["y", "@playwright/mcp@latest"]
+    }
+  }
+}
+```
+
+Reinicia Claude Code tras guardar el archivo. career-ops tendrá entonces acceso a `browser_navigate` y `browser_snapshot` durante las sesiones de apply.
+
+---
+
+## Verifica la configuración
+
+Ejecuta el script doctor para confirmar que los tres componentes están en su sitio:
+
+```bash title="Terminal"
+npm run doctor
+```
+
+Busca la confirmación de que Playwright, Chromium y el servidor MCP están listos. Si la comprobación pasa, la configuración está completa.
+
+---
+
+## Mira cómo el navegador rellena el formulario
+
+Por defecto, Playwright se ejecuta en modo headless: lee y rellena el formulario en segundo plano sin abrir una ventana visible.
+
+Para ver cómo el navegador se abre y rellena el formulario en directo, añade una instrucción al comando apply:
+
+<Tabs items={["Claude Code", "Codex", "OpenCode", "Qwen CLI"]}>
+  <Tab value="Claude Code">
+    ```bash
+    /career-ops apply {company_name} open up with playwright the browser and fill out the entire form
+    ```
+  </Tab>
+  <Tab value="Codex">
+    ```bash
+    Run the /career-ops apply command with the {company_name} argument. Then, use the Playwright MCP to open a browser window and fill out the entire form live.
+    ```
+  </Tab>
+  <Tab value="OpenCode">
+    ```bash
+    Run the /career-ops apply command with the {company_name} argument. Then, use the Playwright MCP to open a browser window and fill out the entire form live.
+    ```
+  </Tab>
+  <Tab value="Qwen CLI">
+    ```bash
+    Run the /career-ops apply command with the {company_name} argument. Then, use the Playwright MCP to open a browser window and fill out the entire form live.
+    ```
+  </Tab>
+</Tabs>
+
+Sin esa instrucción, career-ops sigue usando Playwright y el MCP — simplemente opera en silencio en segundo plano.
+
+## Qué habilita cada componente
+
+<div className="rounded-lg bg-radial-[at_bottom] from-blue-500/20 p-4 border bg-origin-border border-fd-primary/10 prose-no-margin dark:bg-black/20">
+  <div className="rounded-xl bg-fd-background p-3">
+    | Componente             | Propósito                                                                                                         |
+    | ---------------------- | ----------------------------------------------------------------------------------------------------------------- |
+    | Paquete de Playwright  | Biblioteca central que impulsa la automatización del navegador                                                     |
+    | Chromium               | Renderiza páginas, genera PDFs con calidad de impresión mediante `/career-ops pdf`, comprueba si las ofertas de empleo siguen activas y da soporte a los escaneos completos de ATS |
+    | MCP de Playwright      | Permite a career-ops navegar por formularios y sugerir respuestas para los campos durante `/career-ops apply`      |
+  </div>
+</div>

--- a/content/docs/meta.es.json
+++ b/content/docs/meta.es.json
@@ -1,0 +1,16 @@
+{
+  "pages": [
+    "---Introducción---",
+    "index",
+    "free-ai-engine",
+    "supported-clis",
+    "windows",
+    "introduction/what-is-career-ops",
+    "introduction/guides",
+    "faq",
+    "---Referencia---",
+    "reference/modes",
+    "reference/portals",
+    "reference/glossary"
+  ]
+}

--- a/content/docs/reference/glossary.es.mdx
+++ b/content/docs/reference/glossary.es.mdx
@@ -1,0 +1,82 @@
+---
+title: Glosario
+description: El vocabulario de una búsqueda de empleo con IA, definido — ATS, puntuación A–F, Data Contract, spray-and-pray, liveness check, tailoring, zero-token scan, historias STAR+R y todos los términos que usa career-ops.
+seoTitle: "Glosario de career-ops — términos de la búsqueda de empleo con IA, definidos"
+icon: BookOpen
+translationHash: 908b3fb3fc8e8f13
+localized: true
+translatedFrom: /docs/reference/glossary
+---
+
+{/* Mirrored with src/lib/glossary-data.ts (DefinedTermSet JSON-LD) — edit
+    both together. Definitions must stay verifiable against the core repo. */}
+
+Todos los términos que usa career-ops, definidos en un solo lugar. Cada término enlaza a su referencia más detallada cuando existe.
+
+## ATS (Applicant Tracking System)
+
+El software que usan las empresas para recibir, almacenar y filtrar candidaturas — [Greenhouse](/es/docs/reference/portals/greenhouse), [Ashby](/es/docs/reference/portals/ashby) y [Lever](/es/docs/reference/portals/lever) son ejemplos habituales. career-ops lee sus APIs públicas de empleo para descubrir vacantes y puede prerrellenar sus formularios de solicitud, pero nunca envía nada automáticamente.
+
+## Puntuación A–F
+
+La nota que career-ops asigna a una oferta tras evaluarla frente a tu CV y tu perfil en múltiples dimensiones. Una **A** significa «presenta tu candidatura ya, con plena convicción»; una **F** significa que la oferta no supera tus propios criterios. La rúbrica de puntuación es pública en la [página de metodología](https://career-ops.org/methodology).
+
+## Data Contract
+
+La promesa arquitectónica central de career-ops: la **capa de sistema** (scripts, modos, plantillas) puede actualizarse en cualquier momento, mientras que la **capa de usuario** — `cv.md`, `config/profile.yml`, `data/`, `reports/`, `output/` — no se toca jamás durante una actualización. Tus datos sobreviven a todas las versiones.
+
+## Spray-and-pray
+
+La estrategia de solicitud masiva: enviar el mismo CV a cientos de ofertas sin ningún criterio. career-ops la rechaza explícitamente: el pipeline evalúa y clasifica las ofertas primero, de modo que el esfuerzo se concentra en el pequeño conjunto de puestos que de verdad merecen la pena.
+
+## Liveness check
+
+Una heurística que career-ops ejecuta para detectar si una oferta sigue abierta antes de que gastes tiempo o tokens en ella. Es una señal orientativa — las ofertas caducadas a veces siguen publicadas en los portales de empleo — y puedes marcar una oferta manualmente cuando la heurística se equivoca.
+
+## Tailoring
+
+Reescribir tu CV para una oferta concreta — reordenando el énfasis, destacando las habilidades y métricas que encajan, alineando el vocabulario con la descripción del puesto — manteniendo cada afirmación fiel a tu experiencia real. career-ops genera un CV adaptado por candidatura, en Markdown que puedes editar.
+
+## Modo
+
+Un flujo de trabajo enfocado, definido como prompt, que career-ops distribuye como un fichero Markdown plano que tu CLI de IA ejecuta — [scan, apply, tracker](/es/docs/reference/modes), [interview/practice](/es/docs/introduction/guides/interview-modes) y una docena más. Los modos son texto inspeccionable, no código de caja negra.
+
+## Pipeline
+
+El flujo de trabajo de career-ops de principio a fin: escanear portales → evaluar ofertas A–F → adaptar el CV → solicitar → hacer seguimiento → preparar entrevistas. Cada etapa es un modo que puedes ejecutar por separado o en batch.
+
+## Zero-token scan
+
+Una pasada de descubrimiento que no consume tokens de LLM: `scan.mjs` llama directamente por HTTP a las APIs de los ATS (Greenhouse, Ashby, Lever), así que encontrar ofertas nuevas es gratis con independencia del motor de IA que uses.
+
+## Motor de IA
+
+La CLI de programación con IA que ejecuta los prompts de career-ops — Claude Code, OpenCode, Codex, GitHub Copilot CLI y [otras CLIs compatibles](/docs/supported-clis) — o cualquier endpoint compatible con OpenAI. career-ops es agnóstico respecto al motor y [funciona también con motores gratuitos](/docs/free-ai-engine).
+
+## Banco de preguntas
+
+Un fichero Markdown local (`interview-prep/question-bank.md`) donde career-ops acumula preguntas reales de entrevista y tu desempeño en cada una (✅/🟡/🔴). El [modo interview/debrief](/es/docs/introduction/guides/interview-modes) lo actualiza después de cada entrevista real, de modo que la preparación se acumula ronda tras ronda.
+
+## Historia STAR+R
+
+Una historia de entrevista estructurada como **S**ituación, **T**area, **A**cción, **R**esultado, más **R**eflexión — el formato que career-ops usa en su banco de historias para que las respuestas conductuales sean concretas, cuantificadas y reutilizables de una entrevista a otra.
+
+## Banco de historias
+
+Un fichero Markdown local (`interview-prep/story-bank.md`) con tus historias STAR+R preparadas. Las sesiones de práctica verifican tus respuestas contra él, y los debriefs extraen historias nuevas de lo que realmente dijiste en las entrevistas reales.
+
+## Portal
+
+La página de empleo de una empresa, respaldada por un ATS, que career-ops puede escanear. Tus portales en seguimiento viven en `portals.yml`; el escáner lee sus APIs públicas en cada ejecución.
+
+## Evaluación en batch
+
+Puntuar muchas ofertas guardadas en una sola ejecución en vez de una a una, con flags para mantener el control: `--limit` acota el tamaño del batch, `--dry-run` muestra una vista previa de lo que se procesaría y `--resume-paused` continúa una ejecución interrumpida sin volver a gastar tokens.
+
+## Local-first
+
+El principio arquitectónico de career-ops: todo — tus datos, los prompts, los scripts, la CLI de IA — se ejecuta en tu máquina. No hay backend alojado, no hay cuenta y no hay que registrarse en nada.
+
+## CareerOps
+
+CareerOps es la práctica de llevar la búsqueda de empleo como los ingenieros llevan producción: con evidencia, con disciplina y con herramientas en el lado de la mesa donde se sienta el candidato. El término nombra la práctica, no un producto; career-ops es su primera implementación de referencia. Acuñado por Santiago Fernández de Valderrama Aparicio en [The CareerOps Manifesto](https://career-ops.org/manifesto) (14 de julio de 2026).

--- a/content/docs/reference/meta.es.json
+++ b/content/docs/reference/meta.es.json
@@ -1,0 +1,7 @@
+{
+  "title": "Referencia",
+  "pages": [
+    "modes",
+    "portals"
+  ]
+}

--- a/content/docs/reference/modes/apply.es.mdx
+++ b/content/docs/reference/modes/apply.es.mdx
@@ -1,0 +1,66 @@
+---
+title: apply
+description: "Asistente de candidatura en vivo. Lee las preguntas abiertas de los formularios de Greenhouse, Ashby y Lever, y redacta respuestas basadas en tu CV y en la descripción del puesto."
+seoTitle: "Modo apply de career-ops — borradores automáticos de respuestas a preguntas de formularios ATS"
+icon: Send
+date: "2026-05-19"
+lastModified: "2026-05-19"
+translationHash: 2b3d824399a29c66
+localized: true
+translatedFrom: /docs/reference/modes/apply
+---
+
+## Qué hace
+
+El modo `apply` lee un formulario de candidatura abierto (Greenhouse, Ashby, Lever), identifica las preguntas abiertas — «¿Por qué este puesto?», «Cuéntanos sobre un proyecto», «¿Cuál es tu expectativa salarial?» — y redacta respuestas basadas en tu CV y en la descripción del puesto. Tú editas los borradores sobre la marcha, los copias en el portal y envías.
+
+## Cuándo usarlo
+
+Abre la descripción del puesto y el formulario de candidatura en paralelo. Ejecuta apply cuando el formulario esté cargado. El resultado está listo para pegar, no es una candidatura terminada — tú sigues al mando del tono, los datos y cualquier campo extra que el portal añada por encima. apply funciona mejor con Playwright en modo visible, donde lee la página en vivo tal y como tú la ves; sin Playwright, pega las preguntas o comparte una captura de pantalla y redactará a partir de eso.
+
+## Cómo es una ejecución
+
+Ejecuta apply con el formulario de candidatura abierto en Chrome. Antes de escribir una sola respuesta, el modo lee la pestaña activa, la cruza con el informe que ya generaste para esa oferta, confirma que la publicación sigue activa y examina el formulario en busca de preguntas eliminatorias (knock-out) que podrían descartarte automáticamente.
+
+```txt title="Example"
+> /career-ops apply
+
+Detected tab: Notion — Applied AI Engineer (Greenhouse)
+Matched report #072 · score 4.6/5 · archetype: Applied AI operator
+Preflight: posting live — company and role match the report.
+
+Pre-scan flagged 1 knock-out question:
+  KNOCK-OUT: "Will you now or in the future require visa sponsorship?"
+  Your profile does not record work authorization. Confirm before I draft.
+
+Responses for Notion — Applied AI Engineer
+
+1. Why this role?
+   > Your agent-tooling team is where I want to apply the production
+   > AI pipelines I have shipped this year. (paste-ready)
+
+2. Tell us about a relevant project
+   > Built and sold an AI-workflow company in 2025; the pipeline
+   > behind it is the same one I would bring here. (paste-ready)
+
+Notes: I filled text fields only. Tick the checkboxes, solve the
+captcha, and submit yourself.
+```
+
+## Advertencias
+
+apply no envía formularios ni pulsa botones. Lee las preguntas y produce borradores de respuesta en el chat. El paso de envío es tuyo. Los campos cerrados (desplegables, botones de opción, subida de archivos) quedan fuera del alcance. Si la comprobación preflight detecta que la publicación ha cerrado, apply se niega a redactar la versión final salvo que lo fuerces explícitamente — un enlace muerto no merece una respuesta a medida.
+
+## Peculiaridades conocidas de los ATS
+
+apply se ha probado en campo en cerca de una docena de candidaturas gestionadas con Playwright, y algunos portales rompen la ejecución si no los tienes en cuenta:
+
+- **Ashby** deduplica candidatos por email dentro de cada empresa, así que una segunda candidatura puede fusionarse silenciosamente con la primera. Si ya existe un informe para esa empresa, apply sugiere un alias de email con `+tag`.
+- **Lever** lanza un captcha cuando una casilla o un botón de opción se marca de forma programática, así que apply rellena solo los campos de texto y te deja el resto para que lo marques tú.
+- **Workday** ignora los valores introducidos sin pulsaciones de teclado reales, así que apply escribe las respuestas carácter a carácter y te pide revisar los desplegables de autorización de trabajo antes de guardar.
+
+## Relacionado
+
+- [auto-pipeline](/es/docs/reference/modes/auto-pipeline)
+- [pdf](/es/docs/reference/modes/pdf)
+- [tracker](/es/docs/reference/modes/tracker)

--- a/content/docs/reference/modes/auto-pipeline.es.mdx
+++ b/content/docs/reference/modes/auto-pipeline.es.mdx
@@ -1,0 +1,52 @@
+---
+title: auto-pipeline
+description: "Flujo por defecto cuando pegas la URL de una descripción de puesto o su texto sin formato. Ejecuta la evaluación A–G, genera el informe, exporta un PDF adaptado y escribe una entrada en el tracker — sin intervención manual entre pasos."
+seoTitle: "auto-pipeline de career-ops — evalúa una oferta y construye CV + tracker desde una sola URL"
+icon: Zap
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: a103f3feac73a799
+localized: true
+translatedFrom: /docs/reference/modes/auto-pipeline
+---
+
+## Qué hace
+
+career-ops invoca auto-pipeline cada vez que sueltas en el prompt la URL de una JD o su texto pegado. El modo lee la oferta, la puntúa contra la rúbrica — cinco dimensiones más una puntuación global holística —, escribe la evaluación en reports/, genera el PDF adaptado vía Playwright y actualiza la entrada del tracker — todo en un único turno del agente.
+
+## Cuándo usarlo
+
+Usa auto-pipeline cuando quieras que el pipeline completo se ejecute automáticamente. Es el modo por defecto para las ofertas nuevas que entran en tu búsqueda.
+
+## Cómo es una ejecución
+
+Pega la URL de una oferta sin ningún subcomando y auto-pipeline ejecuta la cadena entera de principio a fin: extrae la descripción, comprueba que la publicación sigue activa, la puntúa, guarda el informe, exporta un PDF adaptado y registra la entrada en tu tracker.
+
+```txt title="Terminal"
+> https://job-boards.greenhouse.io/notion/jobs/4523451008
+
+Extracting JD with Playwright... done.
+Liveness gate: posting is live.
+Evaluation: 4.6/5 — legitimacy verified.
+Saved reports/072-notion-applied-ai-engineer-2026-05-18.md
+Generated the tailored PDF via Playwright.
+Score >= 4.5 — drafted Section H application answers in the report.
+Updated data/applications.md (Report and PDF marked done).
+```
+
+## Conviene saber
+
+- Pega una URL y auto-pipeline se encarga de la extracción por ti: primero Playwright para portales de una sola página como Lever, Ashby, Greenhouse y Workday, después WebFetch para páginas estáticas y, como último recurso, WebSearch.
+- Antes de la evaluación se ejecuta una comprobación de vigencia (liveness gate). Si el enlace está muerto o la página es un cascarón vacío de «posición ya cubierta», el modo se detiene ahí en lugar de puntuar contenido fantasma — y si la entrada venía de `data/pipeline.md`, marca esa fila como cerrada.
+- Los borradores de respuestas de candidatura solo se escriben cuando la puntuación es 4.5 o superior, para que los puestos con poco encaje no gasten tokens en textos que no vas a enviar.
+
+## Posibles problemas
+
+Si solo quieres la evaluación sin el PDF (más rápido, más barato), invoca `/career-ops oferta` en su lugar. auto-pipeline consume más tokens porque ejecuta la cadena completa.
+
+## Relacionado
+
+- [pipeline](/es/docs/reference/modes/pipeline)
+- [oferta](/es/docs/reference/modes/oferta)
+- [pdf](/es/docs/reference/modes/pdf)
+- [tracker](/es/docs/reference/modes/tracker)

--- a/content/docs/reference/modes/contacto.es.mdx
+++ b/content/docs/reference/modes/contacto.es.mdx
@@ -1,0 +1,51 @@
+---
+title: contacto
+description: "La jugada maestra de LinkedIn. A partir del nombre de una empresa y el contexto de tu red, contacto saca a la luz contactos probablemente cercanos (conexiones en común, segundo grado) y redacta un mensaje de outreach corto adaptado al puesto al que estás aplicando."
+seoTitle: "modo contacto de career-ops — encuentra contactos cercanos en LinkedIn y redacta el outreach"
+icon: UserPlus
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: ef2b573d6f41f444
+localized: true
+translatedFrom: /docs/reference/modes/contacto
+---
+
+## Qué hace
+
+El modo contacto lee el nombre de la empresa y el contexto de la oferta, y a continuación sugiere objetivos de outreach que encuentra mediante WebSearch: el hiring manager, el recruiter asignado, dos o tres compañeros del equipo y algún entrevistador conocido. Redacta un mensaje corto — tres frases, menos de 300 caracteres — adaptado al puesto y a quién es cada contacto.
+
+## Cuándo usarlo
+
+Usa contacto cuando ya has aplicado a un puesto y quieres encontrar una vía de referral. O úsalo antes de aplicar, cuando una intro cálida pueda sacarte del montón del recruiter. Lo predeterminado es la jugada maestra de LinkedIn; para una plataforma con un límite estricto de caracteres — el chat de un portal de empleo, la primera línea de un cold email, el 打招呼 de BOSS Zhipin — pide un "greeting" y contacto escribe un único mensaje de primer contacto ultracorto, sin fase de descubrimiento de contactos.
+
+## Cómo es una ejecución
+
+Dale a contacto una empresa y encuentra a las personas que merece la pena contactar, elige a la que más se beneficia de que tú acabes allí y escribe un mensaje construido para ese perfil: un recruiter oye requisitos imprescindibles cumplidos, un hiring manager oye impacto.
+
+```txt title="Ejemplo"
+> /career-ops contacto notion
+
+Targets found (WebSearch):
+  • Hiring manager — Head of Applied AI
+  • Recruiter — Technical Talent Partner
+  • 2 peers — AI Engineers on the team
+
+Primary target: Hiring Manager
+
+Draft (287/300 chars):
+> Saw Notion is scaling agent tooling inside the editor. I built and
+> sold an AI-workflow company in 2025 that shipped the same kind of
+> pipeline. Would love to hear how your team is approaching it.
+
+Alternative: message the recruiter first if you want a faster screen
+than a cold note to the manager.
+```
+
+## Cosas a tener en cuenta
+
+contacto no hace scraping de LinkedIn (rechazado según el issue #238). Trabaja con el contexto que tú aportas — tu CV, tus empresas anteriores, las conexiones en común que menciones — más resultados públicos de WebSearch. El agente no tiene acceso a tu grafo privado de LinkedIn. Cada mensaje se mantiene por debajo del límite de 300 caracteres de las solicitudes de conexión de LinkedIn y nunca incluye tu número de teléfono.
+
+## Relacionado
+
+- [deep](/es/docs/reference/modes/deep)
+- [interview-prep](/es/docs/reference/modes/interview-prep)

--- a/content/docs/reference/modes/deep.es.mdx
+++ b/content/docs/reference/modes/deep.es.mdx
@@ -1,0 +1,52 @@
+---
+title: deep
+description: "Genera un documento de investigación en profundidad sobre una empresa — historial de financiación, equipo directivo, prensa reciente, trayectoria del producto, señales de banda salarial, red flags. Úsalo antes de aplicar a una empresa en Serie B o posterior que no conozcas bien."
+seoTitle: "Modo deep de career-ops — investigación en profundidad de la empresa antes de aplicar"
+icon: Search
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: cef52678d1e8b67a
+localized: true
+translatedFrom: /docs/reference/modes/deep
+---
+
+## Qué hace
+
+El modo `deep` genera un prompt de investigación estructurado para una empresa que estás evaluando, organizado en torno a seis ejes: su estrategia de IA, sus movimientos en los últimos seis meses, su cultura de ingeniería, los retos técnicos a los que probablemente se enfrenta, sus competidores y diferenciación, y tu ángulo como candidato. Pegas ese prompt en una herramienta de investigación — Perplexity, Claude o ChatGPT — y te devuelve un informe que puedes leer antes de la entrevista. deep personaliza cada eje con el puesto y la empresa concretos.
+
+## Cuándo usarlo
+
+Usa deep cuando aplicas a una empresa en Serie B o posterior donde la decisión de aplicar — o cómo enfocar la entrevista — necesita más de lo que cuenta la descripción del puesto. El eje del ángulo del candidato bebe de tu cv.md y profile.yml, así que el informe resultante cierra con lo que tú aportas específicamente, en lugar de con datos genéricos de la empresa.
+
+## Cómo es una ejecución
+
+Dale a deep una empresa y un puesto y escribe un prompt de investigación listo para pegar. Cada uno de los seis ejes es una checklist de preguntas que la herramienta de investigación debe responder, y el último eje devuelve los hallazgos hacia ti.
+
+```txt title="Example"
+> /career-ops deep notion
+
+Deep Research: Notion — Applied AI Engineer
+Paste the block below into Perplexity, Claude, or ChatGPT.
+
+1. AI strategy — which products use AI/ML, the stack behind them,
+   the engineering blog, any papers or talks.
+2. Recent moves (last 6 months) — AI/ML hires, acquisitions,
+   product launches, funding or leadership changes.
+3. Engineering culture — ship cadence, monorepo vs multirepo,
+   languages, remote posture, Glassdoor/Blind signals.
+4. Likely challenges — scaling, reliability, cost, latency, any
+   migration in flight.
+5. Competitors and differentiation — main rivals and the moat.
+6. Candidate angle — given my cv.md and profile.yml, the unique
+   value I bring and the story to tell in the interview.
+```
+
+## Cosas a tener en cuenta
+
+El informe solo es tan bueno como la información pública que la herramienta de investigación pueda encontrar. Las startups en modo stealth producen resultados escasos, y cualquier herramienta puede alucinar una ronda de financiación o el nombre de un directivo. Verifícalo todo contra fuentes primarias antes de tomar una decisión con mucho en juego basándote en ello.
+
+## Relacionado
+
+- [oferta](/es/docs/reference/modes/oferta)
+- [contacto](/es/docs/reference/modes/contacto)
+- [interview-prep](/es/docs/reference/modes/interview-prep)

--- a/content/docs/reference/modes/followup.es.mdx
+++ b/content/docs/reference/modes/followup.es.mdx
@@ -1,0 +1,53 @@
+---
+title: followup
+description: "Marca las candidaturas y entrevistas con el seguimiento vencido según las reglas de cadencia que configures. Redacta los mensajes de seguimiento para que los revises y envíes."
+seoTitle: "Modo followup de career-ops — controla los seguimientos vencidos y redacta los mensajes"
+icon: CalendarClock
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: b1eb8003f10d7ed3
+localized: true
+translatedFrom: /docs/reference/modes/followup
+---
+
+## Qué hace
+
+El modo followup lee tu tracker de candidaturas, compara la fecha del último contacto con la cadencia configurada (por defecto: un primer toque 7 días después de aplicar, y 1 día después de una entrevista para la nota de agradecimiento) y marca las entradas vencidas o urgentes. Para cada entrada marcada redacta un mensaje de seguimiento contextual, basado en ese informe y en tu CV.
+
+## Cuándo usarlo
+
+Ejecuta followup los lunes por la mañana como ritual semanal. Cada lunes saca a la superficie los seguimientos que tocan esa semana, con los borradores listos para enviar. Es conservador por diseño — no marca una entrada hasta que el umbral de cadencia ha pasado con claridad, así que el dashboard se mantiene corto y todo lo que aparece en él está genuinamente pendiente.
+
+## Cómo es una ejecución
+
+followup ejecuta un script de cadencia sobre tu tracker, imprime un dashboard ordenado por urgencia y redacta un mensaje para cada fila vencida o urgente. Los borradores abren con una prueba concreta, no con la petición, y nunca dicen "just checking in".
+
+```txt title="Terminal"
+> /career-ops followup
+
+Follow-up Cadence Dashboard — 2026-05-18
+14 applications tracked, 3 actionable
+
+| # | Company | Role                | Status    | Days | Sent | Urgency |
+|---|---------|---------------------|-----------|------|------|---------|
+| 1 | Notion  | Applied AI Engineer | Applied   | 9    | 0    | OVERDUE |
+| 2 | Ramp    | Forward-Deployed    | Applied   | 8    | 0    | OVERDUE |
+| 3 | Linear  | Product Engineer    | Responded | 1    | 0    | URGENT  |
+
+Draft — Notion (overdue):
+> Subject: Re: Applied AI Engineer — Notion
+>
+> Hi team, I applied for the Applied AI Engineer role on May 9th.
+> The AI-workflow company I built and sold in 2025 shipped the same
+> agent pipeline your posting describes. Would any time this week
+> work for a short conversation?
+```
+
+## Cosas a tener en cuenta
+
+Un puesto en estado Applied recibe como máximo dos seguimientos; cuando el segundo queda sin respuesta, followup deja de redactar borradores y sugiere cerrar la entrada o probar con otro contacto a través de `contacto`. ¿Quieres un ritmo más ajustado que los siete días por defecto? Pasa un flag al script de cadencia — `node followup-cadence.mjs --applied-days 5` — en lugar de editar los borradores a mano.
+
+## Relacionado
+
+- [tracker](/es/docs/reference/modes/tracker)
+- [patterns](/es/docs/reference/modes/patterns)

--- a/content/docs/reference/modes/index.es.mdx
+++ b/content/docs/reference/modes/index.es.mdx
@@ -1,0 +1,46 @@
+---
+title: Modos
+description: "Los 14 modos de career-ops invocables por el usuario — evaluar, adaptar, aplicar, hacer seguimiento y preparar entrevistas — cada uno una skill en markdown que corre en cualquier CLI de IA compatible."
+seoTitle: "Modos de career-ops — los 14 comandos de búsqueda de empleo (evaluar, adaptar, aplicar, seguir, preparar)"
+icon: Layers
+translationHash: 4d490714e084c6f4
+localized: true
+translatedFrom: /docs/reference/modes
+---
+
+## Los 14 modos
+
+career-ops incluye **14 modos invocables por el usuario**. Cada uno es una skill en markdown plano que el agente carga y ejecuta dentro del CLI de IA que ya uses — Claude Code, Codex, OpenCode, Gemini CLI, Qwen o GitHub Copilot. Un modo se invoca como `/career-ops <mode>`, y cada uno cubre una etapa de la búsqueda de empleo: evaluar una oferta contra la rúbrica (cinco dimensiones más una puntuación global holística), adaptar el CV, redactar una candidatura, hacer seguimiento de los resultados o preparar entrevistas. Los modos son System Layer según el [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) — se actualizan con la herramienta y nunca modifican tu `cv.md`, tu perfil ni tus informes.
+
+## Evaluar
+
+El bucle central de puntuación — leer una oferta de empleo y puntuarla contra las cinco dimensiones más una puntuación global holística antes de invertir esfuerzo en ella.
+
+- **[auto-pipeline](/es/docs/reference/modes/auto-pipeline)** — el flujo por defecto. Pega la URL o el texto de una JD; ejecuta la evaluación A–F, escribe el informe, exporta un PDF adaptado y registra una entrada en el tracker sin pasos manuales de por medio.
+- **[pipeline](/es/docs/reference/modes/pipeline)** — ejecuta auto-pipeline contra cada URL encolada en `data/pipeline.md`, de modo que las ofertas de todo un día se procesan en una sola sesión.
+- **[oferta](/es/docs/reference/modes/oferta)** — la evaluación A–F contra una única oferta cuando solo necesitas la decisión de puntuación, no el pipeline completo.
+- **[ofertas](/es/docs/reference/modes/ofertas)** — clasifica dos o más ofertas en competencia según compensación, encaje, crecimiento y red flags en una única matriz de decisión.
+- **[deep](/es/docs/reference/modes/deep)** — un documento de investigación en profundidad sobre la empresa (financiación, equipo directivo, prensa, señales de compensación, red flags) antes de aplicar a una empresa que no conoces bien.
+
+## Adaptar y aplicar
+
+Convierte una oferta con puntuación alta en una candidatura enviada.
+
+- **[pdf](/es/docs/reference/modes/pdf)** — genera un CV en PDF adaptado y limpio para ATS contra una JD concreta vía Playwright.
+- **[apply](/es/docs/reference/modes/apply)** — lee las preguntas abiertas de un formulario de candidatura y redacta respuestas fundamentadas en tu CV y la JD.
+- **[contacto](/es/docs/reference/modes/contacto)** — identifica contactos de LinkedIn con los que probablemente tengas cercanía y redacta un mensaje de contacto breve y específico para el puesto.
+- **[followup](/es/docs/reference/modes/followup)** — detecta candidaturas y entrevistas con el seguimiento atrasado y redacta los mensajes.
+
+## Seguir y crecer
+
+Mantén la búsqueda organizada y calíbrala con el tiempo.
+
+- **[tracker](/es/docs/reference/modes/tracker)** — un resumen de estado en el propio chat de todas las candidaturas agrupadas por etapa.
+- **[patterns](/es/docs/reference/modes/patterns)** — lee tus candidaturas rechazadas y descartadas para sacar a la luz patrones en tu enfoque y puntos ciegos.
+- **[interview-prep](/es/docs/reference/modes/interview-prep)** — documentos de preparación específicos por ronda (recruiter, hiring manager, técnica con pares, panel) con preguntas probables e historias STAR.
+- **[training](/es/docs/reference/modes/training)** — puntúa un curso o certificación contra la dirección de carrera que has declarado y su coste de oportunidad.
+- **[project](/es/docs/reference/modes/project)** — puntúa una idea de proyecto de portfolio contra tus puestos objetivo y el tiempo que llevaría construirla.
+
+## Portales
+
+Los tres escáneres de portales que no consumen tokens — Greenhouse, Ashby y Lever — tienen su propia [referencia de portales](/es/docs/reference/portals).

--- a/content/docs/reference/modes/interview-prep.es.mdx
+++ b/content/docs/reference/modes/interview-prep.es.mdx
@@ -1,0 +1,67 @@
+---
+title: interview-prep
+description: "career-ops interview-prep genera un documento de inteligencia de entrevista específico para cada empresa y puesto, segmentado según quién está en la sala — recruiter, hiring manager, técnica entre pares o panel — con preguntas probables, puntos de conversación e historias STAR extraídas de tu propio perfil."
+seoTitle: "career-ops interview-prep — preparación de entrevistas específica por empresa, ronda a ronda"
+icon: GraduationCap
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: 43a22bcddda1882a
+localized: true
+translatedFrom: /docs/reference/modes/interview-prep
+---
+
+career-ops **interview-prep** convierte una entrevista programada en un documento de inteligencia operativo. Nombras una empresa y un puesto — o le pasas una oferta de empleo de un puesto que nunca evaluaste formalmente — e investiga el proceso de selección, clasifica cada ronda según quién la dirige (recruiter screen, hiring manager, técnica entre pares o panel) y redacta las preguntas que cada uno probablemente hará, cada una con un borrador de respuesta extraído de tu propia trayectoria. Nunca inventa una pregunta: todas están o bien documentadas con fuente (Glassdoor, Blind) o etiquetadas como `[inferred from JD]`. El resultado es un documento de preparación guardado, no un chat.
+
+## Qué hace
+
+interview-prep lee el contexto de la empresa (idealmente ya enriquecido con `deep` u `oferta`), la descripción del puesto y tu perfil, y produce un único documento de preparación acotado a las rondas que esa empresa realmente ejecuta. El documento cubre los patrones de preguntas esperables por audiencia, puntos de conversación específicos de tu trayectoria e historias STAR ya redactadas que puedes adaptar en directo. Cuando ya existe un informe de evaluación para el puesto, ese informe es la fuente de autoridad; cuando pasas una URL de un puesto que nunca evaluaste, interview-prep descarga la descripción por sí mismo — primero la API estructurada del ATS, después Playwright, con un fallback headless — y nunca fabrica una oferta.
+
+## Cuándo usarlo
+
+Ejecuta interview-prep en cuanto haya una ronda en el calendario — produce un único documento con una sección por cada audiencia que involucra el proceso: la sección de recruiter screen cubre la preparación de la negociación salarial, la de hiring manager cubre el encaje en el puesto, la técnica entre pares cubre arquitectura y código, y la de panel cubre señales de liderazgo. También se dispara automáticamente cuando mueves a `Interview` en tu tracker un puesto con puntuación 4.0 o superior.
+
+interview-prep es el paso de **investigación** — el documento de inteligencia que estudias de antemano. Es un modo distinto de los ejercicios interactivos de entrevista `plan`, `practice` y `debrief`, que te hacen ensayar en vivo y revisan una ronda a posteriori; están conectados (un debrief realimenta el material que interview-prep leerá la próxima vez). Para esos ejercicios, consulta la [guía de modos de entrevista](/es/docs/introduction/guides/interview-modes).
+
+## Cómo es una ejecución
+
+Nombras la empresa y el puesto, y el modo devuelve un único informe de inteligencia de entrevista acotado a las rondas que esa empresa realmente ejecuta. Investiga el proceso, clasifica cada ronda por audiencia — recruiter screen, hiring manager, técnica entre pares o panel — y redacta las preguntas probables, etiquetando cada una con una cita de fuente o con la marca `[inferred from JD]`.
+
+```bash title="Terminal"
+/career-ops interview-prep Anthropic "Applied AI Engineer"
+```
+
+```txt title="interview-prep/anthropic-applied-ai-engineer.md (excerpt)"
+# Interview Intel: Anthropic — Applied AI Engineer
+
+**Legitimacy:** High Confidence
+**Researched:** 2026-05-18
+**Sources:** 12 Glassdoor reviews, 4 Blind posts, 3 other
+**Audiences covered:** recruiter-screen, hiring-manager, peer-tech
+
+## Process Overview
+- Rounds: 4 rounds, ~18 days end-to-end
+- Difficulty: 3.5/5 (Glassdoor avg, 12 reviews)
+- Known quirks: pair programming, not whiteboard
+
+## Likely Questions — recruiter-screen
+- "Why are you looking, and why us?" — 60-90s, anchored to your narrative
+- Comp expectation — defer to the band if leverage is thin
+- Location / visa / notice period — numbers, not vibes
+```
+
+El informe también mapea historias de tu `story-bank.md` a cada pregunta probable y señala los huecos donde todavía no tienes ninguna historia preparada.
+
+## Cuándo recurrir a él
+
+Recurre a interview-prep en cuanto tengas una ronda programada y quieras un documento de trabajo en lugar de consejos genéricos. Algunas cosas afinan el resultado:
+
+- Ejecuta antes `oferta` o `deep` contra la empresa. La preparación lee el informe de evaluación para extraer el arquetipo, los huecos y los proof points que encajan, así que más contexto produce preguntas más específicas.
+- Pega los nombres de los entrevistadores o la agenda cuando los tengas. Para un panel, el modo construye una lectura por entrevistador y redacta una pregunta de cierre a medida para cada franja.
+- Si ya has dado una cifra de compensación para el puesto, la sección de recruiter screen la incorpora — career-ops lee la cifra que declaraste para que la preparación de la negociación salarial se base en lo que realmente dijiste, no en una suposición.
+- Confía en las etiquetas: las preguntas con fuente citan Glassdoor o Blind, las inferidas llevan `[inferred from JD]`. El modo nunca inventa una pregunta para atribuírsela a un candidato.
+
+## Relacionado
+
+- [deep](/es/docs/reference/modes/deep)
+- [contacto](/es/docs/reference/modes/contacto)
+- [oferta](/es/docs/reference/modes/oferta)

--- a/content/docs/reference/modes/meta.es.json
+++ b/content/docs/reference/modes/meta.es.json
@@ -1,0 +1,19 @@
+{
+  "title": "Modos",
+  "pages": [
+    "auto-pipeline",
+    "pipeline",
+    "apply",
+    "oferta",
+    "ofertas",
+    "contacto",
+    "deep",
+    "interview-prep",
+    "pdf",
+    "training",
+    "project",
+    "tracker",
+    "patterns",
+    "followup"
+  ]
+}

--- a/content/docs/reference/modes/oferta.es.mdx
+++ b/content/docs/reference/modes/oferta.es.mdx
@@ -1,0 +1,62 @@
+---
+title: oferta
+description: "Ejecuta la evaluación A–G sobre un único anuncio. Omite la generación de PDF y la escritura en el tracker. Úsalo cuando solo necesitas la decisión de puntuación y no el pipeline completo."
+seoTitle: "Modo oferta de career-ops — puntúa una oferta de empleo antes de aplicar"
+icon: Target
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: 1d733a23b8c520f8
+localized: true
+translatedFrom: /docs/reference/modes/oferta
+---
+
+## Qué hace
+
+El modo oferta lee una única JD (URL o texto pegado), la puntúa contra la rúbrica — cinco dimensiones más una puntuación global holística — con evidencia citada, y escribe el informe de evaluación. Sin PDF, sin entrada en el tracker. Rápido y barato.
+
+## Cuándo usarlo
+
+Usa oferta para hacer un triaje rápido de un anuncio dudoso. Si la puntuación supera el 4.0 y decides aplicar, escala a auto-pipeline o al modo apply.
+
+## Cómo es una ejecución
+
+Le pasas al modo un anuncio y devuelve la evaluación de siete bloques — los Bloques A a F más una lectura de legitimidad en el Bloque G — con puntuación y razonamiento citado. Pega el texto de la JD directamente, o pasa una URL y el modo confirma primero que la publicación sigue activa, de modo que un enlace muerto nunca quema una evaluación completa.
+
+```bash title="Terminal"
+/career-ops oferta https://boards.greenhouse.io/acme/jobs/4021
+```
+
+```txt title="Evaluation excerpt"
+# Evaluation: Acme — Staff AI Engineer
+
+**Score:** 4.3/5
+**Archetype:** LLMOps
+**Legitimacy:** High Confidence
+
+## A) Role Summary
+| Field      | Value  |
+|------------|--------|
+| Domain     | LLMOps |
+| Seniority  | Staff  |
+| Remote     | Full   |
+
+## G) Posting Legitimacy
+Assessment: High Confidence — posted 3 days ago, apply button active,
+JD names specific tools and first-6-month scope.
+```
+
+Los Bloques B a F cubren el encaje del CV y sus carencias, la estrategia de nivel, compensación y demanda, un plan de personalización, e historias de entrevista STAR+R mapeadas a los requisitos del puesto.
+
+## Cuándo recurrir a él
+
+Recurre a oferta para puntuar un único anuncio rápidamente sin comprometerte con el pipeline completo. Conviene saber:
+
+- Si pasas una URL, primero se ejecuta una comprobación de liveness — una publicación caducada o con 404 se detiene antes del Bloque A, así que nunca gastas una ejecución en contenido fantasma.
+- La investigación de empresa y compensación está acotada a un máximo de cinco búsquedas web; esto es una evaluación, no una investigación en profundidad. Ejecuta `/career-ops deep` por separado cuando quieras la imagen más completa de la empresa.
+- El Bloque G devuelve uno de tres niveles — High Confidence, Proceed with Caution o Suspicious — de modo que los probables ghost jobs salen a la luz antes de que inviertas esfuerzo en la entrevista.
+
+## Relacionados
+
+- [auto-pipeline](/es/docs/reference/modes/auto-pipeline)
+- [ofertas](/es/docs/reference/modes/ofertas)
+- [pdf](/es/docs/reference/modes/pdf)

--- a/content/docs/reference/modes/ofertas.es.mdx
+++ b/content/docs/reference/modes/ofertas.es.mdx
@@ -1,0 +1,56 @@
+---
+title: ofertas
+description: "Se usa cuando tienes dos o más ofertas competidoras sobre la mesa y necesitas una comparación normalizada de compensación, encaje del rol, trayectoria de crecimiento y red flags. Genera una recomendación con ranking."
+seoTitle: "modo ofertas de career-ops — compara ofertas de empleo competidoras lado a lado"
+icon: GitCompare
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: b51253649996ab03
+localized: true
+translatedFrom: /docs/reference/modes/ofertas
+---
+
+## Qué hace
+
+El modo `ofertas` lee varias evaluaciones de JD (ya producidas por oferta o auto-pipeline) y las clasifica entre sí sobre las cinco dimensiones más una puntuación global holística y una matriz de decisión normalizada. El resultado es un informe comparativo lado a lado y una recomendación con ranking.
+
+## Cuándo usarlo
+
+Usa ofertas cuando llegues a fases finales de entrevista para varios roles y necesites una forma estructurada de decidir entre ellos. Es especialmente útil para ofertas de nivel staff, donde los paquetes de compensación y las vías de crecimiento difieren sustancialmente.
+
+## Cómo es una ejecución
+
+Le das al modo dos o más ofertas y puntúa cada una en diez dimensiones ponderadas, y después las ordena. El mayor peso recae en la alineación con el North Star (25 %), seguida del encaje con el CV y la seniority (15 % cada una); la compensación y la trayectoria de crecimiento pesan un 10 % cada una, y la reputación, la calidad del trabajo remoto, el stack tecnológico, el time-to-offer y las señales culturales completan el resto.
+
+```bash title="Terminal"
+/career-ops ofertas
+```
+
+```txt title="Comparison excerpt"
+# Offer Comparison — 3 roles
+
+| Dimension (weight)       | Acme | Globex | Initech |
+|--------------------------|------|--------|---------|
+| North Star align (25%)   | 5    | 3      | 4       |
+| CV match (15%)           | 4    | 4      | 3       |
+| Compensation (10%)       | 3    | 5      | 4       |
+| Growth trajectory (10%)  | 5    | 3      | 3       |
+| ...                      |      |        |         |
+| Weighted total           | 4.4  | 3.6    | 3.5     |
+
+Recommendation: Acme — strongest North Star fit and growth path.
+Globex pays more but ranks lower on trajectory and time-to-offer.
+```
+
+## Cuándo recurrir a él
+
+Recurre a ofertas cuando tengas dos o más ofertas competidoras y necesites una forma normalizada de elegir. Donde más rinde es a nivel staff, donde los paquetes de compensación y las vías de crecimiento divergen lo suficiente como para que la intuición engañe.
+
+- Proporciona las vacantes como texto pegado, URLs o referencias a empleos que ya estén en tu tracker; si no hay ninguna en contexto, el modo te las pedirá.
+- Puntúa primero cada oferta por separado — con `oferta` o `auto-pipeline` — para que la comparación ordene evaluaciones consistentes en lugar de mezclar profundidades distintas.
+- Como la alineación con el North Star pondera un 25 %, un salario más alto por sí solo no encabezará el ranking; un rol que encaje con tu trayectoria objetivo puede superar en puntuación a un desvío mejor pagado.
+
+## Relacionados
+
+- [oferta](/es/docs/reference/modes/oferta)
+- [auto-pipeline](/es/docs/reference/modes/auto-pipeline)

--- a/content/docs/reference/modes/patterns.es.mdx
+++ b/content/docs/reference/modes/patterns.es.mdx
@@ -1,0 +1,52 @@
+---
+title: patterns
+description: "Lee tus candidaturas rechazadas y descartadas y saca a la luz patrones — formas de JD que puntúan alto pero nunca convierten, desajustes de arquetipo, problemas de banda salarial. El resultado es una señal de calibración para tu filtro de targeting."
+seoTitle: "Modo patterns de career-ops — descubre por qué tus candidaturas no convierten"
+icon: TrendingDown
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: 392fb9e40a5ff463
+localized: true
+translatedFrom: /docs/reference/modes/patterns
+---
+
+## Qué hace
+
+El modo `patterns` lee todos los informes de las etapas de rechazadas y descartadas, busca rasgos comunes (sector, tamaño de empresa, nivel de seniority, palabras clave concretas) y produce un análisis estructurado de qué está funcionando y qué no en tu targeting.
+
+## Cuándo usarlo
+
+Ejecuta patterns cada 20–30 rechazos para recalibrar. El modo saca a la luz puntos ciegos de tu perfil y te ayuda a no seguir enviando candidaturas hacia los mismos patrones muertos.
+
+## Cómo es una ejecución
+
+Ejecutas el modo después de una tanda de resultados y te devuelve un informe de análisis de patrones con fecha, más un resumen breve de los tres hallazgos que más importan. Por debajo, ejecuta `analyze-patterns.mjs` sobre tu tracker y tus informes, y después te presenta un funnel de conversión, una tabla de puntuación frente a resultado, los principales bloqueadores y un suelo de puntuación recomendado.
+
+```bash title="Terminal"
+/career-ops patterns
+```
+
+```txt title="Pattern Analysis summary"
+Pattern Analysis Complete (24 applications, Apr 7 - May 18)
+
+Key findings:
+- Geo-restricted roles: 0% conversion (7 of 24) — stop evaluating US-only postings
+- Regional/global remote roles convert at 57-67% — your sweet spot
+- No positive outcomes below 4.2/5 — treat that as your score floor
+
+Full report: reports/pattern-analysis-2026-05-18.md
+```
+
+Tras presentar el resumen, el modo se ofrece a actuar sobre los hallazgos — actualizar los filtros de `portals.yml`, fijar un umbral de puntuación o reponderar qué arquetipos tienes como objetivo.
+
+## Cuándo recurrir a él
+
+Recurre a patterns cuando suficientes candidaturas hayan pasado ya de la evaluación como para que los resultados aporten señal. La barrera dura son cinco entradas con un estado posterior a "Evaluated" — Applied, Responded, Interview, Offer, Rejected o Discarded; por debajo de eso el modo termina y te pide que vuelvas con más datos. Cuantos más resultados, más nítidos los patrones, así que rinde de verdad tras un mes de candidaturas constantes.
+
+- Si guardas transcripciones de entrevistas en `interview-prep/sessions/`, el modo añade una señal de targeting: dónde se concentran tus respuestas más fluidas y específicas, lo que detecta cuando el tipo de rol en el que eres más fuerte difiere de aquel al que no dejas de aplicar.
+- El informe nunca menciona a un entrevistador o una empresa reales de esas sesiones — solo resume clusters de competencias, de modo que lo que acabe en un commit sigue siendo privado.
+
+## Relacionados
+
+- [tracker](/es/docs/reference/modes/tracker)
+- [followup](/es/docs/reference/modes/followup)

--- a/content/docs/reference/modes/pdf.es.mdx
+++ b/content/docs/reference/modes/pdf.es.mdx
@@ -1,0 +1,52 @@
+---
+title: pdf
+description: "Genera un CV en PDF adaptado a una JD concreta usando Playwright para renderizar markdown con una plantilla tipográfica limpia. El resultado es estructuralmente simple — sin tablas, sin columnas, sin gráficos — exactamente lo que los parsers ATS procesan de forma fiable."
+seoTitle: "modo pdf de career-ops — genera un CV adaptado y compatible con ATS"
+icon: FileText
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: beb822061e860203
+localized: true
+translatedFrom: /docs/reference/modes/pdf
+---
+
+## Qué hace
+
+El modo pdf lee tu cv.md maestro y el contexto de la JD, y ejecuta el paso de adaptación (reescribe bullets, reordena secciones, integra keywords prioritarias) antes de exportar a PDF vía Playwright con una plantilla CSS que respeta las convenciones de los parsers ATS. El resultado está listo para subir.
+
+## Cuándo usarlo
+
+Usa pdf cuando ya has evaluado la oferta y has decidido aplicar, y solo quieres el PDF adaptado sin volver a ejecutar el paso de evaluación.
+
+## Cómo es una ejecución
+
+Apuntas el modo a una oferta que ya has evaluado y produce un único PDF adaptado y listo para ATS — sin re-evaluación. Extrae 15-20 keywords de la JD, elige el tamaño de papel según la ubicación de la empresa, reescribe tu resumen y reordena los bullets en torno al puesto, y después renderiza el HTML a PDF e informa de la cobertura de keywords.
+
+```bash title="Terminal"
+/career-ops pdf acme
+
+# detected JD language: en · paper: letter (US) · 18 keywords extracted
+node generate-pdf.mjs output/cv-jane-doe-acme.html \
+  output/cv-jane-doe-acme-2026-05-18.pdf --format=letter --report=008
+
+PDF:   output/cv-jane-doe-acme-2026-05-18.pdf
+Pages: 2 · Keyword coverage: 16/18 (89%)
+```
+
+El layout se mantiene a una sola columna, con cabeceras de sección estándar y texto seleccionable — la estructura que los parsers ATS leen sin problemas — y las keywords se entretejen en logros reales, nunca se inventan.
+
+## Cuándo recurrir a él
+
+Recurre a pdf cuando has decidido aplicar y solo quieres el CV adaptado, saltándote el paso de evaluación. Algunos comportamientos que conviene conocer:
+
+- El tamaño de papel sigue automáticamente la ubicación de la empresa: `letter` para puestos en EE. UU. y Canadá, `a4` en el resto del mundo.
+- La inyección de keywords se basa en la verdad. El modo reformula experiencia real con el vocabulario exacto de la JD, pero nunca añade una habilidad que no tienes.
+- Para DACH y buena parte de la Europa continental puedes optar por incluir foto configurando `candidate.photo` en `config/profile.yml`; déjalo vacío y el CV se renderiza píxel a píxel idéntico pero sin ella, que es la opción por defecto más segura para EE. UU., Reino Unido y mercados ATS-first.
+
+## Posibles problemas
+
+Requiere Playwright instalado en local. El script de build puede fallar en instalaciones Linux mínimas sin fuentes del sistema. Ejecuta `npm run doctor` para diagnosticar.
+
+## Relacionado
+
+- [auto-pipeline](/es/docs/reference/modes/auto-pipeline)

--- a/content/docs/reference/modes/pipeline.es.mdx
+++ b/content/docs/reference/modes/pipeline.es.mdx
@@ -1,0 +1,53 @@
+---
+title: pipeline
+description: "Lee las URLs encoladas en data/pipeline.md y ejecuta el auto-pipeline completo contra cada una. Úsalo cuando hayas reunido diez o veinte ofertas durante el día y quieras procesarlas en una sola sesión."
+seoTitle: "Modo pipeline de career-ops — evalúa en lote muchas ofertas de empleo a la vez"
+icon: GitBranch
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: 1e5c70f073c9c18b
+localized: true
+translatedFrom: /docs/reference/modes/pipeline
+---
+
+## Qué hace
+
+El modo pipeline recorre las URLs de data/pipeline.md (una por línea) e invoca auto-pipeline contra cada una. Para cada oferta que produce una evaluación válida se escriben informes, PDFs y entradas en el tracker. Los scrapes fallidos se registran y se omiten.
+
+## Cuándo usarlo
+
+Usa pipeline cuando tengas un backlog de URLs por procesar. Déjalas en data/pipeline.md, invoca /career-ops pipeline y olvídate.
+
+## Cómo es una ejecución
+
+Dejas las URLs en `data/pipeline.md` y el modo procesa toda la bandeja de entrada en una sola pasada. Primero ejecuta un barrido de liveness sin gasto de tokens para descartar las ofertas expiradas, después evalúa cada URL superviviente a través del auto-pipeline completo y termina con una tabla resumen de lo que ha encontrado.
+
+```txt title="Pipeline run"
+$ /career-ops pipeline
+
+Liveness sweep: 8 pending URLs
+  6 live · 2 expired (moved to Processed, marked Discarded)
+
+Processing 6 live URLs (parallel workers)...
+
+| # | Company | Role         | Score | PDF | Recommended action |
+|---|---------|--------------|-------|-----|--------------------|
+| 1 | Acme    | Staff AI Eng | 4.3/5 | done | apply             |
+| 2 | Globex  | ML Platform  | 3.1/5 | skip | review            |
+| 3 | Initech | AI PM        | 2.4/5 | skip | skip              |
+```
+
+Cada URL procesada pasa de la sección `## Pending` a la sección `## Processed` del fichero, de modo que la bandeja de entrada se mantiene como un registro vivo de lo que queda pendiente.
+
+## Cuándo recurrir a él
+
+Recurre a pipeline cuando hayas acumulado un backlog de ofertas durante el día y quieras procesarlas en una sola sesión. Cómo gestiona la cola:
+
+- La sección `## Pending` acepta cualquier formato: funciona con una URL pegada tal cual, o puedes añadir columnas `company`, `role`, `location` y `comp`, y el modo las lee todas.
+- El barrido de liveness se ejecuta antes del bucle por URL, de modo que una bandeja de entrada obsoleta con ocho URLs no cuesta ocho evaluaciones desperdiciadas.
+- Con tres o más URLs pendientes las procesa en paralelo, un worker por URL, en lugar de una a una.
+- Los PDFs solo se generan cuando una puntuación supera `auto_pdf_score_threshold` (3.0 por defecto); súbelo para omitir los PDFs de los roles marginales y generarlos bajo demanda más adelante con `/career-ops pdf`.
+
+## Relacionado
+
+- [auto-pipeline](/es/docs/reference/modes/auto-pipeline)

--- a/content/docs/reference/modes/project.es.mdx
+++ b/content/docs/reference/modes/project.es.mdx
@@ -1,0 +1,61 @@
+---
+title: project
+description: "Los builders acumulan ideas más rápido de lo que pueden lanzarlas. El modo project puntúa una idea de proyecto de portfolio frente a tus roles objetivo, tu portfolio existente y la inversión de tiempo necesaria, y hace visible si merece la pena construirla."
+seoTitle: "Modo project de career-ops — puntúa un proyecto de portfolio frente a los roles objetivo"
+icon: Lightbulb
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: 87b86e456dd18f90
+localized: true
+translatedFrom: /docs/reference/modes/project
+---
+
+## Qué hace
+
+El modo `project` lee la descripción de la idea de proyecto, tus arquetipos objetivo de config/profile.yml y el contexto de tu portfolio existente, y después puntúa el proyecto en tres dimensiones: valor de señal para los roles objetivo, diferenciación respecto a tu portfolio existente y tiempo estimado hasta tener algo publicable.
+
+## Cuándo usarlo
+
+Usa project cuando tengas tres o cuatro ideas de side-projects y quieras elegir la que de verdad hace avanzar tu búsqueda de empleo. Es el equivalente para side-projects del modo oferta.
+
+## Ejemplo
+
+```
+`/career-ops project` + project description — output is a scored evaluation with a build/skip recommendation.
+```
+
+## Cómo es una ejecución
+
+Una ejecución de project devuelve una lectura de legitimidad, una puntuación ponderada en seis dimensiones y un único veredicto claro. Le entregas una idea al modo, y él la califica tal y como la leería un hiring manager al encontrarla en tu portfolio, en lugar de juzgar si el código va a compilar.
+
+```txt title="Example"
+Portfolio Project Evaluation
+URL: (idea only, no repo yet)
+Legitimacy: High Confidence
+
+Dimension                 Weight  Score
+Signal for target roles     25%     5   Directly demonstrates a JD skill
+Uniqueness                  20%     3
+Demo ability                20%     5   Live demo in 2 min
+Metrics potential           15%     4   latency, cost, accuracy
+Time to MVP                 10%     4   ~1 week
+STAR story potential        10%     4   trade-offs worth narrating
+
+Verdict: BUILD
+  Week 1 -> MVP with the core metric
+  Week 2 -> polish + interview pack
+```
+
+El veredicto es siempre uno de tres: BUILD, con hitos semanales; SKIP, con qué hacer en su lugar; o PIVOT TO, hacia una alternativa que aporte más señal para los roles que persigues. Las seis dimensiones están ponderadas, de modo que un proyecto que se demuestra bien y produce métricas limpias puede superar a una idea más novedosa que no tiene un retorno visible.
+
+## El interview pack
+
+Todo proyecto aprobado se entrega con un interview pack, porque el entregable es la historia, no el repositorio. El pack tiene tres partes: un one-pager que cubre producto, arquitectura, métricas y plan de evaluación; una demo, ya sea una URL en vivo o un recorrido grabado de dos minutos; y un postmortem de qué funcionó, qué no y cómo lo mitigaste. Un proyecto construido sin narrativa detrás rara vez mueve una búsqueda de empleo, mientras que un proyecto modesto con una historia nítida de trade-offs a menudo sí lo hace. El plan 80/20 refleja esto: la semana uno es el MVP con su métrica principal, la semana dos es el pulido más el propio pack.
+
+## Advertencias
+
+El modo no valida la viabilidad técnica, solo el valor de señal para tu carrera. Haz una pasada de scoping técnico aparte.
+
+## Relacionado
+
+- [training](/es/docs/reference/modes/training)

--- a/content/docs/reference/modes/tracker.es.mdx
+++ b/content/docs/reference/modes/tracker.es.mdx
@@ -1,0 +1,54 @@
+---
+title: tracker
+description: "Lectura rápida del estado de cada candidatura. Útil como chequeo diario o al preparar la revisión semanal. La interfaz completa manejada por teclado vive en el dashboard TUI en Go; este modo es el resumen en el chat."
+seoTitle: "Modo tracker de career-ops — consulta el estado de cada candidatura"
+icon: LayoutGrid
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: eb25e59a2aa5c2a3
+localized: true
+translatedFrom: /docs/reference/modes/tracker
+---
+
+## Qué hace
+
+El modo `tracker` lee todos los ficheros de reports/ y produce un resumen estructurado agrupado por etapa: aplicadas, evaluadas, en entrevista, rechazadas, descartadas. Los recuentos por etapa, la actividad reciente y los seguimientos vencidos aparecen en una sola respuesta.
+
+## Cuándo usarlo
+
+Usa tracker para un chequeo de estado diario de quince segundos. Usa el dashboard TUI en Go cuando necesites profundizar.
+
+## Ejemplo
+
+```
+`/career-ops tracker` — output is a structured status summary in the chat.
+```
+
+## Cómo es una ejecución
+
+Una ejecución de tracker imprime la tabla completa de candidaturas más un bloque de estadísticas en una sola respuesta, de modo que puedes leer toda la búsqueda de un vistazo. Cada fila es una candidatura con su empresa, puesto, puntuación, estado actual, y si se han generado el PDF adaptado y el informe de evaluación.
+
+```txt title="Example"
+# | Date       | Company   | Role              | Score | Status    | PDF | Report
+1 | 2026-06-14 | Anthropic | AI Engineer       |  87   | Interview | yes | yes
+2 | 2026-06-18 | Vercel    | Applied AI Eng    |  79   | Applied   | yes | yes
+3 | 2026-06-21 | Figma     | Product Eng, AI   |  72   | Evaluated | yes | yes
+
+Total: 3   Applied: 1   Interview: 1   Evaluated: 1
+Average score: 79   PDF generated: 100%   Report generated: 100%
+```
+
+Una candidatura avanza por un conjunto fijo de estados: Evaluated (informe escrito, decisión pendiente), Applied (la has enviado), Responded (la empresa respondió pero aún sin entrevista), Interview (un proceso activo), y después un estado terminal de Offer, Rejected, Discarded o SKIP para los puestos que no encajan. Para registrar un cambio de estado, actualiza la fila en la tabla del tracker o usa el dashboard TUI en Go.
+
+## Cómo leer las cifras acumuladas
+
+Para las cifras acumuladas — el funnel completo, los totales del scanner, la cobertura de portales y el cumplimiento de los seguimientos — el modo ejecuta `node stats.mjs --summary` y presenta su salida tal cual. Ese comando lee tus ficheros locales y cuesta cero tokens, así que los números nunca se recalculan a mano ni se estiman de memoria. Usa el resumen en el chat de arriba para una lectura diaria rápida, y el comando de estadísticas cuando quieras los totales acumulados de toda la búsqueda.
+
+## Cosas a tener en cuenta
+
+tracker es de solo lectura. Los cambios de estado son pulsaciones explícitas en el dashboard TUI en Go o ediciones manuales en el frontmatter del informe.
+
+## Relacionados
+
+- [followup](/es/docs/reference/modes/followup)
+- [patterns](/es/docs/reference/modes/patterns)

--- a/content/docs/reference/modes/training.es.mdx
+++ b/content/docs/reference/modes/training.es.mdx
@@ -1,0 +1,57 @@
+---
+title: training
+description: "¿Deberías hacer ese curso de sistemas de ML de 4.000 $? ¿La especialización de Coursera? ¿La cara certificación de AWS? El modo training puntúa una inversión en formación contra la dirección profesional que has declarado y saca a la luz el retorno real en tiempo y dinero."
+seoTitle: "Modo training de career-ops — ¿merece la pena ese curso o certificación?"
+icon: BookOpen
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: f9ba1d91483777d9
+localized: true
+translatedFrom: /docs/reference/modes/training
+---
+
+## Qué hace
+
+El modo `training` lee los detalles del curso o certificación (temario, dedicación de tiempo, coste), lee tu sección North Star de config/profile.yml y puntúa la inversión en tres dimensiones: cierre de la brecha de habilidades, valor de señal para los roles objetivo y coste de oportunidad.
+
+## Cuándo usarlo
+
+Usa training cuando te tiente una oferta formativa pero no tengas claro si de verdad te acerca a la dirección que has declarado. Especialmente útil para certificaciones caras y bootcamps.
+
+## Ejemplo
+
+```
+`/career-ops training` + course name and URL — output is a scored evaluation with recommendation.
+```
+
+## Cómo es una ejecución
+
+Una ejecución de training puntúa un curso o certificación en cinco dimensiones más una puntuación global holística y devuelve uno de tres veredictos, de modo que ves el retorno en tiempo y dinero antes de comprometer ninguno de los dos. Le das la oferta formativa — temario, semanas, horas por semana y coste — y la califica contra la dirección profesional que has declarado.
+
+```txt title="Ejemplo"
+Training Evaluation — "Production LLM Systems" (8 weeks, 6 h/wk, $1,200)
+
+North Star alignment   Moves toward the Applied AI target
+Recruiter signal       HMs read this as production-grade, not tutorial
+Time and effort        8 weeks x 6 h = 48 h
+Opportunity cost       ~2 portfolio projects foregone
+Risks                  Syllabus current; brand is mid-tier
+Portfolio deliverable  Yes -- a graded eval harness
+
+Verdict: DO WITH TIMEBOX (max 6 weeks)
+  Condensed plan, essentials only, weekly scoreboard
+```
+
+Un veredicto DO viene con un plan de cuatro a doce semanas con entregables semanales y un marcador. Un veredicto DON'T DO nombra una alternativa mejor y explica por qué. DO WITH TIMEBOX limita las semanas y reduce el plan a lo esencial, que es el resultado habitual para cursos útiles pero con relleno.
+
+## Qué puntúa más alto
+
+El modo da más peso a las ofertas que construyen credibilidad en IA de nivel de producción frente a credenciales genéricas. En orden de prioridad, eso significa evaluación y testing de LLMs, observabilidad y monitorización, trade-offs de coste y fiabilidad, gobernanza y seguridad de IA, y arquitectura de IA empresarial. Un curso que termina en un artefacto demostrable — un eval harness, un despliegue monitorizado — puntúa más que uno que termina solo en un certificado, porque el artefacto es lo que un hiring manager puede ver de verdad.
+
+## Advertencias
+
+El modo está sesgado hacia tu North Star declarado. Si no has rellenado con cuidado la sección North Star de config/profile.yml, la evaluación será superficial.
+
+## Relacionado
+
+- [project](/es/docs/reference/modes/project)

--- a/content/docs/reference/portals/ashby.es.mdx
+++ b/content/docs/reference/portals/ashby.es.mdx
@@ -1,0 +1,57 @@
+---
+title: Ashby
+description: "Ashby es el ATS moderno preferido por las startups Serie A–C del espacio de la IA y las dev-tools. career-ops consulta directamente la API pública de su job board."
+seoTitle: "Escanea ofertas de Ashby con career-ops — escaneo de portales ATS con cero tokens"
+icon: Sparkles
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: 013014c1d6d759e4
+localized: true
+translatedFrom: /docs/reference/portals/ashby
+---
+
+## Qué hace
+
+El provider ashby de providers/ashby.mjs hace peticiones HTTP a api.ashbyhq.com/posting-api/job-board/`{slug}` y parsea el JSON resultante. El slug es el identificador del job board de Ashby de la empresa (p. ej. 'anthropic' para Anthropic).
+
+## Cuándo usarlo
+
+Usa el escaneo de Ashby cuando tengas en el punto de mira labs de IA, empresas de infraestructura y startups modernas. Anthropic, Vercel, Replicate y muchas empresas de YC usan Ashby. Más de 40 slugs preconfigurados vienen incluidos en templates/portals.example.yml.
+
+## Ejemplo
+
+```
+In your portals.yml: `- provider: ashby\n  slug: anthropic\n  careers_url: https://jobs.ashbyhq.com/anthropic` — then scan picks up active Anthropic roles.
+```
+
+## Qué hace el escáner
+
+El escáner lee tus slugs de Ashby habilitados en portals.yml, llama a la API pública del job board de Ashby para cada uno y fusiona las ofertas nuevas en tu pipeline sin navegador, sin login y sin gastar un solo token de LLM en la propia descarga. Una sola ejecución de `node scan.mjs` cubre a la vez tus boards de Ashby, Greenhouse y Lever, y después filtra los resultados por las palabras clave de título que hayas configurado.
+
+```bash title="Terminal"
+node scan.mjs
+```
+
+```txt title="Output"
+Portal Scan - 2026-07-06
+Offers found: 41 total
+Filtered by title: 6 relevant
+Duplicates: 3 (already evaluated or in pipeline)
+New added to pipeline.md: 3
+
+  + Anthropic | Applied AI Engineer | ashby
+  + Replicate | Inference Engineer  | ashby
+```
+
+## Cómo se comunica career-ops con Ashby
+
+career-ops consulta el endpoint GraphQL `ApiJobBoardWithTeams` de Ashby con el slug de tu board y lee la lista `jobPostings` directamente de la respuesta JSON. De cada oferta extrae el título, un id que se usa para construir la URL pública de solicitud, el nombre de la ubicación, el tipo de empleo y un resumen de compensación cuando el board lo expone. Como se trata de una llamada estructurada a la API y no de scraping de páginas, el escaneo es rápido, se mantiene dentro de los límites de peticiones y no gasta tokens del modelo. Los tokens solo se gastan más tarde, durante el paso de evaluación, cuando decides que una oferta merece un vistazo más de cerca. Repetir el escaneo es seguro: cada URL se deduplica contra tu historial de escaneos, tus candidaturas ya evaluadas y el pipeline actual, de modo que una oferta que ya has visto nunca se añade dos veces.
+
+## A tener en cuenta
+
+La API del job board de Ashby devuelve directamente el texto completo de la descripción del puesto, sin necesidad de una petición adicional. La evaluación es algo más rápida que con las ofertas de Greenhouse.
+
+## Relacionado
+
+- [greenhouse](/es/docs/reference/portals/greenhouse)
+- [lever](/es/docs/reference/portals/lever)

--- a/content/docs/reference/portals/greenhouse.es.mdx
+++ b/content/docs/reference/portals/greenhouse.es.mdx
@@ -1,0 +1,57 @@
+---
+title: Greenhouse
+description: "career-ops consulta directamente la API pública de boards de Greenhouse. Sin scraping de HTML, sin riesgo de rate limits y sin consumir tokens de IA durante el propio escaneo."
+seoTitle: "Escanea ofertas de Greenhouse con career-ops — escaneo de portales ATS sin gastar tokens"
+icon: Leaf
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: 7b6f2cf40aacd803
+localized: true
+translatedFrom: /docs/reference/portals/greenhouse
+---
+
+## Qué hace
+
+El proveedor greenhouse de providers/greenhouse.mjs hace peticiones HTTP a boards-api.greenhouse.io/v1/boards/`{slug}`/jobs y convierte la respuesta JSON al formato de listado de career-ops. El slug es el identificador del board de Greenhouse de la empresa (p. ej. 'notion' para Notion).
+
+## Cuándo usarlo
+
+Usa el escaneo de Greenhouse cuando tus empresas objetivo usen Greenhouse como ATS. La mayoría de las tecnológicas estadounidenses de entre 50 y 10.000 empleados lo hacen. templates/portals.example.yml incluye más de 70 slugs de Greenhouse preconfigurados que puedes activar.
+
+## Ejemplo
+
+```
+In your portals.yml: `- provider: greenhouse\n  slug: notion\n  careers_url: https://job-boards.greenhouse.io/notion` — then `/career-ops scan` picks up all open Notion roles.
+```
+
+## Qué hace el escáner
+
+El escáner lee los slugs de Greenhouse que tengas activados en portals.yml, llama a la API pública de boards para cada uno y añade a tu pipeline los roles nuevos cuyo título coincida, sin scraping y sin gastar ni un token de LLM en la descarga. Una sola ejecución de `node scan.mjs` procesa tus boards de Greenhouse, Ashby y Lever en una pasada, y después filtra los resultados según las palabras clave de título que hayas configurado.
+
+```bash title="Terminal"
+node scan.mjs
+```
+
+```txt title="Output"
+Portal Scan - 2026-07-06
+Offers found: 58 total
+Filtered by title: 9 relevant
+Duplicates: 6 (already evaluated or in pipeline)
+New added to pipeline.md: 3
+
+  + Notion | AI Product Engineer | greenhouse
+  + OpenAI | Applied Engineer    | greenhouse
+```
+
+## Cómo se comunica career-ops con Greenhouse
+
+career-ops solicita `boards-api.greenhouse.io/v1/boards/{slug}/jobs` y lee el array `jobs` del JSON, tomando el título de cada rol y su `absolute_url`. Ese endpoint de boards devuelve metadatos del listado — título, ubicación y departamento — pero no la descripción completa, así que career-ops obtiene el texto íntegro de la oferta con una petición adicional por rol durante el paso de evaluación, o añadiendo `?content=true` cuando el board lo soporta. El escaneo en sí es un simple GET por HTTPS contra un endpoint público, y por eso se mantiene dentro de los rate limits y no gasta tokens del modelo. Repetir el escaneo es seguro: cada URL se deduplica contra tu historial de escaneos, tus candidaturas ya evaluadas y el pipeline actual, de modo que un rol que ya has visto nunca se añade dos veces.
+
+## Detalles a tener en cuenta
+
+Los listados de la API de Greenhouse solo incluyen el título, la ubicación y el departamento en el endpoint de boards. El texto completo de la descripción del puesto (JD) requiere una petición adicional por listado, que career-ops gestiona automáticamente durante el paso de evaluación.
+
+## Relacionado
+
+- [ashby](/es/docs/reference/portals/ashby)
+- [lever](/es/docs/reference/portals/lever)

--- a/content/docs/reference/portals/lever.es.mdx
+++ b/content/docs/reference/portals/lever.es.mdx
@@ -1,0 +1,57 @@
+---
+title: Lever
+description: "Lever es el ATS consolidado entre las empresas mid-market y en fase de crecimiento. career-ops consulta directamente la API pública de postings de Lever."
+seoTitle: "Escanea ofertas de Lever con career-ops — escaneo de portales ATS sin gastar tokens"
+icon: Wrench
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: 535b6f24a4a180f6
+localized: true
+translatedFrom: /docs/reference/portals/lever
+---
+
+## Qué hace
+
+El provider lever de providers/lever.mjs hace peticiones HTTP a api.lever.co/v0/postings/`{slug}` y parsea la respuesta JSON. El slug es el identificador de postings de Lever de la empresa (p. ej. 'figma' para Figma).
+
+## Cuándo usarlo
+
+Usa el escaneo de Lever para empresas en el rango de Serie C+ a pre-IPO que no hayan migrado a Greenhouse ni a Ashby. Figma, Brex y muchas empresas fintech siguen usando Lever.
+
+## Ejemplo
+
+```
+In your portals.yml: `- provider: lever\n  slug: figma\n  careers_url: https://jobs.lever.co/figma` — scan picks up active Figma roles.
+```
+
+## Qué hace el escáner
+
+El escáner lee tus slugs de Lever habilitados en portals.yml, llama a la API pública de postings de Lever para cada uno y fusiona en tu pipeline los roles nuevos cuyo título coincida, sin sesión de navegador y sin gastar un solo token de LLM en la descarga. La misma ejecución de `node scan.mjs` cubre también tus boards de Greenhouse y Ashby, y después filtra todo por las palabras clave de título que hayas configurado.
+
+```bash title="Terminal"
+node scan.mjs
+```
+
+```txt title="Output"
+Portal Scan - 2026-07-06
+Offers found: 33 total
+Filtered by title: 5 relevant
+Duplicates: 2 (already evaluated or in pipeline)
+New added to pipeline.md: 3
+
+  + Figma | AI Product Engineer | lever
+  + Brex  | Applied AI Engineer | lever
+```
+
+## Cómo se comunica career-ops con Lever
+
+career-ops solicita `api.lever.co/v0/postings/{slug}` — o el host `api.eu.lever.co` para los boards de la UE — y lee el array JSON de postings. De cada rol toma el campo `text` como título y `hostedUrl` como enlace, recurriendo a `applyUrl` cuando `hostedUrl` no está presente. Como Lever devuelve el board completo en una sola respuesta estructurada, el escaneo es un único GET público por HTTPS por empresa, que se mantiene dentro de los rate limits y no gasta tokens del modelo. El coste en tokens solo empieza más tarde, cuando evalúas un rol que te interesa. Repetir el escaneo es seguro: cada URL se deduplica contra tu historial de escaneos, tus candidaturas ya evaluadas y el pipeline actual, de modo que un rol que ya has visto nunca se añade dos veces.
+
+## A tener en cuenta
+
+La API de Lever expone la descripción del puesto (JD) completa en la respuesta de postings. Algunos boards de Lever incluyen metadatos internos del rol que career-ops saca a la superficie como señal adicional durante el scoring.
+
+## Relacionado
+
+- [greenhouse](/es/docs/reference/portals/greenhouse)
+- [ashby](/es/docs/reference/portals/ashby)

--- a/content/docs/reference/portals/meta.es.json
+++ b/content/docs/reference/portals/meta.es.json
@@ -1,0 +1,8 @@
+{
+  "title": "Portales",
+  "pages": [
+    "greenhouse",
+    "ashby",
+    "lever"
+  ]
+}

--- a/content/docs/windows.es.mdx
+++ b/content/docs/windows.es.mdx
@@ -1,0 +1,30 @@
+---
+title: career-ops en Windows
+seoTitle: "¿Funciona career-ops en Windows? Sí — con soporte de primera, el instalador se encarga de todo"
+description: "career-ops funciona en Windows con soporte de primera. La única particularidad de la plataforma — los symlinks — la gestiona el instalador automáticamente, sin modo administrador, sin mklink y sin requisito de versión mínima del sistema."
+icon: MonitorCheck
+translationHash: 90fc184fa31d979f
+localized: true
+translatedFrom: /docs/windows
+---
+
+**Sí — career-ops funciona en Windows con soporte de primera.** Existe una única particularidad específica de Windows, y el instalador la resuelve por ti automáticamente: sin Modo de desarrollador, sin `mklink` manual y sin requisito de versión mínima del sistema. Si tienes Node instalado, instalas y ejecutas career-ops en Windows exactamente igual que en cualquier otra plataforma.
+
+## La única particularidad de Windows, resuelta por ti
+
+Windows no crea symlinks por defecto, así que un checkout recién hecho de Git deja los puntos de entrada de las skills del CLI (`.claude/skills/`, `.opencode/skills/`, etc.) como simples ficheros puntero en lugar de symlinks reales — que es justo lo que provoca el error de "las skills no cargan" que la gente sufre en otras herramientas.
+
+career-ops lo detecta automáticamente. Al ejecutar el instalador o el actualizador — `npx @santifer/career-ops init` en una instalación nueva, o `node update-system.mjs apply` en una actualización — se ejecuta un paso `materializeSkillEntrypoints` que sustituye esos ficheros puntero por el contenido completo de cada skill. No necesitas permisos de administrador, ni Modo de desarrollador, ni ningún comando `mklink` manual.
+
+<Callout title="Sin requisito de versión mínima del sistema">
+career-ops no exige ninguna versión concreta de Windows (ni de macOS). Si Node funciona, career-ops funciona. Cualquier afirmación sobre una versión mínima del sistema operativo que hayas podido ver en otro sitio no es correcta.
+</Callout>
+
+## La referencia canónica de configuración
+
+El detalle técnico — el comportamiento exacto del instalador, las variantes de comandos para PowerShell y CMD, y el resto de la FAQ — vive en el repo core y se mantiene actualizado allí:
+
+- [docs/FAQ.md — "Skills aren't loading on Windows"](https://github.com/santifer/career-ops/blob/main/docs/FAQ.md) — la respuesta canónica, sincronizada con el instalador.
+- [docs/SETUP.md](https://github.com/santifer/career-ops/blob/main/docs/SETUP.md) — guía completa de configuración.
+
+Una vez instalado, elige tu motor en [Configura un motor de IA gratuito](/docs/free-ai-engine) o usa cualquier [CLI compatible](/docs/supported-clis), y después continúa con el [Inicio rápido](/es/docs).

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -32,7 +32,7 @@ async function createSearchServer() {
   });
 
   const docs = await chunkedAll(
-    source.getPages().map(async (page) => {
+    source.getPages('en').map(async (page) => {
       if (!('getText' in page.data)) return null;
 
       return {

--- a/src/app/llms-full.txt/route.ts
+++ b/src/app/llms-full.txt/route.ts
@@ -72,7 +72,7 @@ The full evaluation runs as Block A through G: A (role summary), B (CV match), C
 career-ops is permanently free, MIT-licensed, and community-funded: no paid tier, no waitlist, no account, no telemetry. Sustainability comes from voluntary patronage via GitHub Sponsors (https://github.com/sponsors/santifer). Nine tiers: seven individual ($1–$250) are identical statements of support; two corporate ($500 Corporate Supporter, $1,000 Ecosystem Partner) add logo placement on the README and /sustain — nothing else changes. No premium features, no roadmap influence, no priority support. Path 3 Sovereign Maintainer model.`;
 
 export async function GET() {
-  const scan = source.getPages().map(getLLMText);
+  const scan = source.getPages('en').map(getLLMText);
   const scanned = await Promise.all(scan);
 
   const blogPosts = await Promise.all(blogSource.getPages().map(blogLLMText));

--- a/src/app/llms.mdx/docs/[[...slug]]/route.ts
+++ b/src/app/llms.mdx/docs/[[...slug]]/route.ts
@@ -16,7 +16,7 @@ export async function GET(_req: Request, { params }: RouteContext<'/llms.mdx/doc
 }
 
 export function generateStaticParams() {
-  return source.getPages().map((page) => ({
+  return source.getPages('en').map((page) => ({
     lang: page.locale,
     slug: getPageMarkdownUrl(page).segments,
   }));

--- a/src/app/og/docs/[...slug]/route.tsx
+++ b/src/app/og/docs/[...slug]/route.tsx
@@ -21,7 +21,7 @@ export async function GET(_req: Request, { params }: RouteContext<'/og/docs/[...
 }
 
 export function generateStaticParams() {
-  return source.getPages().map((page) => ({
+  return source.getPages('en').map((page) => ({
     lang: page.locale,
     slug: getPageImage(page).segments,
   }));

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -83,7 +83,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   // /docs/** auto-discovered from Fumadocs source (includes
   // /docs/reference/modes/* and /docs/reference/portals/* shipped
   // post-migration from the deleted /use-cases routes).
-  for (const page of source.getPages()) {
+  for (const page of source.getPages('en')) {
     // page.url already includes the /docs prefix via baseUrl in source.ts.
     // Reconstruct MDX path from slugs:
     //   []                                 -> content/docs/index.mdx


### PR DESCRIPTION
## Why

Santiago relaxed the README/web frontera: the Spanish docs should mirror the English ones, not just the buyer subset. A `/es/docs` sidebar with 2 of ~30 pages read as broken. This translates the **whole technical reference** and stands up the reusable pipeline that keeps it maintainable — which was the original ask ("un solo esqueleto, fácil de tener en varios idiomas").

## The pipeline (Phase 2 core — runs on `claude -p`, the subscription, **not** an API key)

- **`.i18n/translate.mjs`** — for each EN `.mdx` it produces a faithful Spanish `.es.mdx` via `claude -p`, injecting the glossary of non-translatables + the canonical facts into every prompt, and stamping the content-hash `translationHash`. **24/24 translated cleanly, 0 failures.**

## Content

- **25 new `.es.mdx`**: all 14 modes, 3 portals, glossary, modes index, 5 guides, windows, pdf. Code, commands, MDX components (`<Tabs>`/`<Steps>`/`<Callout>`…), CLI names, mode ids and the literal-English thesis all preserved; canonical funnel (740→68→12→1) and five-vs-six dimensions respected (the `project` mode legitimately scores six — kept, verified against EN).
- **5 `meta.es.json`**: localize the sidebar folder labels + section headers (Introducción / Referencia / Modos / Portales / Guías). The ES tree now fills out — no more 2-item sidebar.
- Internal `/docs/` links in the ES pages rewritten to `/es/docs/` (except the 3 buyer pages still awaiting fan-out terms — kept EN to avoid 404s).

## Fix (surfaced by the volume)

`source.getPages()` with no locale returns EN**+**ES now, so the sitemap emitted every `/es` URL **twice** and the og/llms/chat routes pulled ES pages into EN-only outputs. Pinned sitemap, og, llms.mdx, llms-full and chat to `source.getPages('en')`.

## Verified (local build)

- ✅ 27 `/es/docs` pages + `/es`; Spanish folder labels.
- ✅ Sitemap ES 27 unique (dedup fixed).
- ✅ **Full EN sitemap 51/51 identical to prod**; EN `/docs` 30 pages unchanged.
- ✅ Canonical + sentinel checks clean.

## Follow-up (not in this PR)

- The 3 buyer pages (`free-ai-engine`, `supported-clis`, `faq`) translate next, with search-ops's measured ES fan-out terms (framing layer). Their ES links flip to `/es/docs/` then.
- search-ops to audit the ES docs cluster hreflang on prod after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)