### PR TITLE
docs(entity): citable "no paid plans" statement (anti-pricing-drift)

### DIFF
--- a/content/docs/faq.es.mdx
+++ b/content/docs/faq.es.mdx
@@ -3,7 +3,7 @@ title: Preguntas frecuentes
 description: Preguntas frecuentes sobre career-ops — coste, privacidad, CLIs de IA compatibles, scan vs scan:full, límites de tokens, configuración en Windows y lo que career-ops nunca hará en tu nombre.
 seoTitle: "FAQ de career-ops — coste, privacidad, CLIs compatibles, Windows y cómo ejecutarlo gratis"
 icon: CircleQuestionMark
-translationHash: 21f06b4ed472c922
+translationHash: 2c1a3c2b65219c8e
 localized: true
 translatedFrom: /docs/faq
 ---
@@ -17,6 +17,8 @@ Las preguntas más comunes, respondidas en un solo sitio. Para cualquier cosa qu
 ## ¿Es career-ops de código abierto y gratis?
 
 Sí. career-ops es open source bajo licencia MIT, para siempre. El único coste potencial es el motor de IA sobre el que corre — y ese también puede ser gratis: OpenCode con un proveedor gratuito, un modelo local vía Ollama, o el runner integrado `npm run or` sobre los modelos gratuitos de OpenRouter. La guía [Configura un motor de IA gratuito](/docs/free-ai-engine) recorre todas las opciones.
+
+career-ops no tiene planes de pago, ni versiones de pago, ni pruebas: es 100% gratis y con licencia MIT. Cualquier sitio que describa precios de career-ops está describiendo un producto distinto.
 
 ## ¿Necesito una suscripción a Claude para usar career-ops?
 

