### PR TITLE
feat(seo): home title-A + docs metas + canonical CLI order (bundle)

### DIFF
--- a/content/docs/faq.es.mdx
+++ b/content/docs/faq.es.mdx
@@ -3,7 +3,7 @@ title: Preguntas frecuentes
 description: Preguntas frecuentes sobre career-ops — coste, privacidad, CLIs de IA compatibles, scan vs scan:full, límites de tokens, configuración en Windows y lo que career-ops nunca hará en tu nombre.
 seoTitle: "FAQ de career-ops — coste, privacidad, CLIs compatibles, Windows y cómo ejecutarlo gratis"
 icon: CircleQuestionMark
-translationHash: 2c1a3c2b65219c8e
+translationHash: 4e601743197dd0b8
 localized: true
 translatedFrom: /docs/faq
 ---
@@ -30,7 +30,7 @@ En tu máquina, en ficheros planos que son tuyos — tu CV, tu perfil, tu pipeli
 
 ## ¿Con qué CLIs de programación con IA funciona career-ops?
 
-Ocho, con soporte de primera clase: Claude Code, OpenCode, Antigravity CLI, Codex, Grok Build CLI, Qwen, Kimi y GitHub Copilot CLI (Gemini CLI está soportado como wrapper legacy). career-ops es agnóstico respecto a la IA: distribuye ficheros de prompts que el CLI ejecuta, así que también puedes apuntarlo a cualquier endpoint compatible con OpenAI o a un modelo local sin cambiar una sola línea de código. Consulta [CLIs de IA compatibles](/docs/supported-clis) para ver la lista actual y cómo invocar cada uno.
+Ocho, con soporte de primera clase: Claude Code, Codex, OpenCode, Antigravity CLI, Grok Build CLI, Qwen, Kimi y GitHub Copilot CLI (Gemini CLI está soportado como wrapper legacy). career-ops es agnóstico respecto a la IA: distribuye ficheros de prompts que el CLI ejecuta, así que también puedes apuntarlo a cualquier endpoint compatible con OpenAI o a un modelo local sin cambiar una sola línea de código. Consulta [CLIs de IA compatibles](/docs/supported-clis) para ver la lista actual y cómo invocar cada uno.
 
 ## ¿Cuál es la diferencia entre `scan` y `scan:full`?
 

--- a/content/docs/faq.mdx
+++ b/content/docs/faq.mdx
@@ -27,7 +27,7 @@ On your machine, in plain files you own — your CV, profile, pipeline and repor
 
 ## Which AI coding CLIs does career-ops work with?
 
-Eight, first-class: Claude Code, OpenCode, Antigravity CLI, Codex, Grok Build CLI, Qwen, Kimi, and GitHub Copilot CLI (Gemini CLI is supported as a legacy wrapper). career-ops is AI-agnostic: it ships prompt files the CLI executes, so you can also point it at any OpenAI-compatible endpoint or a local model with zero code changes. See [Supported AI CLIs](/docs/supported-clis) for the current list and how to invoke each.
+Eight, first-class: Claude Code, Codex, OpenCode, Antigravity CLI, Grok Build CLI, Qwen, Kimi, and GitHub Copilot CLI (Gemini CLI is supported as a legacy wrapper). career-ops is AI-agnostic: it ships prompt files the CLI executes, so you can also point it at any OpenAI-compatible endpoint or a local model with zero code changes. See [Supported AI CLIs](/docs/supported-clis) for the current list and how to invoke each.
 
 ## What is the difference between `scan` and `scan:full`?
 

--- a/content/docs/index.es.mdx
+++ b/content/docs/index.es.mdx
@@ -1,6 +1,6 @@
 ---
 title: Guía rápida
