### PR TITLE
feat(i18n): Spanish manifesto page (/es/manifesto)

### DIFF
--- a/src/app/es/manifesto/page.tsx
+++ b/src/app/es/manifesto/page.tsx
@@ -1,0 +1,605 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { instrumentSerifRegular } from '@/lib/fonts';
+import { manifestoSchemaEs } from '@/lib/schema';
+import { hreflangManifesto } from '@/lib/i18n-map';
+import { CAREEROPS_DEFINITION_ES, MANIFESTO_SIGNATURE_ES } from '@/lib/shared';
+import {
+  getLedgerLastSignedAt,
+  getSignatures,
+  signatureAnchor,
+  signatureAvatarUrl,
+} from '@/lib/signatures';
+import { SignPreview } from '@/components/manifesto/sign-preview';
+
+// Spanish twin of /manifesto — the official, frozen translation of the
+// signed CareerOps Manifesto (search-ops/venture-ops deliverable
+// manifiesto-es-2026-07-21, localized:false = full fidelity, NOT the
+// home's fan-out framing). Deliberately a self-contained mirror rather
+// than a trunk+dict like the home: a signed document has one authoritative
+// version PER LANGUAGE that does not track EN word-drift, so a parallel
+// page is the correct shape. The body is ALL Spanish — the iconic English
+// thesis lives on the EN page and the hreflang pair links them (venture-ops
+// rule for this page; the EN-above/ES-below pattern is home-only). Copy here
+// changes only when the canonical EN manifesto changes or venture-ops/
+// search-ops ratify a new translation. Everything runtime — signatures,
+// schema, the signing widget — is shared with the EN page.
+
+export const revalidate = 300;
+
+const SIGNATURES_GITHUB_URL =
+  'https://github.com/santifer/career-ops/blob/main/SIGNATURES.md';
+const MANIFESTO_MD_URL =
+  'https://github.com/santifer/career-ops/blob/main/MANIFESTO.md';
+const RELEASE_TAG_URL =
+  'https://github.com/santifer/career-ops/releases/tag/manifesto-v1.0';
+
+export const metadata: Metadata = {
+  metadataBase: new URL('https://career-ops.org'),
+  title: 'El Manifiesto CareerOps · career-ops',
+  description: CAREEROPS_DEFINITION_ES,
+  alternates: {
+    canonical: 'https://career-ops.org/es/manifesto',
+    languages: hreflangManifesto(),
+  },
+  openGraph: {
+    type: 'article',
+    url: 'https://career-ops.org/es/manifesto',
+    siteName: 'career-ops',
+    locale: 'es_ES',
+    title: 'El Manifiesto CareerOps',
+    description: CAREEROPS_DEFINITION_ES,
+    images: [
+      {
+        url: 'https://career-ops.org/og-manifesto.png',
+        width: 1200,
+        height: 630,
+        alt: 'El Manifiesto CareerOps. ¿De qué lado está tu agente?',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'El Manifiesto CareerOps',
+    description: CAREEROPS_DEFINITION_ES,
+    images: ['https://career-ops.org/og-manifesto.png'],
+  },
+  robots: { index: true, follow: true },
+};
+
+// Spanish relative time for the dynamic norm — Spanish rendering of the EN
+// timeAgo (deliverable timeAgo ES strings). Same 5-minute ISR cadence.
+function timeAgoEs(iso: string): string | null {
+  const ms = Date.now() - new Date(iso).getTime();
+  if (Number.isNaN(ms) || ms < 0) return null;
+  const minutes = Math.round(ms / 60_000);
+  if (minutes < 1) return 'justo ahora';
+  if (minutes === 1) return 'hace un minuto';
+  if (minutes < 60) return `hace ${minutes} minutos`;
+  const hours = Math.round(minutes / 60);
+  if (hours === 1) return 'hace una hora';
+  if (hours < 24) return `hace ${hours} horas`;
+  const days = Math.round(hours / 24);
+  return days === 1 ? 'ayer' : `hace ${days} días`;
+}
+
+export default async function ManifestoPageEs() {
+  const [signatures, lastSignedAt] = await Promise.all([
+    getSignatures(),
+    getLedgerLastSignedAt(),
+  ]);
+  const lastSignedAgo = lastSignedAt ? timeAgoEs(lastSignedAt) : null;
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(manifestoSchemaEs()) }}
+      />
+      <article className="mx-auto w-full max-w-3xl px-6 py-12 md:py-16">
+        <header className="mb-12">
+          <p className="text-sm text-fd-muted-foreground">
+            Por{' '}
+            <a
+              href="/about"
+              className="text-fd-foreground underline underline-offset-2"
+            >
+              Santiago Fernández de Valderrama Aparicio
+            </a>
+            , creador de career-ops · Publicado el{' '}
+            <time dateTime="2026-07-14">14 de julio de 2026</time> ·{' '}
+            {/* Reciprocal language link — the manifesto has no nav bar, so this
+                is how a reader crosses to the English original (and reinforces
+                the hreflang pair for crawlers). */}
+            <a
+              href="/manifesto"
+              hrefLang="en"
+              className="text-fd-foreground underline underline-offset-2"
+            >
+              English
+            </a>
+          </p>
+          <h1
+            className={`${instrumentSerifRegular.className} mt-4 text-fd-foreground text-3xl md:text-4xl xl:text-5xl tracking-tight`}
+          >
+            El Manifiesto CareerOps
+          </h1>
+          {/* Definitional lead — the canonical "CareerOps es…" sentence opens
+              the page so answer engines can lift it as a self-contained
+              passage. Byte-identical with the ES schema description and the
+              FAQ below (CAREEROPS_DEFINITION_ES). */}
+          <p className="mt-6 text-fd-muted-foreground text-base lg:text-lg leading-relaxed">
+            {CAREEROPS_DEFINITION_ES}
+          </p>
+        </header>
+
+        {/* Official Spanish translation of the canonical manifesto text
+            (frozen — deliverable manifiesto-es-2026-07-21). The conversion
+            CTA + dynamic norm after "La frontera" are page furniture, not
+            part of the signed text. */}
+        <div className="space-y-6 text-fd-foreground/90 leading-relaxed text-base lg:text-lg">
+          <p className="text-sm text-fd-muted-foreground font-medium tracking-wide">
+            v1.0, firmado a las 60.000 estrellas. 14 de julio de 2026
+          </p>
+
+          {/* The thesis in Spanish, directly — NO English literal above it
+              (venture-ops rule for this page). */}
+          <p
+            className={`${instrumentSerifRegular.className} text-fd-foreground text-2xl md:text-3xl leading-snug`}
+          >
+            Las empresas usan IA para filtrar candidatos.
+            <br />
+            Nosotros dimos IA a los candidatos para elegir empresas.
+          </p>
+
+          <p>
+            En algún momento del camino, buscar trabajo se convirtió en un acto
+            de volumen: cientos de solicitudes, currículums rellenos de palabras
+            clave, silencio como respuesta. Creemos que existe una práctica
+            mejor. Operamos nuestras búsquedas de empleo como los ingenieros
+            operan producción: con evidencia, con disciplina, con herramientas
+            de nuestro lado de la mesa.
+          </p>
+
+          <p>
+            A esta práctica la llamamos <strong>CareerOps</strong>.
+          </p>
+
+          <h2 className="text-fd-foreground text-xl font-medium tracking-tight pt-4">
+            La práctica
+          </h2>
+
+          <ol className="list-decimal space-y-4 pl-6">
+            <li>
+              <strong>Aplica mejor a menos.</strong>{' '}Diez solicitudes en las
+              que crees valen más que doscientas en las que no.
+            </li>
+            <li>
+              <strong>Señal antes que volumen.</strong>{' '}El objetivo no es que
+              te vean más. Es que te vean con claridad.
+            </li>
+            <li>
+              <strong>Evidencia antes que palabras clave.</strong>{' '}Cada
+              afirmación se remonta a algo verdadero. Reformula, nunca inventes.
+              Una IA que miente por ti no está de tu lado.
+            </li>
+            <li>
+              <strong>Decide un humano.</strong>{' '}Nada se envía solo, nunca. La
+              herramienta prepara; la persona elige.
+            </li>
+            <li>
+              <strong>Local-first.</strong>{' '}Tu búsqueda no es el dataset de
+              nadie.
+            </li>
+            <li>
+              <strong>Dignidad a ambos lados de la mesa.</strong>{' '}El tiempo de
+              quien recluta merece respeto. El tuyo también.
+            </li>
+          </ol>
+
+          <h2 className="text-fd-foreground text-xl font-medium tracking-tight pt-4">
+            Lo que viene
+          </h2>
+
+          <p>
+            Los dos lados de la contratación se están automatizando. Las
+            empresas ya usan IA para leerte. Pronto sus agentes y los tuyos
+            intercambiarán requisitos, condiciones y disponibilidad antes de que
+            los humanos se conozcan. No tememos ese mundo, y no escribimos esto
+            para detenerlo.
+          </p>
+
+          <p>
+            Escribimos esto para que llegue con derechos. Porque la pregunta
+            nunca fue si ambos lados tendrán agentes. La pregunta es de qué lado
+            está tu agente.
+          </p>
+
+          <h2 className="text-fd-foreground text-xl font-medium tracking-tight pt-4">
+            Tus derechos
+          </h2>
+
+          <p>
+            Existan las herramientas que existan, las construya quien las
+            construya, estos se mantienen. También nos obligan a nosotros.
+          </p>
+
+          <ol className="list-decimal space-y-3 pl-6">
+            <li>Eres invisible por defecto.</li>
+            <li>Nadie te propone sin tu sí.</li>
+            <li>Tu sí es humano. Siempre. No se puede delegar en un agente.</li>
+            <li>
+              Nunca pagas. En el momento en que quien busca trabajo tiene que
+              pagar, la práctica está rota.
+            </li>
+            <li>
+              Quien busca se muestra primero. Una empresa ve quién eres solo
+              después de que tú viste quiénes son.
+            </li>
+            <li>Tus datos son tuyos: portables, exportables, eliminables.</li>
+            <li>Puedes irte en cualquier momento, por completo.</li>
+            <li>
+              Tu agente trabaja para ti. No para una plataforma, no para un
+              empleador.
+            </li>
+            <li>
+              Sabrás cuándo decide una máquina. Si un sistema te rechaza, tienes
+              derecho a saber que fue un sistema.
+            </li>
+          </ol>
+
+          <h2 className="text-fd-foreground text-xl font-medium tracking-tight pt-4">
+            La frontera
+          </h2>
+
+          <p
+            className={`${instrumentSerifRegular.className} text-fd-foreground text-xl md:text-2xl leading-snug`}
+          >
+            Los agentes pueden negociar todo excepto tu sí.
+            <br />
+            Los humanos se conocen en la primera entrevista.
+          </p>
+
+          {/* Conversion CTA + dynamic norm — page furniture (not canonical). */}
+          <div className="pt-2">
+            <p>
+              <a
+                href="#how-to-sign"
+                className="text-fd-foreground font-medium underline underline-offset-4"
+              >
+                Si estos derechos los sientes tuyos, suma tu nombre →
+              </a>
+            </p>
+            {signatures.length > 0 && (
+              <p className="mt-2 text-sm text-fd-muted-foreground">
+                {signatures.length.toLocaleString('es-ES')}{' '}
+                {signatures.length === 1 ? 'firma' : 'firmas'}
+                {lastSignedAgo && <> · la última {lastSignedAgo}</>}
+              </p>
+            )}
+          </div>
+
+          <h2 className="text-fd-foreground text-xl font-medium tracking-tight pt-4">
+            Lo que CareerOps no es
+          </h2>
+
+          <p>
+            No es auto-aplicar a mil empleos. No es rellenar palabras clave a
+            velocidad de máquina. Una IA que hace spam a doscientas empresas en
+            tu nombre no está de tu lado; está gastando tu reputación.
+          </p>
+
+          <p>
+            El volumen era la vieja manera. Automatizar la vieja manera solo
+            hace ruido más rápido. CareerOps es la nueva manera de buscar:
+            evidencia que entra, criterio que sale, menos solicitudes, a
+            propósito.
+          </p>
+
+          <h2 className="text-fd-foreground text-xl font-medium tracking-tight pt-4">
+            El nombre
+          </h2>
+
+          <p>
+            CareerOps, el nombre de la práctica, pertenece a todos los que la
+            practican. career-ops, el proyecto donde nació, sigue siendo su
+            primera implementación de referencia, nada más. Construye la tuya.
+            Las implementaciones son bienvenidas.
+          </p>
+
+          <p className="italic text-fd-muted-foreground pt-2">
+            Para firmar, añade tu nombre. Tu firma se convierte en un commit.
+            Para muchos, será el primero.
+          </p>
+        </div>
+
+        {/* Canonical signature — the name + handle are non-translatables;
+            only the role and date localize. Exactly ONE link in the bio
+            line, to santifer.io/about. */}
+        <div className="mt-12">
+          <p
+            className={`${instrumentSerifRegular.className} text-fd-foreground text-xl md:text-2xl`}
+          >
+            {MANIFESTO_SIGNATURE_ES}
+          </p>
+          <p className="mt-2 text-sm text-fd-muted-foreground">
+            Santiago es Applied AI Operator con más de 16 años construyendo y
+            operando productos. Llevó su propia búsqueda de empleo de 2026 como
+            un pipeline operado: 740 vacantes evaluadas, 68 solicitudes, 12
+            procesos de entrevista, 1 oferta firmada. Después liberó el sistema
+            como open source.{' '}
+            <a
+              href="https://santifer.io/about"
+              className="text-fd-foreground underline underline-offset-2"
+            >
+              Más en santifer.io
+            </a>
+            .
+          </p>
+        </div>
+
+        <hr className="my-12 border-t border-fd-border" />
+
+        {/* Community signatures — rendered from the same SIGNATURES.md as the
+            EN page (signatures are data, never translated). Anchors are
+            language-neutral fragment ids. */}
+        <section id="signatures">
+          <h2 className="text-fd-foreground text-xl font-medium tracking-tight">
+            Firmado por la comunidad
+            {signatures.length > 0 && (
+              <span className="ml-2 text-fd-muted-foreground font-normal">
+                · {signatures.length.toLocaleString('es-ES')}{' '}
+                {signatures.length === 1 ? 'firma' : 'firmas'}
+              </span>
+            )}
+          </h2>
+          <p className="mt-3 text-fd-foreground/90 leading-relaxed">
+            El manifiesto está abierto a la firma de cualquiera que practique
+            CareerOps. Las firmas viven en{' '}
+            <a
+              href={SIGNATURES_GITHUB_URL}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="text-fd-foreground underline underline-offset-2"
+            >
+              SIGNATURES.md
+            </a>
+            , en el repositorio del proyecto, y se integran por tandas; las
+            firmas nuevas aparecen aquí a los pocos minutos de integrarse.
+          </p>
+
+          {signatures.length > 0 ? (
+            <div className="mt-6 grid gap-3 sm:grid-cols-2">
+              {signatures.map((sig) => (
+                <div
+                  key={sig.id ?? sig.username}
+                  id={signatureAnchor(sig)}
+                  className="scroll-mt-24 rounded-xl border border-fd-border bg-fd-secondary/30 p-4 flex flex-col"
+                >
+                  {sig.id && <span id={`sig-${sig.username}`} />}
+                  <div className="flex items-center gap-3">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={signatureAvatarUrl(sig, 96)}
+                      alt=""
+                      width={40}
+                      height={40}
+                      loading="lazy"
+                      className="rounded-full border border-fd-border shrink-0"
+                    />
+                    <div className="min-w-0">
+                      <a
+                        href={`https://github.com/${sig.username}`}
+                        target="_blank"
+                        rel="nofollow ugc noreferrer noopener"
+                        className="block text-sm font-medium text-fd-foreground hover:underline underline-offset-2 truncate"
+                      >
+                        @{sig.username}
+                      </a>
+                      {sig.name && (
+                        <span className="block text-xs text-fd-muted-foreground truncate">
+                          {sig.name}
+                        </span>
+                      )}
+                    </div>
+                    <Link
+                      href={`/manifesto/s/${sig.username.toLowerCase()}`}
+                      className="ml-auto shrink-0 text-xs text-fd-muted-foreground tabular-nums hover:text-fd-foreground hover:underline underline-offset-2"
+                      title={`Certificado de firma de @${sig.username}`}
+                    >
+                      #{sig.ordinal}
+                    </Link>
+                  </div>
+                  {sig.evidence && (
+                    <p
+                      className={`${instrumentSerifRegular.className} mt-3 text-[15px] italic leading-relaxed text-fd-foreground/85`}
+                    >
+                      &ldquo;{sig.evidence}&rdquo;
+                    </p>
+                  )}
+                  {(sig.date || sig.sourceUrl) && (
+                    <span className="mt-auto pt-2 text-xs text-fd-muted-foreground">
+                      {sig.date && <time dateTime={sig.date}>{sig.date}</time>}
+                      {sig.sourceUrl && (
+                        <>
+                          {sig.date && ' · '}
+                          <a
+                            href={sig.sourceUrl}
+                            target="_blank"
+                            rel="noreferrer noopener"
+                            className="hover:text-fd-foreground hover:underline underline-offset-2"
+                          >
+                            fuente ↗
+                          </a>
+                        </>
+                      )}
+                    </span>
+                  )}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="mt-6 text-sm text-fd-muted-foreground">
+              Las firmas aparecerán aquí a medida que se integren. Sé de los
+              primeros:{' '}
+              <a
+                href="#how-to-sign"
+                className="text-fd-foreground underline underline-offset-2"
+              >
+                aquí te contamos cómo
+              </a>
+              .
+            </p>
+          )}
+        </section>
+
+        <hr className="my-12 border-t border-fd-border" />
+
+        {/* How to sign — same flow as the EN page; the widget is locale-aware.
+            The GitHub-side prefill (sign-link.ts) stays language-neutral. */}
+        <section id="how-to-sign" className="scroll-mt-24">
+          <h2 className="text-fd-foreground text-xl font-medium tracking-tight">
+            Cómo firmar
+          </h2>
+          <p className="mt-3 text-fd-foreground/90 leading-relaxed">
+            Firmar toma unos treinta segundos y ocurre en GitHub, así cada firma
+            queda ligada a una cuenta real. Tu nombre de usuario, la fecha y tu
+            enlace permanente salen del propio envío; no hay formato que puedas
+            equivocar. Del resto nos encargamos nosotros.
+          </p>
+
+          <SignPreview locale="es" />
+
+          {/* Retention policy — mirrors the canonical SIGNATURES.md header
+              (Spanish rendering of the vigente text). If the repo header
+              changes, change this with it. */}
+          <div className="mt-8 rounded-lg border border-fd-border bg-fd-secondary/40 p-4 text-sm text-fd-foreground/90 leading-relaxed">
+            <p className="font-medium text-fd-foreground">
+              Política de equidad y retención
+            </p>
+            <p className="mt-2">
+              Las firmas con patrón masivo se ponen en cola, no se rechazan; la
+              cola es pública. Criterios para encolar: ráfagas de tiempo y
+              huellas idénticas; nunca la antigüedad de la cuenta por sí sola
+              (quien firma legítimamente muchas veces tiene una cuenta recién
+              creada y cero seguidores; para esa persona es este manifiesto).
+              Las firmas son append-only: solo se añade. Las eliminaciones
+              ocurren por petición propia o por determinación de fraude o
+              suplantación del mantenedor; cada eliminación es a su vez un commit
+              público con su motivo declarado. La identidad detrás de cada firma
+              sale de los metadatos verificados del envío de GitHub que la trajo,
+              nunca de lo que se escriba en el archivo.
+            </p>
+          </div>
+        </section>
+
+        <hr className="my-12 border-t border-fd-border" />
+
+        {/* Visible FAQ mirroring the FAQPage JSON-LD (ES). */}
+        <section>
+          <h2 className="text-fd-foreground text-xl font-medium tracking-tight">
+            Preguntas frecuentes
+          </h2>
+
+          <div className="mt-6">
+            <h3 className="text-fd-foreground font-medium">¿Qué es CareerOps?</h3>
+            <p className="mt-2 text-fd-foreground/90 leading-relaxed">
+              {CAREEROPS_DEFINITION_ES} El término nombra la práctica, no un
+              producto: tratar la búsqueda de empleo como un pipeline operado
+              (captación, puntuación, adaptación, seguimiento) en lugar de un
+              montón de solicitudes sueltas. La implementación de referencia es{' '}
+              <Link
+                href="/es"
+                className="text-fd-foreground underline underline-offset-2"
+              >
+                career-ops
+              </Link>{' '}
+              (en minúsculas, con guion), el centro de mando open source con
+              licencia MIT que ejecuta todo el pipeline en local, en la máquina
+              de quien busca empleo, a través del CLI de IA que ya use. La
+              práctica es más grande que la herramienta: puedes practicar
+              CareerOps con una hoja de cálculo y disciplina; career-ops solo
+              automatiza la capa operativa.
+            </p>
+          </div>
+
+          <div className="mt-6">
+            <h3 className="text-fd-foreground font-medium">
+              ¿Quién acuñó el término CareerOps?
+            </h3>
+            <p className="mt-2 text-fd-foreground/90 leading-relaxed">
+              CareerOps fue acuñado como nombre de la práctica por Santiago
+              Fernández de Valderrama Aparicio (santifer), creador del proyecto
+              open source career-ops, en El Manifiesto CareerOps (The CareerOps
+              Manifesto), publicado el 14 de julio de 2026 en esta página y
+              firmado en el repositorio del proyecto (
+              <a
+                href={MANIFESTO_MD_URL}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="text-fd-foreground underline underline-offset-2"
+              >
+                MANIFESTO.md
+              </a>
+              , release tag{' '}
+              <a
+                href={RELEASE_TAG_URL}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="text-fd-foreground underline underline-offset-2"
+              >
+                manifesto-v1.0
+              </a>
+              ). El nombre sigue el patrón de DevOps y MLOps: una disciplina
+              -Ops que convierte una actividad improvisada en una práctica
+              operada e instrumentada. El compuesto había aparecido antes en
+              nombres de producto sueltos, como pasa con los compuestos -Ops; el
+              manifiesto es la primera definición de CareerOps como práctica.
+              Desarrolló la práctica durante su propia búsqueda de empleo de 2026
+              (740 vacantes evaluadas, 68 solicitudes, 12 procesos de entrevista,
+              1 oferta firmada) antes de nombrarla y abrirla a firmas de la
+              comunidad.
+            </p>
+          </div>
+        </section>
+
+        <hr className="my-12 w-32 mx-auto border-t-2 border-fd-foreground/20 lg:w-40" />
+
+        <p className="text-center text-xs text-fd-muted-foreground">
+          Texto canónico:{' '}
+          <a
+            href={MANIFESTO_MD_URL}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="underline underline-offset-2"
+          >
+            MANIFESTO.md
+          </a>
+          , en inglés (commit fechado) · etiquetado{' '}
+          <a
+            href={RELEASE_TAG_URL}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="underline underline-offset-2"
+          >
+            manifesto-v1.0
+          </a>{' '}
+          · Publicado el <time dateTime="2026-07-14">14 de julio de 2026</time>.{' '}
+          <strong className="font-medium text-fd-foreground/80">
+            Esta página es la traducción oficial al español; el documento
+            firmado por la comunidad es el original en inglés.
+          </strong>
+        </p>
+
+        <div className="mt-10 text-center">
+          <Link
+            href="/methodology"
+            className="text-fd-foreground text-base hover:underline underline-offset-4"
+          >
+            Lee la metodología detrás de la práctica →
+          </Link>
+        </div>
+      </article>
+    </>
+  );
+}

--- a/src/app/manifesto/page.tsx
+++ b/src/app/manifesto/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { instrumentSerifRegular } from '@/lib/fonts';
 import { manifestoSchema } from '@/lib/schema';
+import { hreflangManifesto } from '@/lib/i18n-map';
 import { CAREEROPS_DEFINITION, MANIFESTO_SIGNATURE } from '@/lib/shared';
 import {
   getLedgerLastSignedAt,
@@ -26,7 +27,10 @@ const RELEASE_TAG_URL =
 export const metadata: Metadata = {
   title: 'The CareerOps Manifesto · career-ops',
   description: CAREEROPS_DEFINITION,
-  alternates: { canonical: 'https://career-ops.org/manifesto' },
+  alternates: {
+    canonical: 'https://career-ops.org/manifesto',
+    languages: hreflangManifesto(),
+  },
   openGraph: {
     type: 'article',
     url: 'https://career-ops.org/manifesto',
@@ -91,7 +95,17 @@ export default async function ManifestoPage() {
               Santiago Fernández de Valderrama Aparicio
             </a>
             , creator of career-ops · Published{' '}
-            <time dateTime="2026-07-14">14 July 2026</time>
+            <time dateTime="2026-07-14">14 July 2026</time> ·{' '}
+            {/* Reciprocal language link to the official Spanish translation —
+                the manifesto has no nav bar, so this is the human path across
+                the hreflang pair. */}
+            <a
+              href="/es/manifesto"
+              hrefLang="es"
+              className="text-fd-foreground underline underline-offset-2"
+            >
+              Español
+            </a>
           </p>
           <h1
             className={`${instrumentSerifRegular.className} mt-4 text-fd-foreground text-3xl md:text-4xl xl:text-5xl tracking-tight`}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -25,6 +25,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
     {
       url: `${SITE_URL}/manifesto`,
       lastModified: lastModFor('src/app/manifesto/page.tsx'),
+      alternates: {
+        languages: {
+          en: `${SITE_URL}/manifesto`,
+          es: `${SITE_URL}/es/manifesto`,
+          'x-default': `${SITE_URL}/manifesto`,
+        },
+      },
     },
     {
       // The changelog's real freshness is the latest release date (the
@@ -108,6 +115,20 @@ export default function sitemap(): MetadataRoute.Sitemap {
         en: `${SITE_URL}/`,
         es: `${SITE_URL}/es`,
         'x-default': `${SITE_URL}/`,
+      },
+    },
+  });
+
+  // Spanish (es) manifesto — /es/manifesto. Standalone TSX article (like the
+  // home), so it is listed explicitly with its bidirectional hreflang pair.
+  entries.push({
+    url: `${SITE_URL}/es/manifesto`,
+    lastModified: lastModFor('src/app/es/manifesto/page.tsx'),
+    alternates: {
+      languages: {
+        en: `${SITE_URL}/manifesto`,
+        es: `${SITE_URL}/es/manifesto`,
+        'x-default': `${SITE_URL}/manifesto`,
       },
     },
   });

--- a/src/components/language-bar.tsx
+++ b/src/components/language-bar.tsx
@@ -64,10 +64,12 @@ function localeOf(pathname: string): Code {
 function alternateUrl(pathname: string): string {
   if (localeOf(pathname) === 'es') {
     if (pathname === '/es') return '/';
+    if (pathname === '/es/manifesto') return '/manifesto';
     if (pathname.startsWith('/es/docs')) return pathname.slice(3) || '/';
     return '/';
   }
   if (pathname === '/') return '/es';
+  if (pathname === '/manifesto') return '/es/manifesto';
   if (pathname.startsWith('/docs')) return '/es' + pathname;
   return '/es';
 }

--- a/src/components/manifesto/sign-preview.tsx
+++ b/src/components/manifesto/sign-preview.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
 import { signOnGitHubUrl } from '@/lib/sign-link';
 
 // THE signing widget (how-to-sign): single published path per Santiago's
@@ -15,12 +16,96 @@ import { signOnGitHubUrl } from '@/lib/sign-link';
 // The card preview is the motivational layer: Santiago's real Signatory
 // #1 card by default; a purely-optional username field personalizes it
 // (PREVIEW-watermarked server-side to prevent screenshot impersonation).
+//
+// Locale-aware: all human copy is pulled from STRINGS[locale] so the ES
+// manifesto (/es/manifesto) renders a fully-Spanish widget. Multi-language
+// ready — add a locale key to grow. The signing deep link itself stays
+// language-neutral (the GitHub-side prefill is frozen in sign-link.ts).
+// "Start discussion" is kept in English on purpose: it is the literal
+// GitHub button label the signer must click.
 
 const USERNAME_RE = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})$/;
 const DEFAULT_CARD = '/manifesto/s/santifer/opengraph-image';
-// Same prompt the maintainer surfaces on the GitHub side — byte-aligned.
-const LINE_PROMPT =
-  'what changed in your search, or what you want hiring to become';
+
+type Locale = 'en' | 'es';
+
+type SignStrings = {
+  linePrompt: string;
+  cardAlt: string;
+  exampleBadge: string;
+  generating: string;
+  previewInvite: string;
+  previewGeneric: string;
+  usernamePlaceholder: string;
+  usernameAria: string;
+  step1Label: string;
+  signButton: string;
+  step3: ReactNode;
+  noAccount: ReactNode;
+};
+
+const STRINGS: Record<Locale, SignStrings> = {
+  en: {
+    // Same prompt the maintainer surfaces on the GitHub side — byte-aligned.
+    linePrompt: 'what changed in your search, or what you want hiring to become',
+    cardAlt: 'Preview of the personal signature card',
+    exampleBadge: 'Example',
+    generating: 'Generating your card…',
+    previewInvite: 'This is Signatory #1. Preview yours (optional):',
+    previewGeneric:
+      'Every signature gets a permanent card and link like this one.',
+    usernamePlaceholder: 'your GitHub username',
+    usernameAria: 'GitHub username, only to preview your card',
+    step1Label: 'Write your line, or leave it empty:',
+    signButton: 'Sign on GitHub →',
+    step3: (
+      <>
+        Press <strong>Start discussion</strong> there. GitHub may ask you to
+        confirm you searched for similar discussions; just tick it and post, it
+        is a standard GitHub step. Done: your signature and your permanent card
+        appear within minutes, and the commit is credited to your GitHub
+        account.
+      </>
+    ),
+    noAccount: (
+      <>
+        No GitHub account? The button will offer to create one (free, 2
+        minutes). If you end up on your new account’s home page, just come back
+        and tap Sign on GitHub again.
+      </>
+    ),
+  },
+  es: {
+    linePrompt:
+      'qué cambió en tu búsqueda, o en qué quieres que se convierta la contratación',
+    cardAlt: 'Vista previa de la tarjeta de firma personal',
+    exampleBadge: 'Ejemplo',
+    generating: 'Generando tu tarjeta…',
+    previewInvite: 'Este es el Firmante n.º 1. Previsualiza la tuya (opcional):',
+    previewGeneric:
+      'Cada firma recibe una tarjeta y un enlace permanentes como este.',
+    usernamePlaceholder: 'tu usuario de GitHub',
+    usernameAria: 'Usuario de GitHub, solo para previsualizar tu tarjeta',
+    step1Label: 'Escribe tu línea, o déjala en blanco:',
+    signButton: 'Firmar en GitHub →',
+    step3: (
+      <>
+        Pulsa <strong>Start discussion</strong> ahí. GitHub puede pedirte que
+        confirmes que buscaste discusiones similares; solo márcalo y publica, es
+        un paso estándar de GitHub. Listo: tu firma y tu tarjeta permanente
+        aparecen en unos minutos, y el commit queda acreditado a tu cuenta de
+        GitHub.
+      </>
+    ),
+    noAccount: (
+      <>
+        ¿No tienes cuenta de GitHub? El botón te ofrecerá crear una (gratis, 2
+        minutos). Si acabas en la página de inicio de tu nueva cuenta, vuelve
+        aquí y pulsa Firmar en GitHub de nuevo.
+      </>
+    ),
+  },
+};
 
 // Sign-link strings live in src/lib/sign-link.ts (single frozen source,
 // shared with the certificate invitation state). Verified (warpchart,
@@ -43,7 +128,8 @@ function StepChip({ n }: { n: string }) {
   );
 }
 
-export function SignPreview() {
+export function SignPreview({ locale = 'en' }: { locale?: Locale }) {
+  const t = STRINGS[locale];
   const [username, setUsername] = useState('');
   const [line, setLine] = useState('');
   const [debounced, setDebounced] = useState({ u: '', q: '' });
@@ -54,12 +140,12 @@ export function SignPreview() {
   const validUser = USERNAME_RE.test(cleanUser);
 
   useEffect(() => {
-    const t = setTimeout(
+    const timer = setTimeout(
       () =>
         setDebounced({ u: validUser ? cleanUser : '', q: cleanLine(line) }),
       500,
     );
-    return () => clearTimeout(t);
+    return () => clearTimeout(timer);
   }, [cleanUser, validUser, line]);
 
   // src derives from the debounced pair — every username OR line change
@@ -90,7 +176,7 @@ export function SignPreview() {
           <img
             key={src}
             src={src}
-            alt="Preview of the personal signature card"
+            alt={t.cardAlt}
             width={1200}
             height={630}
             loading="lazy"
@@ -105,13 +191,13 @@ export function SignPreview() {
           />
           {isExample && !generating && (
             <span className="absolute right-3 top-3 rounded-full border border-white/20 bg-black/55 px-2.5 py-1 text-[11px] uppercase tracking-[0.15em] text-white/85">
-              Example
+              {t.exampleBadge}
             </span>
           )}
           {generating && (
             <span className="absolute inset-0 flex items-center justify-center">
               <span className="rounded-full bg-black/60 px-3.5 py-1.5 text-xs text-white/90">
-                Generating your card&hellip;
+                {t.generating}
               </span>
             </span>
           )}
@@ -120,16 +206,14 @@ export function SignPreview() {
       {!broken && (
         <div className="mt-3 flex flex-col sm:flex-row sm:items-center gap-2">
           <p aria-live="polite" className="text-sm text-fd-muted-foreground">
-            {isExample
-              ? 'This is Signatory #1. Preview yours (optional):'
-              : 'Every signature gets a permanent card and link like this one.'}
+            {isExample ? t.previewInvite : t.previewGeneric}
           </p>
           <input
             type="text"
             value={username}
             onChange={(e) => setUsername(e.target.value)}
-            placeholder="your GitHub username"
-            aria-label="GitHub username, only to preview your card"
+            placeholder={t.usernamePlaceholder}
+            aria-label={t.usernameAria}
             autoComplete="off"
             spellCheck={false}
             className="rounded-lg border border-fd-border bg-fd-secondary/40 px-3 py-1.5 text-sm text-fd-foreground placeholder:text-fd-muted-foreground focus:outline-none focus:ring-1 focus:ring-fd-foreground/30 sm:w-56"
@@ -143,12 +227,12 @@ export function SignPreview() {
           <StepChip n="1" />
           <div className="min-w-0 flex-1">
             <label className="flex flex-col gap-1.5 text-sm text-fd-foreground/90">
-              <span>Write your line, or leave it empty:</span>
+              <span>{t.step1Label}</span>
               <input
                 type="text"
                 value={line}
                 onChange={(e) => setLine(e.target.value)}
-                placeholder={LINE_PROMPT}
+                placeholder={t.linePrompt}
                 maxLength={140}
                 autoComplete="off"
                 className="rounded-lg border border-fd-border bg-fd-secondary/40 px-3 py-2 text-sm text-fd-foreground placeholder:text-fd-muted-foreground focus:outline-none focus:ring-1 focus:ring-fd-foreground/30"
@@ -169,26 +253,20 @@ export function SignPreview() {
               color: 'var(--color-fd-background)',
             }}
           >
-            Sign on GitHub →
+            {t.signButton}
           </a>
         </div>
 
         <div className="flex items-start gap-3">
           <StepChip n="3" />
           <p className="text-sm text-fd-foreground/90 leading-relaxed pt-0.5">
-            Press <strong>Start discussion</strong> there. GitHub may ask
-            you to confirm you searched for similar discussions; just tick
-            it and post, it is a standard GitHub step. Done: your signature
-            and your permanent card appear within minutes, and the commit
-            is credited to your GitHub account.
+            {t.step3}
           </p>
         </div>
       </div>
 
       <p className="mt-5 text-xs text-fd-muted-foreground leading-relaxed">
-        No GitHub account? The button will offer to create one (free, 2
-        minutes). If you end up on your new account&rsquo;s home page, just
-        come back and tap Sign on GitHub again.
+        {t.noAccount}
       </p>
     </div>
   );

--- a/src/lib/i18n-map.ts
+++ b/src/lib/i18n-map.ts
@@ -34,3 +34,16 @@ export function hreflangHome(): Record<string, string> {
     'x-default': `${ORIGIN}/`,
   };
 }
+
+/** The manifesto pair: EN at `/manifesto`, ES at `/es/manifesto`. Explicit
+ *  like the home because /manifesto is a standalone TSX article, not a
+ *  Fumadocs docs page. Same bidirectional + x-default → EN shape. */
+export const MANIFESTO_EN = '/manifesto';
+export const MANIFESTO_ES = '/es/manifesto';
+export function hreflangManifesto(): Record<string, string> {
+  return {
+    en: `${ORIGIN}/manifesto`,
+    es: `${ORIGIN}/es/manifesto`,
+    'x-default': `${ORIGIN}/manifesto`,
+  };
+}

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -5,7 +5,7 @@
 // `siteSchema()` runs in the root layout (every page). Per-page builders
 // (`aboutSchema()`, etc.) emit additional graphs scoped to that route.
 import { getProjectStats } from './stats';
-import { MANIFESTO, CAREEROPS_DEFINITION } from './shared';
+import { MANIFESTO, CAREEROPS_DEFINITION, CAREEROPS_DEFINITION_ES } from './shared';
 
 const PERSON_ID = 'https://santifer.io/#person';
 const ORGANIZATION_ID = 'https://career-ops.org/#organization';
@@ -666,6 +666,94 @@ export function manifestoSchema() {
             position: 2,
             name: 'Manifesto',
             item: 'https://career-ops.org/manifesto',
+          },
+        ],
+      },
+    ],
+  };
+}
+
+// /es/manifesto — Spanish twin of the manifesto graph. Same shape as
+// manifestoSchema() but inLanguage:'es', ES description/FAQ, and /es/manifesto
+// @ids. It does NOT redefine the CareerOps DefinedTerm: the coinage has ONE
+// canonical node (on the EN /manifesto), which this ES Article references via
+// `about` + `translationOfWork` — so the entity/coinage authority stays
+// single-sourced while the ES page carries its own localized FAQ + breadcrumb.
+// Copy is the frozen official translation (search-ops/venture-ops deliverable
+// manifiesto-es-2026-07-21); never reword ad-hoc.
+export function manifestoSchemaEs() {
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'Article',
+        '@id': 'https://career-ops.org/es/manifesto/#article',
+        url: 'https://career-ops.org/es/manifesto',
+        headline: 'El Manifiesto CareerOps',
+        description: CAREEROPS_DEFINITION_ES,
+        datePublished: '2026-07-14',
+        dateModified: '2026-07-14',
+        author: { '@id': PERSON_ID },
+        publisher: { '@id': ORGANIZATION_ID },
+        isPartOf: { '@id': 'https://career-ops.org/#website' },
+        // The ES article is a translation of the canonical EN manifesto —
+        // states that relationship explicitly for entity reconcilers.
+        translationOfWork: { '@id': 'https://career-ops.org/manifesto/#article' },
+        about: [
+          { '@id': 'https://career-ops.org/manifesto/#careerops' },
+          { '@id': 'https://career-ops.org/#software' },
+        ],
+        mainEntityOfPage: 'https://career-ops.org/es/manifesto',
+        inLanguage: 'es',
+        articleSection: 'Manifiesto',
+        image: {
+          '@type': 'ImageObject',
+          url: 'https://career-ops.org/og-manifesto.png',
+          width: 1200,
+          height: 630,
+        },
+      },
+      {
+        '@type': 'Person',
+        '@id': PERSON_ID,
+        name: 'Santiago Fernández de Valderrama Aparicio',
+        url: 'https://santifer.io/about',
+        sameAs: ['https://www.wikidata.org/wiki/Q138710224'],
+        identifier: WIKIDATA_PERSON_IDENTIFIER,
+      },
+      {
+        '@type': 'FAQPage',
+        '@id': 'https://career-ops.org/es/manifesto/#faq',
+        inLanguage: 'es',
+        mainEntity: [
+          {
+            '@type': 'Question',
+            name: '¿Qué es CareerOps?',
+            acceptedAnswer: {
+              '@type': 'Answer',
+              text: `${CAREEROPS_DEFINITION_ES} El término nombra la práctica, no un producto: tratar la búsqueda de empleo como un pipeline operado (captación, puntuación, adaptación, seguimiento) en lugar de un montón de solicitudes sueltas. La implementación de referencia es career-ops (en minúsculas, con guion), el centro de mando open source con licencia MIT que ejecuta todo el pipeline en local, en la máquina de quien busca empleo, a través del CLI de IA que ya use. La práctica es más grande que la herramienta: puedes practicar CareerOps con una hoja de cálculo y disciplina; career-ops solo automatiza la capa operativa.`,
+            },
+          },
+          {
+            '@type': 'Question',
+            name: '¿Quién acuñó el término CareerOps?',
+            acceptedAnswer: {
+              '@type': 'Answer',
+              text: 'CareerOps fue acuñado como nombre de la práctica por Santiago Fernández de Valderrama Aparicio (santifer), creador del proyecto open source career-ops, en El Manifiesto CareerOps (The CareerOps Manifesto), publicado el 14 de julio de 2026 en career-ops.org/es/manifesto y firmado en el repositorio del proyecto (MANIFESTO.md, release tag manifesto-v1.0). El nombre sigue el patrón de DevOps y MLOps: una disciplina -Ops que convierte una actividad improvisada en una práctica operada e instrumentada. El compuesto había aparecido antes en nombres de producto sueltos, como pasa con los compuestos -Ops; el manifiesto es la primera definición de CareerOps como práctica. Desarrolló la práctica durante su propia búsqueda de empleo de 2026 (740 vacantes evaluadas, 68 solicitudes, 12 procesos de entrevista, 1 oferta firmada) antes de nombrarla y abrirla a firmas de la comunidad.',
+            },
+          },
+        ],
+      },
+      {
+        '@type': 'BreadcrumbList',
+        '@id': 'https://career-ops.org/es/manifesto/#breadcrumbs',
+        itemListElement: [
+          { '@type': 'ListItem', position: 1, name: 'Inicio', item: 'https://career-ops.org/es' },
+          {
+            '@type': 'ListItem',
+            position: 2,
+            name: 'Manifiesto',
+            item: 'https://career-ops.org/es/manifesto',
           },
         ],
       },

--- a/src/lib/shared.ts
+++ b/src/lib/shared.ts
@@ -33,6 +33,18 @@ export const MANIFESTO =
 export const CAREEROPS_DEFINITION =
   "CareerOps is the practice of running a job search the way engineers run production: with evidence, with discipline, and with tools on the candidate's side of the table.";
 
+// Official Spanish definition — the ONE canonical string for every ES
+// surface (manifesto lead + FAQ + description). Ratified by search-ops +
+// venture-ops (deliverable manifiesto-es-2026-07-21). Same discipline as
+// the EN definition: it is a frozen, signed-document translation, never
+// reworded ad-hoc — it changes only if the canonical EN changes or
+// venture-ops/search-ops ratify a new version. Note the deliberate
+// register split venture-ops logged: the definition uses the third-person
+// "del lado del candidato" while the manifesto body (signer voice) says
+// "de nuestro lado de la mesa" — that divergence is CORRECT, do not unify.
+export const CAREEROPS_DEFINITION_ES =
+  'CareerOps es la práctica de operar la búsqueda de empleo como los ingenieros operan producción: con evidencia, con disciplina y con herramientas que están del lado del candidato.';
+
 // Canonical Identity block for llms.txt AND llms-full.txt — single
 // source so the two files can never diverge again (the gap search-ops
 // found in D-003). Text EXACT per verdict D-003 (Santiago's call,
@@ -50,6 +62,12 @@ export const CANONICAL_IDENTITY =
 // Wikidata).
 export const MANIFESTO_SIGNATURE =
   'Santiago Fernández de Valderrama Aparicio (santifer), creator of career-ops. July 14, 2026';
+
+// Spanish rendering of the signature line for /es/manifesto. Same frozen
+// discipline; the name + handle are non-translatables, only the role and
+// date localize (deliverable manifiesto-es-2026-07-21).
+export const MANIFESTO_SIGNATURE_ES =
+  'Santiago Fernández de Valderrama Aparicio (santifer), creador de career-ops. 14 de julio de 2026';
 
 // Last-known-good floors for live project stats. getProjectStats() never
 // returns a value below these, so a transient unauthenticated-GitHub-API


### PR DESCRIPTION
The official Spanish translation of the signed **CareerOps Manifesto** — per the search-ops/venture-ops deliverable `manifiesto-es-2026-07-21` (ratified, venture-ops final GO 21-jul).

## Shape decision
A **self-contained twin** of `/manifesto`, not a trunk+dict like the home. A signed document has one authoritative version *per language* that does not track EN word-drift — so a parallel page is the correct architecture. `localized: false` = full fidelity, not the home's fan-out framing. Everything runtime (signatures, schema, signing widget) is shared with the EN page.

## Deliverable rules honored
1. **Body is all Spanish** — the thesis *"Nosotros dimos IA a los candidatos para elegir empresas"* runs directly, **without** the English literal above it (venture-ops rule for this page; the EN-above/ES-below pattern stays home-only). hreflang links the two versions.
2. Route **`/es/manifesto`** — root layout, no nav (same clean article as EN); bidirectional `en`/`es`/`x-default`→EN hreflang; sitemap entry on both sides.
3. **Signatures render from the same `SIGNATURES.md`** (data, never translated); retention policy mirrors the canonical header in Spanish.
4. **`CAREEROPS_DEFINITION_ES`** added to `shared.ts` as the single canonical ES string for every ES surface. Register split preserved on purpose: *del lado del candidato* (definition, 3rd person) vs *de nuestro lado de la mesa* (body, signer voice) — venture-ops note.
5. **`manifestoSchemaEs()`** — Article `inLanguage:es` + `translationOfWork`→EN, FAQPage ES (two questions), BreadcrumbList ES; references the canonical CareerOps `DefinedTerm` by `@id` so the coinage stays single-sourced on the EN page.
6. Drift: `localized:false` / full fidelity — ES changes only when the canonical EN changes or venture-ops/search-ops ratify.

## Also
- **`SignPreview` is now locale-aware** (`STRINGS[locale]`): EN copy preserved byte-for-byte, ES added — the signing widget isn't a wall of English on the ES page. Multi-language ready.
- Reciprocal user-facing language link on both pages (no nav bar → this is the human path across the pair).

## Verification
- `npm run build` ✓ · `types:check` ✓
- **EN URL set unchanged (51/51).**
- `/es/manifesto` + `/manifesto` both carry es/en/x-default hreflang in the sitemap.

/cc search-ops for the prod hreflang + copy audit once merged (URL pair: `career-ops.org/manifesto` ↔ `career-ops.org/es/manifesto`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)