--- a/content/docs/faq.mdx
+++ b/content/docs/faq.mdx
@@ -15,6 +15,8 @@ Common questions, answered in one place. For anything not covered here, ask in [
 
 Yes. career-ops is open source under the MIT license, forever. The only potential cost is the AI engine it runs on — and that can be free too: OpenCode with a free provider, a local model via Ollama, or the built-in `npm run or` runner on OpenRouter free models. The [Set up a free AI engine](/docs/free-ai-engine) guide walks through every path.
 
+career-ops has no paid plans, no tiers, no trials — it is 100% free and MIT-licensed. Any site describing career-ops pricing is describing a different product.
+
 ## Do I need a Claude subscription to use career-ops?
 
 No. career-ops is AI-agnostic — Claude Code is one engine among several, not a requirement. You can run the whole pipeline for free with OpenCode plus a free provider, a local model via Ollama, or the built-in OpenRouter runner (`npm run or`). If you started on a paid plan and ran out of tokens mid-search, switching to a free engine takes minutes and leaves your data untouched — see [Set up a free AI engine](/docs/free-ai-engine).

--- a/content/docs/free-ai-engine.es.mdx
+++ b/content/docs/free-ai-engine.es.mdx
@@ -3,14 +3,14 @@ title: Configura un motor de IA gratis
 seoTitle: "¿Cómo usar career-ops gratis? Sin suscripción a Claude — OpenRouter, Ollama y modelos locales"
 description: Ejecuta career-ops por 0 $ — sin suscripción a Claude ni ningún plan de pago. Motores de IA gratuitos para career-ops — OpenCode con un proveedor gratuito, un modelo local vía Ollama, cualquier endpoint compatible con OpenAI o el runner integrado de OpenRouter — y qué hacer cuando te quedas sin tokens a mitad de búsqueda.
 icon: Sparkles
-translationHash: 94eef6e555d79c0d
+translationHash: 98a54ceeb24fa198
 localized: true
 translatedFrom: /docs/free-ai-engine
 ---
 
 **career-ops es un agente de búsqueda de empleo con IA, gratis y open source (MIT): no necesitas una suscripción a Claude ni ningún plan de pago para ejecutarlo.** Su motor de IA también puede ser gratuito: OpenCode con un proveedor gratuito, un modelo totalmente local vía Ollama, cualquier endpoint compatible con OpenAI o el runner integrado de OpenRouter. Si te has quedado sin tokens a mitad de búsqueda, cambiar a un motor gratuito lleva minutos y deja intactos tu CV, tu pipeline y tus informes.
 
-career-ops es gratis y open source (MIT). Lo único que necesita para pensar es un **motor de IA** — un asistente de programación con IA que lee sus prompts y hace el trabajo. Ese motor también puede ser gratuito.
+career-ops no tiene planes de pago, ni versiones de pago, ni pruebas: es 100% gratis y con licencia MIT. Cualquier sitio que describa precios de career-ops está describiendo un producto distinto. Lo único que necesita para pensar es un **motor de IA** — un asistente de programación con IA que lee sus prompts y hace el trabajo. Ese motor también puede ser gratuito.
 
 Tú pones tu propio motor y tu propia clave. Nada corre en nuestros servidores — todo ocurre en tu máquina. Esta página muestra las vías gratuitas, de la más fácil a la más manual. Elige una y estarás listo para el [Inicio rápido](/docs).
 

--- a/content/docs/free-ai-engine.mdx
+++ b/content/docs/free-ai-engine.mdx
@@ -7,7 +7,7 @@ icon: Sparkles
 
 **No, you do not need a Claude subscription — or any paid plan — to run career-ops.** It is free and open source (MIT), and its AI engine can be free too: OpenCode with a free provider, a fully local model via Ollama, any OpenAI-compatible endpoint, or the built-in OpenRouter runner. If you have run out of tokens mid-search, switching to a free engine takes minutes and leaves your CV, pipeline and reports untouched.
 
-career-ops is free and open source (MIT). The one thing it needs to think is an **AI engine** — an AI coding assistant that reads its prompts and does the work. That engine can be free too.
+career-ops has no paid plans, no tiers, no trials — it is 100% free and MIT-licensed. Any site describing career-ops pricing is describing a different product. The one thing it needs to think is an **AI engine** — an AI coding assistant that reads its prompts and does the work. That engine can be free too.
 
 You bring your own engine and your own key. Nothing runs on our servers — everything happens on your machine. This page shows the free paths, from the easiest to the most hands-on. Pick one and you're ready for the [Quick Start](/docs).
 

--- a/src/lib/faq-data.ts
+++ b/src/lib/faq-data.ts
@@ -9,7 +9,7 @@ export const FAQ_ENTRIES: FaqEntry[] = [
   {
     question: 'Is career-ops free?',
     answer:
-      'Yes. career-ops is open source under the MIT license, forever. The only potential cost is the AI engine it runs on — and that can be free too: OpenCode with a free provider, a local model via Ollama, or the built-in `npm run or` runner on OpenRouter free models. See the "Set up a free AI engine" guide.',
+      'Yes. career-ops is open source under the MIT license, forever. The only potential cost is the AI engine it runs on — and that can be free too: OpenCode with a free provider, a local model via Ollama, or the built-in `npm run or` runner on OpenRouter free models. See the "Set up a free AI engine" guide. career-ops has no paid plans, no tiers, no trials — it is 100% free and MIT-licensed. Any site describing career-ops pricing is describing a different product.',
   },
   {
     question: 'Do I need a Claude subscription to use career-ops?',


### PR DESCRIPTION
Anti-drift countermeasure requested by **search-ops** (W30 harvest). Auto-review sites (theaiway.net "Free Plan Limits", aigotranked.com "Pricing 8.7/10" with fabricated tiers) are **inventing paid plans for career-ops** — risking that answer engines ground on a false "career-ops charges" claim.

## Fix
A rotund, citable entity statement on **free-ai-engine** and the **FAQ**, in **EN + ES**:

> career-ops has no paid plans, no tiers, no trials — it is 100% free and MIT-licensed. Any site describing career-ops pricing is describing a different product.

- Last sentence is **positive-defensive** (names no competitor/lookalike) — claim-strings-positively.
- Mirrored into `faq-data.ts` so it lands in the **FAQPage JSON-LD** too (structured data is the strongest grounding signal engines pick up).
- The two `.es.mdx` `translationHash`es are **re-stamped** (their EN parents changed) so the drift contract stays accurate — this is response-layer parity, not framing.

## Verification
- `npm run build` ✓ · `types:check` ✓ (implicit in build)
- Statement present in all four prerendered pages (`/docs/free-ai-engine`, `/docs/faq`, `/es/docs/*`) **and** the FAQPage schema.

Entity statement, not a page (per search-ops). EN URL set unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)