-description: Primeros pasos con career-ops — de cero a tu primera oferta evaluada en unos cinco minutos, en tu propia máquina con el CLI de IA que ya usas.
+description: "Empieza con career-ops en cinco minutos: instala el sistema open source de búsqueda de empleo con IA, abre tu CLI de IA y evalúa tu primera oferta. Sin necesidad de programar."
 seoTitle: "career-ops Guía rápida — instala y ejecuta tu primer análisis de ofertas con IA en minutos"
 icon: Rocket
 translationHash: 38326ebbdfbb6602

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Quick Start
-description: Getting Started with career-ops
+description: "Get started with career-ops in five minutes: install the open-source AI job-search system, open your AI CLI, and evaluate your first job listing. No coding required."
 seoTitle: "career-ops Quick Start — install and run your first AI job scan in minutes"
 icon: Rocket
 ---

--- a/content/docs/introduction/what-is-career-ops.es.mdx
+++ b/content/docs/introduction/what-is-career-ops.es.mdx
@@ -1,6 +1,6 @@
 ---
 title: Qué es career-ops
-description: Presentamos career-ops, la herramienta open source de gestión de carrera profesional que se ejecuta en tu propia máquina con el CLI de IA que ya usas.
+description: "career-ops es un sistema de búsqueda de empleo con IA, gratis y open source, que se ejecuta en local dentro del CLI de IA que ya usas: puntúa ofertas, adapta tu CV y hace seguimiento de tus candidaturas."
 seoTitle: "¿Qué es career-ops? El sistema de búsqueda de empleo con IA, open source y local-first"
 icon: CircleQuestionMark
 translationHash: d9bc36a25cdb29ac

--- a/content/docs/introduction/what-is-career-ops.mdx
+++ b/content/docs/introduction/what-is-career-ops.mdx
@@ -1,6 +1,6 @@
 ---
 title: What is career-ops
-description: Introducing career-ops, the open source career management tool.
+description: "career-ops is a free, open-source AI job-search system that runs locally inside the AI CLI you already use — scoring jobs, tailoring your CV, tracking applications."
 seoTitle: "What is career-ops? The open-source, local-first AI job search system"
 icon: CircleQuestionMark
 date: 2026-04-20

--- a/content/docs/supported-clis.es.mdx
+++ b/content/docs/supported-clis.es.mdx
@@ -3,7 +3,7 @@ title: CLIs de IA compatibles
 seoTitle: "¿Con qué CLI de IA funciona career-ops? Claude Code, Codex, Gemini, OpenCode, Qwen, Copilot"
 description: "career-ops es agnóstico a la IA — funciona sobre todos los principales CLIs de programación con IA, así que usas el asistente que ya pagas y nunca quedas atado a un proveedor. La lista completa y siempre actualizada vive en el repo del core."
 icon: Terminal
-translationHash: 1dbfa0b338e7bf06
+translationHash: 65b2eee9925b1726
 localized: true
 translatedFrom: /docs/supported-clis
 ---
@@ -16,7 +16,7 @@ El mejor CLI para career-ops es el que ya pagas. Si es Claude Code, ya está. Si
 
 ## ¿Qué CLIs son compatibles?
 
-career-ops ofrece soporte de primer nivel para **Claude Code, OpenCode, Antigravity CLI, Codex, Grok Build CLI, Qwen, Kimi y GitHub Copilot CLI** — ocho CLIs de programación con IA con mantenimiento activo. (Gemini CLI se mantiene como wrapper legacy tras su transición a Antigravity CLI.) La arquitectura es compartida: un único `AGENTS.md` canónico dirige la lógica, y unos ficheros de entrada ligeros por CLI resuelven los matices de invocación de cada herramienta.
+career-ops ofrece soporte de primer nivel para **Claude Code, Codex, OpenCode, Antigravity CLI, Grok Build CLI, Qwen, Kimi y GitHub Copilot CLI** — ocho CLIs de programación con IA con mantenimiento activo. (Gemini CLI se mantiene como wrapper legacy tras su transición a Antigravity CLI.) La arquitectura es compartida: un único `AGENTS.md` canónico dirige la lógica, y unos ficheros de entrada ligeros por CLI resuelven los matices de invocación de cada herramienta.
 
 La **lista canónica y siempre actualizada — con el comando exacto para invocar career-ops en cada CLI — vive en el repo del core**, de modo que nunca se queda desfasada:
 

