### PR TITLE
feat(i18n): complete Spanish docs parity — 3 buyer pages (30/30)

### DIFF
--- a/content/docs/faq.es.mdx
+++ b/content/docs/faq.es.mdx
@@ -1,0 +1,55 @@
+---
+title: Preguntas frecuentes
+description: Preguntas frecuentes sobre career-ops — coste, privacidad, CLIs de IA compatibles, scan vs scan:full, límites de tokens, configuración en Windows y lo que career-ops nunca hará en tu nombre.
+seoTitle: "FAQ de career-ops — coste, privacidad, CLIs compatibles, Windows y cómo ejecutarlo gratis"
+icon: CircleQuestionMark
+translationHash: 21f06b4ed472c922
+localized: true
+translatedFrom: /docs/faq
+---
+
+{/* Espejado con src/lib/faq-data.ts (FAQPage JSON-LD) — editar ambos a la vez.
+    Las respuestas están verificadas contra docs/FAQ.md del repo core; el fichero
+    del core es la fuente de verdad del comportamiento técnico. */}
+
+Las preguntas más comunes, respondidas en un solo sitio. Para cualquier cosa que no esté cubierta aquí, pregunta en [Discord](https://discord.gg/8pRpHETxa4) o abre una [GitHub Discussion](https://github.com/santifer/career-ops/discussions).
+
+## ¿Es career-ops de código abierto y gratis?
+
+Sí. career-ops es open source bajo licencia MIT, para siempre. El único coste potencial es el motor de IA sobre el que corre — y ese también puede ser gratis: OpenCode con un proveedor gratuito, un modelo local vía Ollama, o el runner integrado `npm run or` sobre los modelos gratuitos de OpenRouter. La guía [Configura un motor de IA gratuito](/docs/free-ai-engine) recorre todas las opciones.
+
+## ¿Necesito una suscripción a Claude para usar career-ops?
+
+No. career-ops es agnóstico respecto a la IA — Claude Code es un motor entre varios, no un requisito. Puedes ejecutar el pipeline completo gratis con OpenCode más un proveedor gratuito, un modelo local vía Ollama, o el runner integrado de OpenRouter (`npm run or`). Si empezaste con un plan de pago y te quedaste sin tokens a mitad de búsqueda, cambiar a un motor gratuito lleva minutos y deja tus datos intactos — consulta [Configura un motor de IA gratuito](/docs/free-ai-engine).
+
+## ¿Dónde se guardan mis datos? ¿career-ops es privado?
+
+En tu máquina, en ficheros planos que son tuyos — tu CV, tu perfil, tu pipeline y tus informes son Markdown/YAML locales. Nada corre en servidores de career-ops. Las actualizaciones del sistema nunca tocan tu capa de datos (`cv.md`, `config/`, `data/`, `reports/`, `output/`): esa separación es el **Data Contract**, y todas las actualizaciones lo respetan.
+
+## ¿Con qué CLIs de programación con IA funciona career-ops?
+
+Ocho, con soporte de primera clase: Claude Code, OpenCode, Antigravity CLI, Codex, Grok Build CLI, Qwen, Kimi y GitHub Copilot CLI (Gemini CLI está soportado como wrapper legacy). career-ops es agnóstico respecto a la IA: distribuye ficheros de prompts que el CLI ejecuta, así que también puedes apuntarlo a cualquier endpoint compatible con OpenAI o a un modelo local sin cambiar una sola línea de código. Consulta [CLIs de IA compatibles](/docs/supported-clis) para ver la lista actual y cómo invocar cada uno.
+
+## ¿Cuál es la diferencia entre `scan` y `scan:full`?
+
+`npm run scan` lee las empresas que configuraste en `portals.yml` y consulta directamente sus APIs de ATS ([Greenhouse](/docs/reference/portals/greenhouse), [Ashby](/docs/reference/portals/ashby), [Lever](/docs/reference/portals/lever)), consumiendo cero tokens de LLM — ese es tu barrido de descubrimiento habitual, diario o semanal. `npm run scan:full` invierte la dirección: recorre directorios públicos de empresas en los ATS y saca a la superficie ofertas recientes que encajan con tu `title_filter` / `location_filter`, de modo que captas puestos de empresas que no has añadido manualmente.
+
+## ¿Cómo evito toparme con límites de tokens o rate limits durante una ejecución en batch?
+
+Acota la ejecución con `./batch/batch-runner.sh --limit 5` para inspeccionar la calidad del output antes de lanzarte a un batch mayor. Si una ejecución se ve interrumpida por un rate limit o un error de red, no la reinicies desde cero — usa `--resume-paused` para saltar los trabajos ya completados y que no se desperdicien tokens en trabajo que ya terminó.
+
+## Las skills no cargan en Windows — error de symlink al instalar
+
+Windows no crea symlinks por defecto, así que al hacer checkout Git deja los puntos de entrada de las skills del CLI como simples ficheros puntero. El instalador y el actualizador lo detectan automáticamente: ejecuta `node update-system.mjs apply` (o `npx @santifer/career-ops init` en una instalación nueva) y el paso de materialización sustituye los ficheros puntero por el contenido completo de cada skill. No hace falta ningún `mklink` manual ni activar el Modo de desarrollador.
+
+## ¿Puedo ejecutar career-ops con un modelo más barato o local?
+
+Sí — career-ops es totalmente agnóstico respecto a la IA. La guía [Running on a Budget](https://github.com/santifer/career-ops/blob/main/docs/RUNNING_ON_A_BUDGET.md) del repo core cubre OpenCode, Qwen CLI, DeepSeek, OpenRouter, Ollama y otros proveedores locales o de bajo coste, con tamaños de modelo recomendados (32B+ para un scoring fiable) y prácticas de ahorro de tokens.
+
+## ¿career-ops aplica a las ofertas por mí?
+
+Tú decides y envías, siempre. career-ops hace todo el trabajo previo — escanea, puntúa, adapta tu CV y puede pre-rellenar los formularios de candidatura de los ATS — pero el envío final es siempre un clic explícito tuyo. El proyecto rechaza de forma explícita la automatización tipo spray-and-pray: la idea es elegir bien las empresas, no enviar candidaturas a ciegas y en masa.
+
+## ¿Cuál es la diferencia entre career-ops y CareerOps?
+
+Son dos nombres para la misma obra. **career-ops** — en minúsculas y con guion — es el proyecto open source: un sistema de búsqueda de empleo potenciado por IA, con licencia MIT, que corre en local dentro de tu CLI de programación con IA, publicado en [career-ops.org](https://career-ops.org) y [github.com/santifer/career-ops](https://github.com/santifer/career-ops). **CareerOps** — en una sola palabra — da nombre a su manifiesto: [The CareerOps Manifesto](https://career-ops.org/manifesto), nueve derechos que cualquier persona que busca empleo debería tener, firmados públicamente por la comunidad. Ambos vienen del mismo autor, Santiago Fernández de Valderrama Aparicio, y ambos viven en el mismo repositorio: cada release, documento y firma del manifiesto se remonta a [github.com/santifer/career-ops](https://github.com/santifer/career-ops).

--- a/content/docs/free-ai-engine.es.mdx
+++ b/content/docs/free-ai-engine.es.mdx
@@ -1,0 +1,99 @@
+---
+title: Configura un motor de IA gratis
+seoTitle: "¿Cómo usar career-ops gratis? Sin suscripción a Claude — OpenRouter, Ollama y modelos locales"
+description: Ejecuta career-ops por 0 $ — sin suscripción a Claude ni ningún plan de pago. Motores de IA gratuitos para career-ops — OpenCode con un proveedor gratuito, un modelo local vía Ollama, cualquier endpoint compatible con OpenAI o el runner integrado de OpenRouter — y qué hacer cuando te quedas sin tokens a mitad de búsqueda.
+icon: Sparkles
+translationHash: 94eef6e555d79c0d
+localized: true
+translatedFrom: /docs/free-ai-engine
+---
+
+**career-ops es un agente de búsqueda de empleo con IA, gratis y open source (MIT): no necesitas una suscripción a Claude ni ningún plan de pago para ejecutarlo.** Su motor de IA también puede ser gratuito: OpenCode con un proveedor gratuito, un modelo totalmente local vía Ollama, cualquier endpoint compatible con OpenAI o el runner integrado de OpenRouter. Si te has quedado sin tokens a mitad de búsqueda, cambiar a un motor gratuito lleva minutos y deja intactos tu CV, tu pipeline y tus informes.
+
+career-ops es gratis y open source (MIT). Lo único que necesita para pensar es un **motor de IA** — un asistente de programación con IA que lee sus prompts y hace el trabajo. Ese motor también puede ser gratuito.
+
+Tú pones tu propio motor y tu propia clave. Nada corre en nuestros servidores — todo ocurre en tu máquina. Esta página muestra las vías gratuitas, de la más fácil a la más manual. Elige una y estarás listo para el [Inicio rápido](/docs).
+
+<Callout title="¿Qué estoy configurando exactamente?">
+Piensa en career-ops como la receta y en el motor de IA como el cocinero. La receta es gratis para siempre. Esta página va de conseguir un cocinero gratis — ya sea un modelo alojado con free tier o un modelo que corre por completo en tu propio ordenador.
+</Callout>
+
+## ¿Qué vía me conviene?
+
+| Si quieres… | Usa | ¿Gratis? | ¿Necesita un buen ordenador? |
+| --- | --- | --- | --- |
+| El arranque gratuito más fácil | **OpenCode + un proveedor gratuito** | Sí | No |
+| Todo 100 % offline y privado | **Ollama (modelo local)** | Sí | Sí — 16 GB+ de VRAM |
+| Reutilizar un CLI que ya tienes | **Su propio free tier** | Normalmente | No |
+| El atajo de un solo comando | **`npm run or`** | Sí | No |
+
+La mayoría debería empezar por la primera fila. El resto están aquí para cuando las quieras.
+
+## Vía 1 — OpenCode + un proveedor gratuito (recomendada)
+
+[OpenCode](https://opencode.ai) es un asistente de programación con IA gratuito y open source. La opinión de Santiago: *"opencode is top."* Se conecta a un montón de proveedores que ofrecen un **free tier**, así que puedes ejecutar career-ops sin gastar nada.
+
+<div className="rounded-lg bg-radial-[at_bottom] from-blue-500/20 p-4 border bg-origin-border border-fd-primary/10 prose-no-margin dark:bg-black/20">
+  <div className="rounded-xl bg-fd-background p-3">
+    <Steps>
+      <Step title="Instala OpenCode">
+        Sigue la instalación de una sola línea en [opencode.ai](https://opencode.ai). Corre en tu terminal, como los demás CLI de IA.
+      </Step>
+      <Step title="Elige un proveedor gratuito">
+        Regístrate en cualquier proveedor con free tier y copia tu API key. Opciones gratuitas populares que usa la comunidad: **OpenRouter** (modelos etiquetados `:free`), **Google AI Studio** (free tier de Gemini) y endpoints compatibles con OpenAI como el free tier de **Nvidia**. La [guía de presupuesto](https://github.com/santifer/career-ops/blob/main/docs/RUNNING_ON_A_BUDGET.md) mantiene la lista actualizada de modelos que rinden bien.
+      </Step>
+      <Step title="Apunta OpenCode hacia él">
+        Define tu clave y la URL base como variables de entorno y luego abre OpenCode dentro de la carpeta de career-ops:
+        ```bash title="Terminal"
+        export OPENAI_API_BASE="https://openrouter.ai/api/v1"
+        export OPENAI_API_KEY="your_free_api_key_here"
+        opencode
+        ```
+      </Step>
+    </Steps>
+  </div>
+</div>
+
+Eso es todo — OpenCode ya es tu motor. Sigue con el [Inicio rápido](/docs).
+
+## Vía 2 — Un CLI que ya tienes
+
+¿Ya usas un [CLI compatible](/docs/supported-clis) — **Claude Code, OpenCode, Codex, GitHub Copilot CLI y más**? Pues ya está — career-ops funciona con todos ellos, y varios incluyen free tier. Simplemente abre tu CLI dentro de la carpeta de career-ops. Sin configuración extra en esta página.
+
+## Vía 3 — 100 % local con Ollama (totalmente offline)
+
+¿Quieres cero nube, cero coste y privacidad total? Ejecuta el modelo en tu propia máquina con [Ollama](https://ollama.com). Nada sale de tu ordenador.
+
+El precio a pagar es el hardware. career-ops le pide al modelo puntuar ofertas en muchas dimensiones y adaptar tu CV — los modelos pequeños sufren con eso.
+
+<Callout type="warn" title="Elige un modelo lo bastante grande">
+Olvídate de los modelos diminutos de 7–8B — fallan con el formato de scoring y producen CVs genéricos. Usa un **modelo de 32B o mayor** (p. ej. Qwen 2.5 Coder 32B), que necesita una GPU con **16–24 GB de VRAM** (una RTX 3090/4090, o un Mac con Apple Silicon y 32 GB+ de memoria unificada). ¿No tienes una máquina así? La Vía 1 es la mejor ruta gratuita.
+</Callout>
+
+```bash title="Terminal"
+# Install Ollama from ollama.com, then pull a capable model:
+ollama pull qwen2.5-coder:32b
+```
+
+Después apunta tu CLI de IA (OpenCode funciona bien aquí) al endpoint local de Ollama, o usa el evaluador local integrado que describe la [guía de presupuesto](https://github.com/santifer/career-ops/blob/main/docs/RUNNING_ON_A_BUDGET.md).
+
+## Vía 4 — El atajo de un solo comando: `npm run or`
+
+career-ops incluye un runner integrado que enruta a **los modelos gratuitos de OpenRouter con fallback automático** — sin configuración de CLI con la que pelearte. Una vez que hayas clonado career-ops y configurado una clave de OpenRouter, un solo comando ejecuta el pipeline:
+
+```bash title="Terminal"
+export OPENROUTER_API_KEY="your_free_key_here"
+npm run or            # runs the full pipeline on free models
+```
+
+También hay variantes específicas — `npm run or:scan`, `or:eval`, `or:apply` — para ejecutar un solo paso.
+
+---
+
+<Callout title="Para desarrolladores — ajusta modelos y coste">
+¿Quieres las recomendaciones de modelos mantenidas al día, ejemplos por proveedor, evaluadores independientes (`node openai-eval.mjs`, `node ollama-eval.mjs`) y flags para ahorrar tokens? La guía **[Running on a Budget](https://github.com/santifer/career-ops/blob/main/docs/RUNNING_ON_A_BUDGET.md)** del repo core entra a fondo. career-ops es totalmente agnóstico al modelo — apúntalo a cualquier endpoint compatible con OpenAI sin cambiar una línea de código.
+</Callout>
+
+## Todo listo
+
+Con tu motor ya configurado, continúa con el **[Inicio rápido](/docs)** — clonarás career-ops, añadirás tu CV y ejecutarás tu primer scan gratuito.

--- a/content/docs/supported-clis.es.mdx
+++ b/content/docs/supported-clis.es.mdx
@@ -1,0 +1,31 @@
+---
+title: CLIs de IA compatibles
+seoTitle: "¿Con qué CLI de IA funciona career-ops? Claude Code, Codex, Gemini, OpenCode, Qwen, Copilot"
+description: "career-ops es agnóstico a la IA — funciona sobre todos los principales CLIs de programación con IA, así que usas el asistente que ya pagas y nunca quedas atado a un proveedor. La lista completa y siempre actualizada vive en el repo del core."
+icon: Terminal
+translationHash: 1dbfa0b338e7bf06
+localized: true
+translatedFrom: /docs/supported-clis
+---
+
+**career-ops funciona sobre todos los principales CLIs de programación con IA — no estás atado a ningún proveedor.** Como career-ops distribuye ficheros de prompts que el CLI ejecuta (no incluye su propio modelo), lo apuntas al asistente de programación con IA que ya uses y funciona sobre ese motor sin cambios. Cuando salga un modelo mejor, cambias de CLI y conservas tu pipeline, tus datos y tu configuración.
+
+<Callout title="Usa lo que ya tienes">
+El mejor CLI para career-ops es el que ya pagas. Si es Claude Code, ya está. Si quieres ejecutarlo gratis, consulta [Configura un motor de IA gratuito](/docs/free-ai-engine).
+</Callout>
+
+## ¿Qué CLIs son compatibles?
+
+career-ops ofrece soporte de primer nivel para **Claude Code, OpenCode, Antigravity CLI, Codex, Grok Build CLI, Qwen, Kimi y GitHub Copilot CLI** — ocho CLIs de programación con IA con mantenimiento activo. (Gemini CLI se mantiene como wrapper legacy tras su transición a Antigravity CLI.) La arquitectura es compartida: un único `AGENTS.md` canónico dirige la lógica, y unos ficheros de entrada ligeros por CLI resuelven los matices de invocación de cada herramienta.
+
+La **lista canónica y siempre actualizada — con el comando exacto para invocar career-ops en cada CLI — vive en el repo del core**, de modo que nunca se queda desfasada:
+
+- [docs/SUPPORTED_CLIS.md](https://github.com/santifer/career-ops/blob/main/docs/SUPPORTED_CLIS.md) — la matriz completa de CLIs compatibles, ficheros de entrada y cómo invocarlos (en modo interactivo y headless/batch).
+
+## ¿Cuál debería elegir?
+
+- **¿Ya pagas Claude Code, Codex o Copilot?** Úsalo. career-ops funciona encima sin configuración extra — abre el CLI dentro de la carpeta de career-ops.
+- **¿Quieres ejecutarlo a coste $0?** [OpenCode con un proveedor gratuito, un modelo local vía Ollama o el runner integrado de OpenRouter](/docs/free-ai-engine) — las tres opciones funcionan.
+- **¿Te importa un modelo o proveedor concreto?** career-ops es agnóstico al modelo — apunta cualquiera de estos CLIs a cualquier endpoint compatible con OpenAI o a un modelo local. Nada cambia en career-ops.
+
+Elijas lo que elijas, los [14 modos](/docs/reference/modes) se comportan igual — el CLI es el motor y career-ops es la estructura que va encima.


### PR DESCRIPTION
Translates the last three untranslated docs — **free-ai-engine**, **supported-clis**, **faq** — so every EN doc now has an `.es.mdx` twin (30/30 parity). Produced with the `.i18n/translate.mjs` pipeline (`claude -p` + non-translatables glossary + drift hash), then framed per search-ops's measured ES terms for the buyer bucket.

## Framing applied (search-ops deliverable, measured fan-out ES 2026-07-21)
- **free-ai-engine** — query-form `seoTitle` (`¿Cómo usar career-ops gratis? …`) + category-led opening liftable (M4 fix: leads with "agente de búsqueda de empleo con IA, gratis y open source").
- **supported-clis** — measured `seoTitle` (`¿Con qué CLI de IA funciona career-ops? …`).
- **faq** — measured heading reformulations (open-source & free, data/privacy) + the apply-for-me answer reframed to the positive (M2 — *tú decides y envías*).

## Contract
- Response layer = faithful transcreation; framing layer = localized per measured fan-out (`localized: true`, drift `translationHash` stamped from the EN body).
- Net-new measured FAQ questions without an EN parent (gloss "¿Qué significa career-ops?", "¿Necesito saber programar?", reviews) are deferred to the W31 refinement per search-ops's own timeline.

## Verification
- `npm run build` ✓ · `types:check` ✓
- Sitemap: 3 ES buyer URLs present with bidirectional `en`/`es`/`x-default` hreflang (source-derived, no hand-kept map).
- **EN URL set unchanged (51/51).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)