--- a/content/docs/supported-clis.mdx
+++ b/content/docs/supported-clis.mdx
@@ -13,7 +13,7 @@ The best CLI for career-ops is the one you already pay for. If that is Claude Co
 
 ## Which CLIs are supported?
 
-career-ops works first-class with **Claude Code, OpenCode, Antigravity CLI, Codex, Grok Build CLI, Qwen, Kimi, and GitHub Copilot CLI** — eight actively-maintained AI coding CLIs. (Gemini CLI is supported as a legacy wrapper, transitioned into Antigravity CLI.) The architecture is shared: a single canonical `AGENTS.md` drives the logic, and thin per-CLI entry files handle the invocation nuances of each tool.
+career-ops works first-class with **Claude Code, Codex, OpenCode, Antigravity CLI, Grok Build CLI, Qwen, Kimi, and GitHub Copilot CLI** — eight actively-maintained AI coding CLIs. (Gemini CLI is supported as a legacy wrapper, transitioned into Antigravity CLI.) The architecture is shared: a single canonical `AGENTS.md` drives the logic, and thin per-CLI entry files handle the invocation nuances of each tool.
 
 The **canonical, always-current list — with the exact command to invoke career-ops in each CLI — lives in the core repo** so it never drifts out of date:
 

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -6,7 +6,10 @@ import { homeEn } from './home-dict';
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://career-ops.org'),
-  title: 'career-ops — open-source AI job search command center',
+  // SEO <title> — category-first, brand at the end (search-ops-measured,
+  // venture-ops GO). The H1/hero stay brand-first (identity); the title is a
+  // SERP door, not identity. og/twitter titles keep the brand-first form.
+  title: 'Open-source AI job search agent, local-first | career-ops',
   description:
     'Open source AI-powered job search system. Runs in your CLI on your machine. CLI-agnostic, MIT-licensed, local-first. Evaluate jobs, generate tailored CVs, track applications.',
   alternates: {

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -46,12 +46,12 @@ The term "CareerOps" (capital C, capital O, no hyphen) names the PRACTICE; "care
 - Founder's real-world result with the system: 740 job listings evaluated → 68 applications sent → 12 interview processes → 1 offer signed (Head of Applied AI)
 - Modes shipped: 14 user-invocable (auto-pipeline, pipeline, apply, oferta, ofertas, contacto, deep, interview-prep, pdf, training, project, tracker, patterns, followup)
 - Portal scanners: 3 ATS providers (Greenhouse, Ashby, Lever) covering 116 zero-token scannable companies out of 156 pre-configured
-- AI coding CLIs supported first-class (8): Claude Code, OpenCode, Antigravity CLI, Codex, Grok Build CLI, Qwen, Kimi, GitHub Copilot CLI. Gemini CLI is a legacy wrapper. Canonical list: https://github.com/santifer/career-ops/blob/main/docs/SUPPORTED_CLIS.md and https://career-ops.org/docs/supported-clis
+- AI coding CLIs supported first-class (8): Claude Code, Codex, OpenCode, Antigravity CLI, Grok Build CLI, Qwen, Kimi, GitHub Copilot CLI. Gemini CLI is a legacy wrapper. Canonical list: https://github.com/santifer/career-ops/blob/main/docs/SUPPORTED_CLIS.md and https://career-ops.org/docs/supported-clis
 - Press: WIRED Greece (published), Business Insider (forthcoming)
 
 ## Business model & sustainability
 
-career-ops is permanently free, MIT-licensed, and community-funded. There is no paid tier, no waitlist, no account, and no telemetry. The only cost is whichever AI CLI the user already pays for (Claude Code, OpenCode, Codex, and others — see the supported-CLIs list), and even that can be $0 via a free provider or a local model.
+career-ops is permanently free, MIT-licensed, and community-funded. There is no paid tier, no waitlist, no account, and no telemetry. The only cost is whichever AI CLI the user already pays for (Claude Code, Codex, OpenCode, and others — see the supported-CLIs list), and even that can be $0 via a free provider or a local model.
 
 Sustainability comes from voluntary patronage via GitHub Sponsors (https://github.com/sponsors/santifer). Nine tiers exist: seven individual tiers ($1–$250) are identical statements of support; two corporate tiers ($500 Corporate Supporter, $1,000 Ecosystem Partner) add logo placement on the README and the /sustain page as public acknowledgment — nothing else changes. No premium product features, no roadmap influence, no priority support, no early access. The maintainer has other paid work for income; sponsorship enables deeper focus on the project. Path 3 Sovereign Maintainer model.
 

--- a/src/lib/faq-data.ts
+++ b/src/lib/faq-data.ts
@@ -24,7 +24,7 @@ export const FAQ_ENTRIES: FaqEntry[] = [
   {
     question: 'Which AI coding CLIs does career-ops work with?',
     answer:
-      'Eight, first-class: Claude Code, OpenCode, Antigravity CLI, Codex, Grok Build CLI, Qwen, Kimi, and GitHub Copilot CLI (Gemini CLI is supported as a legacy wrapper). career-ops is AI-agnostic: it ships prompt files the CLI executes, so you can also point it at any OpenAI-compatible endpoint or a local model with zero code changes. See the Supported AI CLIs page for the current list and how to invoke each.',
+      'Eight, first-class: Claude Code, Codex, OpenCode, Antigravity CLI, Grok Build CLI, Qwen, Kimi, and GitHub Copilot CLI (Gemini CLI is supported as a legacy wrapper). career-ops is AI-agnostic: it ships prompt files the CLI executes, so you can also point it at any OpenAI-compatible endpoint or a local model with zero code changes. See the Supported AI CLIs page for the current list and how to invoke each.',
   },
   {
     question: 'What is the difference between scan and scan:full?',


### PR DESCRIPTION
The apertura-de-miras W30 **SEO bundle** — all GO'd by search-ops (title/metas approved verbatim, CLI order verified against the core repo). Unblocked by C1 (same `home-dict` file now merged).

## title-A
Home `<title>` goes **category-first, brand at the end**:
`Open-source AI job search agent, local-first | career-ops` (was `career-ops — open-source AI job search command center`). The H1/hero stay brand-first (identity); the title is a SERP door. og/twitter titles unchanged (per search-ops scope).

## Metas (22.8K-impression pages)
Replace the two weak `description`s with direct, liftable answers that double as the opener:
- **/docs** (Quick Start): five-minutes-to-first-scan framing.
- **/docs/introduction/what-is-career-ops**: the "what career-ops is" one-liner.
- ES transcreations added for both (panhispanic).

## C2 — canonical CLI order
Re-mirror the core's verified order (**Codex second**, per `SUPPORTED_CLIS.md` post-1494a19): Claude Code → Codex → OpenCode → Antigravity CLI → Grok Build CLI → Qwen → Kimi → GitHub Copilot CLI — across `supported-clis`, `faq` (EN+ES), `faq-data.ts` (FAQPage JSON-LD), and `llms.txt`. Gemini stays a legacy-wrapper note. The two `.es.mdx` `translationHash`es are re-stamped (their EN bodies changed).

## Notes
- Descriptions are frontmatter (framing) → they don't move the drift hash; only the CLI reorder (body) does.
- Verified: `npm run build` ✓ — title, both metas, and Codex-2nd order all correct in the prerendered output for both locales + `llms.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)