### PR TITLE
feat(i18n): French pilot — /fr home + docs (third locale)

### DIFF
--- a/.i18n/hash.mjs
+++ b/.i18n/hash.mjs
@@ -31,6 +31,7 @@
 
 import { readFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
 
 /** Strip the leading YAML frontmatter block, if present. */
 function stripFrontmatter(raw) {
@@ -78,8 +79,11 @@ export function contentHash(raw) {
   return createHash('sha256').update(body, 'utf8').digest('hex').slice(0, 16);
 }
 
-// CLI entry point.
-const file = process.argv[2];
-if (file) {
-  process.stdout.write(contentHash(readFileSync(file, 'utf8')) + '\n');
+// CLI entry point — only when run directly (`node .i18n/hash.mjs <file>`), never
+// on import. Without this guard, importing contentHash (e.g. from translate.mjs)
+// would run this block against the importer's argv and read a stray arg as a
+// file (a --lang flag crashed it, 2026-07-21).
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const file = process.argv[2];
+  if (file) process.stdout.write(contentHash(readFileSync(file, 'utf8')) + '\n');
 }

--- a/.i18n/translate.mjs
+++ b/.i18n/translate.mjs
@@ -6,7 +6,8 @@
 // canonical non-translatables, and stamps the drift-tracking translationHash.
 //
 // Usage:
-//   node .i18n/translate.mjs content/docs/reference/modes/pdf.mdx [more.mdx ...]
+//   node .i18n/translate.mjs [--lang es|fr] content/docs/reference/modes/pdf.mdx [more.mdx ...]
+//   (--lang defaults to es for back-compat; the output suffix follows the lang)
 //
 // It calls `claude -p` once per file (a headless one-shot), captures the
 // translated file on stdout, injects the i18n frontmatter contract fields, and
@@ -20,6 +21,21 @@ import { contentHash } from './hash.mjs';
 
 const GLOSSARY = readFileSync(new URL('./nontranslatables.yml', import.meta.url), 'utf8');
 
+// Target languages. `name` is injected into the prompt; `suffix` names the
+// output file (page.<suffix>.mdx). ES is neutral-panhispanic per search-ops
+// doctrine (2026-07-21): avoid strong Iberian-only tells. Add a language here
+// + its defineI18n entry + its /<suffix> route group to grow to N languages.
+const LANGS = {
+  es: {
+    suffix: 'es',
+    name: 'natural, neutral panhispanic Spanish (Spanish understood across Spain and Latin America). Avoid strong Iberian-only tells: write "archivo" not "fichero", "equipo" or "máquina" not "ordenador"; address the reader as "tú" (never vosotros or usted)',
+  },
+  fr: {
+    suffix: 'fr',
+    name: 'natural French (France), addressing the reader as "vous"',
+  },
+};
+
 /** content/docs/<rel>.mdx  ->  /docs/<rel>  (index -> parent, so /docs). */
 function docsUrl(path) {
   let rel = path.replace(/^.*content\/docs\//, '').replace(/\.mdx$/, '');
@@ -27,11 +43,11 @@ function docsUrl(path) {
   return '/docs' + (rel ? '/' + rel : '');
 }
 
-function buildPrompt(en) {
-  return `You are translating one page of the career-ops documentation from English into natural Spanish (Spain). Output ONLY the translated .mdx file — start directly with the frontmatter \`---\` line, no preamble, no commentary, and do NOT wrap the whole file in a code fence.
+function buildPrompt(en, langName) {
+  return `You are translating one page of the career-ops documentation from English into ${langName}. Output ONLY the translated .mdx file — start directly with the frontmatter \`---\` line, no preamble, no commentary, and do NOT wrap the whole file in a code fence.
 
 RULES
-1. Translate into fluent, natural Spanish of Spain. Translate the prose, the headings, and the frontmatter fields \`title\`, \`description\` and \`seoTitle\`. Keep every other frontmatter key (icon, date, etc.) exactly as-is.
+1. Translate into fluent, ${langName}. Translate the prose, the headings, and the frontmatter fields \`title\`, \`description\` and \`seoTitle\`. Keep every other frontmatter key (icon, date, etc.) exactly as-is.
 2. PRESERVE EXACTLY — never translate: fenced code blocks and their contents, inline \`code\`, shell commands, file names and paths (cv.md, DATA_CONTRACT.md, reports/, output/, config/profile.yml, data/applications.md, AGENTS.md, package names, npm/npx commands), and all URLs. In markdown links translate the visible text but keep the URL. In MDX component tags (<Tabs>, <Tab>, <Callout>, <Steps>, <Step>, <Accordions>, <Accordion>, <details>, <summary>, raw <div>…) keep the tag names and the identifier attributes (value="…", items order) unchanged; you MAY translate human-visible attribute text such as title="…". Keep heading levels and the overall MDX structure identical.
 3. NON-TRANSLATABLES — keep verbatim (this list is authoritative):
 ${GLOSSARY}
@@ -59,11 +75,25 @@ function stampFrontmatter(es, enPath, enRaw) {
   return es.replace(m[0], `---\n${fm}\n${contract}\n---`);
 }
 
-for (const enPath of process.argv.slice(2)) {
-  const esPath = enPath.replace(/\.mdx$/, '.es.mdx');
+// --lang <code> (default es); everything else is a file path.
+const args = process.argv.slice(2);
+let lang = 'es';
+const files = [];
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--lang') lang = args[++i];
+  else files.push(args[i]);
+}
+const spec = LANGS[lang];
+if (!spec) {
+  console.error(`unknown --lang ${lang} (known: ${Object.keys(LANGS).join(', ')})`);
+  process.exit(1);
+}
+
+for (const enPath of files) {
+  const outPath = enPath.replace(/\.mdx$/, `.${spec.suffix}.mdx`);
   const enRaw = readFileSync(enPath, 'utf8');
-  process.stdout.write(`→ ${enPath} … `);
-  const res = spawnSync('claude', ['-p', buildPrompt(enRaw)], {
+  process.stdout.write(`→ [${lang}] ${enPath} … `);
+  const res = spawnSync('claude', ['-p', buildPrompt(enRaw, spec.name)], {
     encoding: 'utf8',
     maxBuffer: 20 * 1024 * 1024,
     timeout: 300000,
@@ -73,9 +103,9 @@ for (const enPath of process.argv.slice(2)) {
     continue;
   }
   try {
-    const es = stampFrontmatter(res.stdout, enPath, enRaw);
-    writeFileSync(esPath, es);
-    console.log(`ok → ${esPath}`);
+    const out = stampFrontmatter(res.stdout, enPath, enRaw);
+    writeFileSync(outPath, out);
+    console.log(`ok → ${outPath}`);
   } catch (e) {
     console.log(`POST-FAIL ${e.message}`);
   }

--- a/content/docs/faq.fr.mdx
+++ b/content/docs/faq.fr.mdx
@@ -1,0 +1,57 @@
+---
+title: FAQ
+description: Questions fréquentes sur career-ops — coût, confidentialité, CLI d'IA pris en charge, scan vs scan:full, limites de tokens, installation sous Windows, et ce que career-ops ne fera jamais à votre place.
+seoTitle: "FAQ career-ops — coût, confidentialité, CLI pris en charge, Windows et utilisation gratuite"
+icon: CircleQuestionMark
+translationHash: 4e601743197dd0b8
+localized: true
+translatedFrom: /docs/faq
+---
+
+{/* Mirrored with src/lib/faq-data.ts (FAQPage JSON-LD) — edit both together.
+    Answers are verified against the core repo's docs/FAQ.md; the core file
+    is the source of truth for technical behavior. */}
+
+Les questions les plus courantes, réunies en un seul endroit. Pour tout ce qui n'est pas couvert ici, posez votre question sur [Discord](https://discord.gg/8pRpHETxa4) ou ouvrez une [GitHub Discussion](https://github.com/santifer/career-ops/discussions).
+
+## career-ops est-il vraiment gratuit et open source ?
+
+Oui. career-ops est open source sous licence MIT, pour toujours. Le seul coût potentiel est le moteur d'IA sur lequel il s'exécute — et celui-ci peut aussi être gratuit : OpenCode avec un fournisseur gratuit, un modèle local via Ollama, ou le runner intégré `npm run or` sur les modèles gratuits d'OpenRouter. Le guide [Configurer un moteur d'IA gratuit](/docs/free-ai-engine) détaille chacune de ces options.
+
+career-ops n'a ni formule payante, ni paliers, ni période d'essai — il est 100 % gratuit et sous licence MIT. Tout site décrivant des tarifs pour career-ops décrit un autre produit.
+
+## Ai-je besoin d'un abonnement Claude pour utiliser career-ops ?
+
+Non. career-ops est agnostique en matière d'IA — Claude Code est un moteur parmi d'autres, pas une exigence. Vous pouvez exécuter l'ensemble du pipeline gratuitement avec OpenCode et un fournisseur gratuit, un modèle local via Ollama, ou le runner OpenRouter intégré (`npm run or`). Si vous avez commencé avec une formule payante et épuisé vos tokens en pleine recherche, passer à un moteur gratuit prend quelques minutes et laisse vos données intactes — voir [Configurer un moteur d'IA gratuit](/docs/free-ai-engine).
+
+## Mes données restent-elles sur mon ordinateur ? career-ops est-il privé ?
+
+Sur votre machine, dans des fichiers en clair qui vous appartiennent — votre CV, votre profil, votre pipeline et vos rapports sont des fichiers Markdown/YAML locaux. Rien ne s'exécute sur des serveurs career-ops. Les mises à jour du système ne touchent jamais votre couche de données (`cv.md`, `config/`, `data/`, `reports/`, `output/`) : cette séparation est le **Data Contract**, et chaque mise à jour la respecte.
+
+## Avec quels CLI de codage IA career-ops fonctionne-t-il ?
+
+Huit, avec une prise en charge complète : Claude Code, Codex, OpenCode, Antigravity CLI, Grok Build CLI, Qwen, Kimi et GitHub Copilot CLI (Gemini CLI est pris en charge via un wrapper legacy). career-ops est agnostique en matière d'IA : il fournit des fichiers de prompts que le CLI exécute, si bien que vous pouvez aussi le pointer vers n'importe quel endpoint compatible OpenAI ou un modèle local, sans modifier une seule ligne de code. Consultez [CLI d'IA pris en charge](/docs/supported-clis) pour la liste à jour et la façon d'invoquer chacun d'eux.
+
+## Quelle est la différence entre `scan` et `scan:full` ?
+
+`npm run scan` lit les entreprises que vous avez configurées dans `portals.yml` et interroge directement leurs API ATS ([Greenhouse](/docs/reference/portals/greenhouse), [Ashby](/docs/reference/portals/ashby), [Lever](/docs/reference/portals/lever)), sans consommer aucun token LLM — c'est votre run de découverte habituel, quotidien ou hebdomadaire. `npm run scan:full` inverse la direction : il parcourt les annuaires publics d'entreprises des ATS et fait remonter les offres récentes qui correspondent à vos `title_filter` / `location_filter`, pour que vous repériez des postes chez des entreprises que vous n'avez pas ajoutées manuellement.
+
+## Comment éviter d'atteindre les limites de tokens ou de débit pendant un run en batch ?
+
+Plafonnez le run avec `./batch/batch-runner.sh --limit 5` pour inspecter la qualité du résultat avant de lancer un lot plus important. Si un run est interrompu par une limite de débit ou une erreur réseau, ne repartez pas de zéro — utilisez `--resume-paused` pour ignorer les tâches déjà terminées, afin qu'aucun token ne soit gaspillé sur du travail déjà accompli.
+
+## Les skills ne se chargent pas sous Windows — erreur de symlink à l'installation
+
+Windows ne crée pas de symlinks par défaut, donc Git extrait les points d'entrée des skills CLI sous forme de simples fichiers pointeurs. L'installateur et l'outil de mise à jour le détectent automatiquement : lancez `node update-system.mjs apply` (ou `npx @santifer/career-ops init` lors d'une nouvelle installation) et l'étape de matérialisation remplace les fichiers pointeurs par le contenu complet des skills. Aucun `mklink` manuel ni activation du Mode développeur n'est nécessaire.
+
+## Puis-je exécuter career-ops avec un modèle moins cher ou local ?
+
+Oui — career-ops est entièrement agnostique en matière d'IA. Le guide [Running on a Budget](https://github.com/santifer/career-ops/blob/main/docs/RUNNING_ON_A_BUDGET.md) du dépôt principal couvre OpenCode, Qwen CLI, DeepSeek, OpenRouter, Ollama et d'autres fournisseurs économiques ou locaux, avec des tailles de modèles recommandées (32B et plus pour un scoring fiable) et des pratiques pour économiser les tokens.
+
+## career-ops postule-t-il à ma place ?
+
+Vous décidez et vous envoyez, toujours. career-ops fait tout le travail en amont — il scanne les offres, les évalue, adapte votre CV et peut pré-remplir les formulaires de candidature des ATS — mais l'envoi final passe toujours par votre clic explicite. Le projet rejette explicitement l'automatisation « spray-and-pray » : l'objectif est de bien choisir les entreprises, pas de postuler à l'aveugle en masse.
+
+## Quelle est la différence entre career-ops et CareerOps ?
+
+Ce sont deux noms pour la même œuvre. **career-ops** — en minuscules, avec un trait d'union — est le projet open source : un système de recherche d'emploi propulsé par l'IA, sous licence MIT, qui s'exécute localement dans votre CLI de codage IA, publié sur [career-ops.org](https://career-ops.org) et [github.com/santifer/career-ops](https://github.com/santifer/career-ops). **CareerOps** — en un seul mot — désigne son manifeste : [The CareerOps Manifesto](https://career-ops.org/manifesto), neuf droits que tout chercheur d'emploi devrait avoir, signés publiquement par la communauté. Les deux viennent du même auteur, Santiago Fernández de Valderrama Aparicio, et les deux vivent dans le même dépôt : chaque release, chaque document et chaque signature du manifeste remonte à [github.com/santifer/career-ops](https://github.com/santifer/career-ops).

--- a/content/docs/free-ai-engine.fr.mdx
+++ b/content/docs/free-ai-engine.fr.mdx
@@ -1,0 +1,99 @@
+---
+title: Configurer un moteur d'IA gratuit
+seoTitle: "Comment utiliser career-ops gratuitement (sans abonnement Claude) — OpenRouter, Ollama, modèles locaux"
+description: Utilisez career-ops pour 0 $ — sans abonnement Claude ni aucune offre payante. Les moteurs d'IA gratuits pour career-ops — OpenCode avec un fournisseur gratuit, un modèle local via Ollama, n'importe quel endpoint compatible OpenAI, ou le runner OpenRouter intégré — et que faire quand vous êtes à court de tokens en pleine recherche.
+icon: Sparkles
+translationHash: 98a54ceeb24fa198
+localized: true
+translatedFrom: /docs/free-ai-engine
+---
+
+**career-ops est un agent de recherche d'emploi par IA, gratuit et open source (MIT) : vous n'avez besoin ni d'un abonnement Claude ni d'aucune offre payante pour l'utiliser.** Son moteur d'IA peut lui aussi être gratuit : OpenCode avec un fournisseur gratuit, un modèle entièrement local via Ollama, n'importe quel endpoint compatible OpenAI, ou le runner OpenRouter intégré. Si vous êtes à court de tokens en pleine recherche, passer à un moteur gratuit prend quelques minutes et laisse votre CV, votre pipeline et vos rapports intacts.
+
+career-ops n'a ni offres payantes, ni formules, ni essais gratuits — il est 100 % gratuit et sous licence MIT. Tout site décrivant des tarifs pour career-ops parle d'un autre produit. La seule chose dont il a besoin pour réfléchir, c'est un **moteur d'IA** — un assistant de codage IA qui lit ses prompts et fait le travail. Ce moteur peut lui aussi être gratuit.
+
+Vous apportez votre propre moteur et votre propre clé. Rien ne tourne sur nos serveurs — tout se passe sur votre machine. Cette page présente les options gratuites, de la plus simple à la plus technique. Choisissez-en une et vous êtes prêt pour le [Démarrage rapide](/docs).
+
+<Callout title="Qu'est-ce que je configure exactement ?">
+Voyez career-ops comme la recette et le moteur d'IA comme le cuisinier. La recette est gratuite pour toujours. Cette page explique comment obtenir un cuisinier gratuitement — qu'il s'agisse d'un modèle hébergé avec une offre gratuite ou d'un modèle qui tourne entièrement sur votre propre ordinateur.
+</Callout>
+
+## Quelle option est faite pour moi ?
+
+| Si vous voulez… | Utilisez | Gratuit ? | Nécessite un bon ordinateur ? |
+| --- | --- | --- | --- |
+| Le démarrage gratuit le plus simple | **OpenCode + un fournisseur gratuit** | Oui | Non |
+| Tout 100 % hors ligne et privé | **Ollama (modèle local)** | Oui | Oui — 16 Go+ de VRAM |
+| Réutiliser un CLI que vous avez déjà | **Sa propre offre gratuite** | En général | Non |
+| Le raccourci en une commande | **`npm run or`** | Oui | Non |
+
+La plupart des gens devraient commencer par la première ligne. Les autres options sont là quand vous en aurez besoin.
+
+## Option 1 — OpenCode + un fournisseur gratuit (recommandé)
+
+[OpenCode](https://opencode.ai) est un assistant de codage IA gratuit et open source. L'avis de Santiago : *"opencode is top."* Il se connecte à de nombreux fournisseurs qui proposent une **offre gratuite**, ce qui vous permet d'utiliser career-ops sans rien dépenser.
+
+<div className="rounded-lg bg-radial-[at_bottom] from-blue-500/20 p-4 border bg-origin-border border-fd-primary/10 prose-no-margin dark:bg-black/20">
+  <div className="rounded-xl bg-fd-background p-3">
+    <Steps>
+      <Step title="Installer OpenCode">
+        Suivez l'installation en une ligne sur [opencode.ai](https://opencode.ai). Il tourne dans votre terminal, comme les autres CLI d'IA.
+      </Step>
+      <Step title="Choisir un fournisseur gratuit">
+        Inscrivez-vous chez n'importe quel fournisseur proposant une offre gratuite et copiez votre clé API. Les options gratuites populaires dans la communauté : **OpenRouter** (modèles tagués `:free`), **Google AI Studio** (offre gratuite Gemini), et les endpoints compatibles OpenAI comme l'offre gratuite de **Nvidia**. Le [guide budget](https://github.com/santifer/career-ops/blob/main/docs/RUNNING_ON_A_BUDGET.md) tient à jour la liste des modèles qui tiennent la route.
+      </Step>
+      <Step title="Connecter OpenCode au fournisseur">
+        Définissez votre clé et l'URL de base comme variables d'environnement, puis ouvrez OpenCode dans le dossier career-ops :
+        ```bash title="Terminal"
+        export OPENAI_API_BASE="https://openrouter.ai/api/v1"
+        export OPENAI_API_KEY="your_free_api_key_here"
+        opencode
+        ```
+      </Step>
+    </Steps>
+  </div>
+</div>
+
+C'est tout — OpenCode est désormais votre moteur. Rendez-vous au [Démarrage rapide](/docs).
+
+## Option 2 — Un CLI que vous avez déjà
+
+Vous utilisez déjà un [CLI pris en charge](/docs/supported-clis) — **Claude Code, OpenCode, Codex, GitHub Copilot CLI, et d'autres** ? C'est réglé — career-ops fonctionne avec tous, et plusieurs proposent une offre gratuite. Ouvrez simplement votre CLI dans le dossier career-ops. Aucune configuration supplémentaire sur cette page.
+
+## Option 3 — 100 % local avec Ollama (entièrement hors ligne)
+
+Vous voulez zéro cloud, zéro coût et une confidentialité totale ? Faites tourner le modèle sur votre propre machine avec [Ollama](https://ollama.com). Rien ne quitte votre ordinateur.
+
+La contrepartie, c'est le matériel. career-ops demande au modèle de noter les offres selon de nombreuses dimensions et d'adapter votre CV — les petits modèles peinent à y arriver.
+
+<Callout type="warn" title="Choisissez un modèle suffisamment grand">
+Évitez les petits modèles 7–8B — ils échouent sur le format de scoring et produisent des CV génériques. Utilisez un **modèle 32B ou plus** (par ex. Qwen 2.5 Coder 32B), ce qui nécessite un GPU avec **16–24 Go de VRAM** (une RTX 3090/4090, ou un Mac Apple Silicon avec 32 Go+ de mémoire unifiée). Pas de machine de ce genre ? L'option 1 est la meilleure voie gratuite.
+</Callout>
+
+```bash title="Terminal"
+# Install Ollama from ollama.com, then pull a capable model:
+ollama pull qwen2.5-coder:32b
+```
+
+Ensuite, pointez votre CLI d'IA (OpenCode fonctionne bien ici) vers l'endpoint local d'Ollama, ou utilisez l'évaluateur local intégré décrit dans le [guide budget](https://github.com/santifer/career-ops/blob/main/docs/RUNNING_ON_A_BUDGET.md).
+
+## Option 4 — Le raccourci en une commande : `npm run or`
+
+career-ops embarque un runner intégré qui route vers **les modèles gratuits d'OpenRouter avec bascule automatique** — aucune configuration de CLI à bidouiller. Une fois career-ops cloné et une clé OpenRouter définie, une seule commande lance le pipeline :
+
+```bash title="Terminal"
+export OPENROUTER_API_KEY="your_free_key_here"
+npm run or            # runs the full pipeline on free models
+```
+
+Il existe aussi des variantes ciblées — `npm run or:scan`, `or:eval`, `or:apply` — pour exécuter une seule étape.
+
+---
+
+<Callout title="Pour les développeurs — ajuster les modèles et les coûts">
+Vous voulez les recommandations de modèles maintenues à jour, des exemples par fournisseur, les évaluateurs autonomes (`node openai-eval.mjs`, `node ollama-eval.mjs`) et les flags d'économie de tokens ? Le guide **[Running on a Budget](https://github.com/santifer/career-ops/blob/main/docs/RUNNING_ON_A_BUDGET.md)** du dépôt principal va en profondeur. career-ops est totalement agnostique du modèle — pointez-le vers n'importe quel endpoint compatible OpenAI sans modifier une ligne de code.
+</Callout>
+
+## Vous êtes prêt
+
+Une fois votre moteur configuré, poursuivez avec le **[Démarrage rapide](/docs)** — vous clonerez career-ops, ajouterez votre CV et lancerez votre premier scan gratuit.

--- a/content/docs/introduction/what-is-career-ops.fr.mdx
+++ b/content/docs/introduction/what-is-career-ops.fr.mdx
@@ -1,0 +1,35 @@
+---
+title: "Qu'est-ce que career-ops"
+description: "career-ops est un système de recherche d'emploi par IA, gratuit et open source, qui s'exécute en local dans le CLI d'IA que vous utilisez déjà — il note les offres, adapte votre CV et suit vos candidatures."
+seoTitle: "Qu'est-ce que career-ops ? Le système open source et local-first de recherche d'emploi par IA"
+icon: CircleQuestionMark
+date: 2026-04-20
+lastModified: 2026-05-12
+translationHash: d9bc36a25cdb29ac
+localized: true
+translatedFrom: /docs/introduction/what-is-career-ops
+---
+
+career-ops est un système de recherche d'emploi open source qui s'exécute dans votre assistant de code IA. Vous lui donnez l'URL d'une offre d'emploi ou son texte brut, et il lit la description, évalue le poste par rapport à votre parcours selon cinq dimensions plus un score global holistique, génère un CV PDF sur mesure citant des lignes précises de votre CV, et consigne tout dans un tracker de candidatures local — le tout en une seule commande, sans tableurs, sans compte, et sans que vos données quittent votre machine. career-ops a été créé par [Santiago Fernández de Valderrama Aparicio](https://santifer.io/about) pour gérer une véritable recherche d'emploi à l'ère de l'IA début 2026 : 740 offres évaluées selon une grille explicite, un poste de Head of Applied AI décroché chez Zinkee. Il l'a publié en open source sous licence MIT une fois qu'il n'en avait plus besoin, afin que quiconque mène une recherche d'emploi structurée puisse utiliser le même système gratuitement, sur sa propre machine, avec le modèle d'IA qu'il paie déjà.
+
+## Philosophie
+
+### Open source, pour de vrai
+
+career-ops n'a ni offre payante, ni liste d'attente, ni compte, ni télémétrie. Vous clonez le repo, remplissez une config YAML, déposez votre CV en markdown, et exécutez le système en local avec le CLI de code IA que vous utilisez déjà. Votre CV, votre profil et votre historique de candidatures ne quittent jamais votre machine, sauf si vous les poussez quelque part vous-même. Le projet grandit grâce aux contributions de la communauté, relues au grand jour : quand quelqu'un ajoute un scraper de portail d'entreprise, améliore la grille de notation ou corrige un bug, cette amélioration est livrée à tout le monde dans la release suivante. C'est là tout le modèle économique — pas d'upsell, pas d'offre enterprise, pas de vente de données prévue. Le système est sous licence MIT pour toujours ; même si le mainteneur cesse de publier, la grille, les prompts et les scrapers restent à vous : libre à vous de les forker, de les auditer et de les exécuter.
+
+<Callout title="Envie de contribuer ?">
+  Lisez le [guide de contribution](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md) avant d'ouvrir une pull request. En résumé : ouvrez d'abord une issue pour discuter du changement, puis soumettez votre PR. Les mainteneurs relisent rapidement.
+</Callout>
+
+### Natif IA et agnostique
+
+career-ops n'embarque pas son propre modèle d'IA. Il fonctionne comme un ensemble de slash commands et de fichiers de prompts dans le CLI de code IA auquel vous faites déjà confiance : Claude Code, Codex, OpenCode, Gemini CLI, Qwen CLI ou GitHub Copilot. L'IA se charge du raisonnement ; career-ops fournit la structure, la grille de notation, les scrapers de portails d'entreprise et le data contract qui garantit que vos fichiers restent les vôtres. Cette architecture signifie que vous n'êtes pas enfermé dans la roadmap ou la tarification d'un fournisseur unique — quand un meilleur modèle sort, vous changez de CLI et career-ops fonctionne par-dessus sans aucune modification. La même grille — cinq dimensions de notation plus un score global holistique — produit un raisonnement comparable que vous la pointiez vers un modèle Claude, OpenAI, Gemini ou Qwen : choisissez le moteur qui correspond à votre profil de coût, de qualité et de confidentialité, et changez librement à mesure que le paysage évolue.
+
+## Quand utiliser career-ops
+
+career-ops est le bon outil quand vous menez une recherche d'emploi active et structurée — pas quand vous parcourez les offres par simple curiosité. Il convient le mieux aux candidats qui ont un CV dont ils sont satisfaits et veulent l'adapter à chaque candidature sans le réécrire manuellement à chaque fois, qui suivent plusieurs candidatures et veulent une source de vérité unique plutôt qu'un tableur tentaculaire, qui veulent postuler uniquement aux postes qui leur correspondent vraiment plutôt qu'à tout ce qui est vaguement pertinent, et qui sont à l'aise avec l'exécution de commandes dans un terminal même s'ils n'écrivent pas de code professionnellement. career-ops n'est probablement pas ce qu'il vous faut si vous envoyez une ou deux candidatures et vous en tenez là. La mise en place — cloner le repo, configurer votre profil, ajouter votre CV — prend environ quinze minutes, un investissement qui ne devient rentable que lorsque vous évaluez plus d'une poignée de postes.
+
+## Ce que career-ops n'est pas
+
+career-ops ne postule pas aux offres à votre place. Le système évalue, note, génère et assure le suivi — mais chaque envoi est votre décision, prise avec le raisonnement de l'agent visible à chaque étape, et rien ne part nulle part sans votre approbation explicite. career-ops n'est pas non plus un générateur de CV ni un optimiseur LinkedIn ; vous apportez le CV que vous avez déjà, et le système veille à ce que chaque version soit ajustée à l'offre que vous avez sous les yeux. C'est un pipeline, pas une usine à contenu. La frontière entre le code système (qui se met à jour à chaque release) et les données utilisateur (qui ne sont jamais écrasées) est garantie par le DATA_CONTRACT.md du dépôt : votre CV, votre profil et votre historique de candidatures sont souverains — career-ops les lira, mais ne réécrira ni ne supprimera jamais silencieusement ce que vous y avez mis, quelle que soit la release.

--- a/content/docs/meta.fr.json
+++ b/content/docs/meta.fr.json
@@ -1,0 +1,16 @@
+{
+  "pages": [
+    "---Introduction---",
+    "index",
+    "free-ai-engine",
+    "supported-clis",
+    "windows",
+    "introduction/what-is-career-ops",
+    "introduction/guides",
+    "faq",
+    "---Référence---",
+    "reference/modes",
+    "reference/portals",
+    "reference/glossary"
+  ]
+}

--- a/src/app/(home)/home-dict.tsx
+++ b/src/app/(home)/home-dict.tsx
@@ -632,3 +632,297 @@ export const homeEs: HomeDict = {
     </>
   ),
 };
+
+// French home (French pilot, 2026-07-21). Same trunk, French copy. The thesis
+// stays LITERAL English (no official French translation until venture-ops
+// ratifies), so there is NO thesisTranslation and only the English blockquote
+// renders. FAQ questions are transcreated to the measured French fan-out
+// (search-ops fanout-fr-2026-W30): the killer "career-ops postule-t-il à ma
+// place ?" and the privacy "Mes données restent-elles sur mon ordinateur ?".
+export const homeFr: HomeDict = {
+  heroHook: (
+    <>
+      Vous avez décroché le poste,
+      <br />
+      et ça ne vous a {brand('rien')} coûté.
+    </>
+  ),
+  heroH1: (
+    <>
+      Recherche d’emploi par IA, open source.
+      <br />
+      Elle tourne dans votre CLI. Vos données, votre machine.
+    </>
+  ),
+  runItNow: 'Commencer',
+  viewSource: 'Voir le code',
+  docsHref: '/fr/docs',
+  manifestoHref: '/manifesto',
+  featuredIn: 'Vu dans',
+  authorTagline: ', 16 ans d’opérateur et Head of Applied AI',
+  // No thesisTranslation for FR — the English thesis stands alone (venture-ops).
+  nowSignedManifesto: <>Désormais un manifeste signé ·</>,
+  readIt: 'À lire →',
+  whatIsHeading: (
+    <>
+      <span className="text-landing-foreground dark:text-landing-foreground-dark">
+        Qu’est-ce que
+      </span>{' '}
+      {brand('career-ops')}
+    </>
+  ),
+  whatIsBody: (
+    <>
+      career-ops est un système open source de recherche d’emploi par IA qui
+      tourne en local, sur votre propre machine, dans n’importe quel CLI de
+      codage IA — Claude Code, OpenCode, Codex, GitHub Copilot et d’autres. Il
+      évalue les offres face à votre CV avec une grille de cinq dimensions plus
+      une note globale, de 1.0 à 5.0, génère des CV PDF optimisés pour les ATS et
+      adaptés à chaque poste, rédige les réponses aux questions ouvertes des
+      formulaires Greenhouse, Ashby et Lever, parcourt plus de 150 portails
+      d’entreprise sans consommer de jetons et suit votre pipeline dans un
+      tableau de bord en terminal écrit en Go. Tout vit sur votre machine :{' '}
+      {brand('sans cloud')}, {brand('sans télémétrie')}, {brand('sans compte')}.
+      Sous licence MIT et gratuit pour toujours ; le seul coût est le CLI d’IA
+      que vous payez déjà. Créé par Santiago Fernández de Valderrama Aparicio
+      après une vraie recherche d’emploi en 2026 : 740 offres évaluées, 68
+      candidatures, 12 entretiens et une offre.
+    </>
+  ),
+  statsComment: 'étoiles · Open source · MIT',
+  commandCenter: (
+    <>
+      Transformez n’importe quel CLI d’IA en {brand('centre de commande')} complet
+      pour votre recherche d’emploi.
+    </>
+  ),
+  tryItOut: 'Essayez',
+  runsCommand: (
+    <>
+      Il lui faut un CLI d’IA comme moteur — vous n’en avez pas encore configuré ?{' '}
+      <a
+        href="/fr/docs/free-ai-engine"
+        className="text-fd-foreground underline underline-offset-2"
+      >
+        Obtenez-en un gratuitement
+      </a>
+      .
+    </>
+  ),
+  mechanism:
+    'Au lieu de suivre vos candidatures à la main dans un tableur, vous avez un pipeline IA qui parcourt les portails, génère des CV PDF adaptés et fait le suivi à votre place.',
+  analogy: (
+    <>
+      &ldquo;C’est comme avoir un coach de carrière pour votre recherche
+      d’emploi, mais {brand('sans le prix')}.&rdquo;
+    </>
+  ),
+  featAgnosticTitle: 'Nativement IA et indépendant',
+  featAgnosticBody: (
+    <>
+      Fonctionne avec n’importe quel CLI de codage IA — Claude Code, OpenCode,
+      Codex, GitHub Copilot et d’autres. Construit sur l’Open Agent Skill
+      Standard.
+    </>
+  ),
+  featApplyTitle: 'Il rédige les réponses ouvertes.',
+  featApplyBody1: (
+    <>
+      Les formulaires Greenhouse, Ashby et Lever demandent « pourquoi ce poste ? »
+      et « parlez-nous d’un projet ».{' '}
+      <code className="font-mono text-brand">/career-ops apply</code> lit le
+      formulaire, rédige chaque réponse à partir de votre CV et de l’offre, et
+      vous les rend prêtes à coller.
+    </>
+  ),
+  featApplyBody2:
+    'Vous éditez, vous envoyez. L’assistant ne clique jamais à votre place.',
+  featApplyCta: 'Voir comment fonctionne apply',
+  featScanTitle: '150+ portails d’entreprise. Zéro recherche manuelle.',
+  featScanBody: (
+    <>
+      Des scrapers préconfigurés parcourent plus de 150 pages d’emploi sur
+      Greenhouse, Ashby et Lever à la demande — zéro jeton d’API. Lancez{' '}
+      <code className="font-mono text-brand">/career-ops scan</code> et recevez
+      une liste priorisée en quelques minutes.
+    </>
+  ),
+  featScanCta: 'Voir tous les portails',
+  featCommunityTitle: 'Construit avec la communauté.',
+  featCommunityBody: (
+    <>
+      career-ops grandit grâce aux pull requests de gens qui font de vraies
+      recherches d’emploi. Les issues sont triées sur Discord et les correctifs
+      sortent dans la semaine. Vous n’utilisez pas seulement l’outil — vous aidez
+      à décider ce qu’il devient.
+    </>
+  ),
+  joinDiscord: (n) => `Rejoignez ${n}+ builders sur Discord`,
+  openSourceTitle: '100% Open-Source.',
+  starsWord: 'étoiles',
+  forksWord: 'forks',
+  repoOfDay: 'Repo du jour nº1',
+  builtByDek: (
+    <>
+      Créé par{' '}
+      <a href="/about" rel="author" className="text-fd-foreground font-medium hover:underline">
+        Santiago Fernández de Valderrama Aparicio
+      </a>{' '}
+      après avoir évalué 740 offres d’emploi.
+      <br />
+      La méthodologie de scoring complète est{' '}
+      <a href="/methodology" className="text-fd-foreground hover:underline underline-offset-2">
+        publiée
+      </a>
+      .
+      <br />
+      Désormais portée par la communauté.
+    </>
+  ),
+  meetContributors: 'Rencontrez les contributeurs →',
+  faqHeading: 'Questions fréquentes',
+  faq: [
+    {
+      q: 'Comment career-ops évalue-t-il les offres d’emploi ?',
+      a: (
+        <>
+          career-ops utilise une évaluation par LLM guidée par une grille sur
+          cinq dimensions — adéquation, alignement avec votre cap, rémunération,
+          signaux culturels et red flags — qui produit une note globale de 1.0 à
+          5.0 avec des citations de lignes précises de votre CV et des exigences
+          de l’offre. En dessous de 4.0, l’agent déconseille de postuler. Pas de
+          formule fermée, pas de candidatures à l’aveugle. La grille complète est
+          publiée sur{' '}
+          <a href="/methodology" className="text-fd-foreground hover:underline underline-offset-2">
+            career-ops.org/methodology
+          </a>
+          .
+        </>
+      ),
+    },
+    {
+      q: 'career-ops postule-t-il à ma place ?',
+      a: (
+        <>
+          Il prépare chaque candidature jusqu’au clic : il parcourt les offres,
+          note chacune face à votre CV et adapte un CV. Puis il vous rend la
+          décision. Vous relisez et envoyez chaque candidature vous-même. C’est
+          délibéré : la candidature automatique de masse abîme votre réputation
+          auprès des recruteurs et des ATS ; career-ops vous enlève le travail
+          fastidieux, pas le jugement.
+        </>
+      ),
+    },
+    {
+      q: 'career-ops est-il gratuit ? Quel est le modèle économique ?',
+      a: (
+        <>
+          career-ops est gratuit pour toujours, sous licence MIT et financé par
+          la communauté. Pas d’offre payante, pas de liste d’attente, pas de
+          compte, pas de télémétrie, pas de fonctionnalités premium. Vous clonez
+          le dépôt, configurez votre profil et lancez le système en local avec le
+          CLI d’IA que vous utilisez déjà. La pérennité vient du mécénat
+          volontaire de la communauté via GitHub Sponsors, pas d’offres premium,
+          de fonctionnalités payantes ou de données. Le mainteneur a un autre
+          travail rémunéré ; le parrainage lui permet de s’y consacrer davantage.
+          Détails sur{' '}
+          <a href="/sustain" className="text-fd-foreground hover:underline underline-offset-2">
+            career-ops.org/sustain
+          </a>
+          .
+        </>
+      ),
+    },
+    {
+      q: 'Mes données restent-elles sur mon ordinateur ? career-ops est-il privé ?',
+      a: (
+        <>
+          Sur votre propre machine, dans des fichiers en clair qui vous
+          appartiennent : votre CV, votre profil, votre pipeline et vos rapports
+          sont du Markdown et du YAML locaux. career-ops tourne entièrement en
+          local via votre CLI d’IA : pas de compte, pas de télémétrie, rien n’est
+          envoyé à un serveur career-ops. Les mises à jour du système ne touchent
+          jamais votre couche de données ; cette séparation est le Data Contract.
+          Les seules données qui quittent votre machine sont celles que votre CLI
+          d’IA envoie à son propre fournisseur.
+        </>
+      ),
+    },
+    {
+      q: 'Qui a créé career-ops ?',
+      a: (
+        <>
+          career-ops a été créé par{' '}
+          <a href="/about" rel="author" className="text-fd-foreground hover:underline underline-offset-2">
+            Santiago Fernández de Valderrama Aparicio
+          </a>{' '}
+          — un Applied AI Operator avec plus de 16 ans à construire des produits,
+          fondateur et exploitant d’une entreprise espagnole de réparation de
+          téléphones (2009–2025) avant sa revente, et actuellement Head of Applied
+          AI chez Zinkee. Il a créé career-ops début 2026 pour gérer sa propre
+          recherche d’emploi à l’ère de l’IA — 740 offres évaluées, un poste de
+          Head of AI décroché — et l’a publié sous licence MIT une fois qu’il
+          n’en avait plus besoin.
+        </>
+      ),
+    },
+    {
+      q: 'career-ops est-il une skill de Claude Code ou un outil autonome ?',
+      a: (
+        <>
+          career-ops est indépendant du CLI. Il fonctionne avec Claude Code,
+          OpenCode, Codex, GitHub Copilot et d’autres — l’agent de codage IA que
+          l’utilisateur paie déjà. Les fichiers de skill (
+          <code className="font-mono text-fd-foreground">modes/</code>) vivent
+          dans le dépôt sous forme de prompts markdown ; tout agent qui prend en
+          charge le chargement de skills peut les invoquer. Aucune dépendance
+          spécifique à Anthropic. Claude Code est le runtime le plus courant grâce
+          à son chargeur de skills, mais les mêmes modes fonctionnent sans
+          changement dans les autres CLIs.
+        </>
+      ),
+    },
+    {
+      q: 'En quoi career-ops diffère-t-il des correcteurs de CV et des outils de candidature automatique ?',
+      a: (
+        <>
+          career-ops est open source et sous licence MIT, tourne en local sur
+          votre propre machine via le CLI de codage IA que vous utilisez déjà, et
+          publie sa grille d’évaluation complète. Un humain garde la main sur
+          chaque candidature ; il n’envoie jamais tout seul. Pas de compte, pas de
+          télémétrie, pas d’abonnement à career-ops lui-même ; le seul coût
+          récurrent est le CLI d’IA que vous choisissez. Pour des comparaisons
+          honnêtes, côte à côte, avec des outils précis, voyez{' '}
+          <a href="/compare" className="text-fd-foreground hover:underline underline-offset-2">
+            career-ops.org/compare
+          </a>
+          .
+        </>
+      ),
+    },
+    {
+      q: 'Avec quels outils d’IA career-ops fonctionne-t-il ?',
+      a: (
+        <>
+          Claude Code, Codex, OpenCode, Antigravity CLI, Grok Build CLI, Qwen,
+          Kimi et GitHub Copilot CLI — huit CLIs de premier plan (Gemini CLI est
+          un wrapper legacy). Les mêmes fichiers de mode fonctionnent sur tous.
+          Chacun choisit le CLI qui correspond à son abonnement et à ses
+          préférences de coût — career-ops ne vous enferme jamais chez un seul
+          fournisseur. Une recherche d’emploi typique tourne sur Claude Pro à
+          20 $/mois, mais le choix vous appartient.
+        </>
+      ),
+    },
+  ],
+  finalCta: 'C’est vous qui filtrez les offres, ou vous laissez-vous filtrer ?',
+  yourTurn: 'À vous de jouer',
+  followWhatWeShip: 'Ou suivez ce qu’on livre.',
+  releaseBlurb: (
+    <>
+      Annonces de versions et nouvelles occasionnelles.
+      <br />
+      Désabonnement à tout moment.
+    </>
+  ),
+};

--- a/src/app/docs/[[...slug]]/page.tsx
+++ b/src/app/docs/[[...slug]]/page.tsx
@@ -2,7 +2,7 @@ import { getPageImage, source } from '@/lib/source';
 import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 import { DocsPageView } from '@/components/docs-page-view';
-import { docsHreflang } from '@/lib/i18n-map';
+import { docsHreflang, DOCS_LOCALES } from '@/lib/i18n-map';
 
 export default async function Page(props: PageProps<'/docs/[[...slug]]'>) {
   const params = await props.params;
@@ -28,12 +28,14 @@ export async function generateMetadata(props: PageProps<'/docs/[[...slug]]'>): P
   // seoTitle (optional frontmatter) drives the <title> tag when present;
   // the visible H1 stays page.data.title (short command name). QW1.
   const metaTitle = page.data.seoTitle ?? page.data.title;
-  // Reciprocal hreflang, but ONLY when this EN page has a real Spanish twin.
-  // Source-derived (no hand-kept map): with fallbackLanguage:null, getPage(slug,
-  // 'es') resolves iff an .es.mdx exists — never an English fallback — so the
-  // bidirectional + x-default→EN cluster is always truthful (search-ops).
-  const hasEsTwin = source.getPage(page.slugs, 'es') != null;
-  const languages = hasEsTwin ? docsHreflang(page.url) : undefined;
+  // Reciprocal hreflang, built from the locales that actually have a twin.
+  // Source-derived (no hand-kept map): with fallbackLanguage:null,
+  // getPage(slug, loc) resolves iff a .<loc>.mdx exists — never a fallback — so
+  // the bidirectional + x-default→EN cluster is always truthful (search-ops).
+  const twins = DOCS_LOCALES.filter(
+    (loc) => source.getPage(page.slugs, loc) != null,
+  );
+  const languages = twins.length ? docsHreflang(page.url, twins) : undefined;
   return {
     title: metaTitle,
     description: page.data.description,

--- a/src/app/fr/(home)/layout.tsx
+++ b/src/app/fr/(home)/layout.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from 'react';
+import { HomeLayout } from 'fumadocs-ui/layouts/home';
+import { baseOptions } from '@/lib/layout.shared';
+
+// Layout for the French home (/fr) — same site chrome as the EN/ES homes. Lives
+// in a (home) route group so this HomeLayout does NOT wrap the /fr/docs subtree
+// (that gets its own DocsLayout).
+export default function Layout({ children }: { children: ReactNode }) {
+  return <HomeLayout {...baseOptions({ locale: 'fr' })}>{children}</HomeLayout>;
+}

--- a/src/app/fr/(home)/page.tsx
+++ b/src/app/fr/(home)/page.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from 'next';
+import { homeFaqSchemaFr } from '@/lib/schema';
+import { hreflangHome } from '@/lib/i18n-map';
+import { HomeContent } from '../../(home)/home-content';
+import { homeFr } from '../../(home)/home-dict';
+
+// French home — SAME trunk as the English/Spanish homes (HomeContent), rendered
+// with the French dictionary. The signature thesis stays in LITERAL English
+// (no official French translation until venture-ops ratifies one), so homeFr
+// has no thesisTranslation and only the English blockquote renders.
+
+export const metadata: Metadata = {
+  metadataBase: new URL('https://career-ops.org'),
+  title: 'career-ops — recherche d’emploi par IA, open source et local-first',
+  description:
+    'Système open source de recherche d’emploi par IA. Il tourne sur votre propre machine, dans l’assistant de codage IA que vous utilisez déjà. Il évalue les offres, adapte votre CV et suit vos candidatures. Sans compte, sans cloud, gratuit.',
+  alternates: {
+    canonical: 'https://career-ops.org/fr',
+    languages: hreflangHome(),
+  },
+  openGraph: {
+    type: 'website',
+    url: 'https://career-ops.org/fr',
+    siteName: 'career-ops',
+    locale: 'fr_FR',
+    title: 'career-ops — recherche d’emploi par IA, open source et local-first',
+    description:
+      'Système open source de recherche d’emploi par IA. Il tourne dans votre CLI. Vos données, votre machine.',
+  },
+};
+
+export default function HomePageFr() {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(homeFaqSchemaFr()) }}
+      />
+      <HomeContent dict={homeFr} />
+    </>
+  );
+}

--- a/src/app/fr/docs/[[...slug]]/page.tsx
+++ b/src/app/fr/docs/[[...slug]]/page.tsx
@@ -4,17 +4,17 @@ import { docsHreflang, DOCS_LOCALES } from '@/lib/i18n-map';
 import { notFound, redirect } from 'next/navigation';
 import type { Metadata } from 'next';
 
-// Spanish docs route — reuses the SAME render trunk (DocsPageView) as /docs/**,
-// resolving each page in the 'es' locale. It exists only for slugs with a real
-// .es.mdx (see generateStaticParams), so it is never a thin English mirror.
+// French docs route — reuses the SAME render trunk (DocsPageView) as /docs/**,
+// resolving each page in the 'fr' locale. It exists only for slugs with a real
+// .fr.mdx (see generateStaticParams), so it is never a thin English mirror.
 type Props = { params: Promise<{ slug?: string[] }> };
 
 export default async function Page(props: Props) {
   const { slug } = await props.params;
-  const page = source.getPage(slug, 'es');
+  const page = source.getPage(slug, 'fr');
   if (!page) {
-    // No Spanish translation for this doc yet → send the reader to the English
-    // page rather than a 404, so the language toggle is always safe to click.
+    // No French translation yet → send the reader to the English page rather
+    // than a 404, so the language toggle is always safe to click.
     const en = source.getPage(slug);
     if (en) redirect(en.url);
     notFound();
@@ -24,25 +24,22 @@ export default async function Page(props: Props) {
 }
 
 export async function generateStaticParams() {
-  // With fallbackLanguage:null, getPages('es') is EXACTLY the set of pages that
-  // have an .es.mdx — so /es/docs/* is generated only for real translations,
-  // never an English-content page under a Spanish URL.
-  return source.getPages('es').map((page) => ({ slug: page.slugs }));
+  // With fallbackLanguage:null, getPages('fr') is EXACTLY the set of pages that
+  // have a .fr.mdx — so /fr/docs/* is generated only for real translations.
+  return source.getPages('fr').map((page) => ({ slug: page.slugs }));
 }
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
   const { slug } = await props.params;
-  const page = source.getPage(slug, 'es');
+  const page = source.getPage(slug, 'fr');
   if (!page) notFound();
 
-  // The EN twin always exists (ES ⊆ EN); its url is the canonical EN path, and
-  // the ES URL is deterministically /es + that path (slugs are not translated).
   const enUrl = source.getPage(slug)?.url ?? `/docs/${(slug ?? []).join('/')}`;
-  const esUrl = `https://career-ops.org/es${enUrl}`;
-  // Cluster from the locales that actually have a twin (es is always present
-  // here; fr appears only if a .fr.mdx exists for this slug).
+  const frUrl = `https://career-ops.org/fr${enUrl}`;
+  // Cluster from the locales that actually have a twin (fr is always present
+  // here; es appears only if a .es.mdx exists for this slug).
   const twins = DOCS_LOCALES.filter((loc) => source.getPage(slug, loc) != null);
-  // seoTitle here is the transcreated ES <title> (framing, localized to ES
+  // seoTitle here is the transcreated FR <title> (framing, localized to the FR
   // fan-out); the visible H1 stays page.data.title.
   const metaTitle = page.data.seoTitle ?? page.data.title;
 
@@ -50,15 +47,15 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
     title: metaTitle,
     description: page.data.description,
     alternates: {
-      canonical: esUrl,
+      canonical: frUrl,
       languages: docsHreflang(enUrl, twins),
     },
     robots: { index: true, follow: true },
     openGraph: {
       type: 'article',
-      url: esUrl,
+      url: frUrl,
       siteName: 'career-ops',
-      locale: 'es_ES',
+      locale: 'fr_FR',
       title: metaTitle,
       description: page.data.description,
     },

--- a/src/app/fr/docs/layout.tsx
+++ b/src/app/fr/docs/layout.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react';
+import { source } from '@/lib/source';
+import { DocsLayout } from 'fumadocs-ui/layouts/docs';
+import { baseOptions } from '@/lib/layout.shared';
+import { AISearchLazy } from '@/components/ai/lazy';
+
+// Docs chrome for the French subtree (French pilot, 2026-07-21). The tree comes
+// from the 'fr' locale, so the sidebar shows exactly the translated pages
+// (fallbackLanguage:null => no English fallback entries) — the curated grounded
+// subset (what-is, faq, free-ai-engine), growing as pages are translated.
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <DocsLayout
+      tree={source.getPageTree('fr')}
+      {...baseOptions({ compact: true, locale: 'fr' })}
+    >
+      <AISearchLazy />
+      {children}
+    </DocsLayout>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -94,7 +94,9 @@ export default async function Layout({ children }: LayoutProps<'/'>) {
               </div>
               <nav className={`${inter.className} flex flex-row flex-wrap items-center gap-x-5 gap-y-2 text-sm`}>
                 <FooterLocaleLink path="/docs">Docs</FooterLocaleLink>
-                <FooterLocaleLink path="/manifesto">Manifesto</FooterLocaleLink>
+                <FooterLocaleLink path="/manifesto" locales={['es']}>
+                  Manifesto
+                </FooterLocaleLink>
                 <a href="/methodology" className="hover:text-fd-foreground hover:underline">
                   Methodology
                 </a>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -106,17 +106,22 @@ export default function sitemap(): MetadataRoute.Sitemap {
     });
   }
 
-  // Spanish (es) home.
+  // Localized homes (es, fr) — share the same hreflang cluster.
+  const homeCluster = {
+    en: `${SITE_URL}/`,
+    es: `${SITE_URL}/es`,
+    fr: `${SITE_URL}/fr`,
+    'x-default': `${SITE_URL}/`,
+  };
   entries.push({
     url: `${SITE_URL}/es`,
     lastModified: new Date('2026-07-20'),
-    alternates: {
-      languages: {
-        en: `${SITE_URL}/`,
-        es: `${SITE_URL}/es`,
-        'x-default': `${SITE_URL}/`,
-      },
-    },
+    alternates: { languages: homeCluster },
+  });
+  entries.push({
+    url: `${SITE_URL}/fr`,
+    lastModified: lastModFor('src/app/fr/(home)/page.tsx'),
+    alternates: { languages: homeCluster },
   });
 
   // Spanish (es) manifesto — /es/manifesto. Standalone TSX article (like the
@@ -133,23 +138,31 @@ export default function sitemap(): MetadataRoute.Sitemap {
     },
   });
 
-  // ES docs — SOURCE-DERIVED, no hand-kept map (search-ops drift contract).
-  // A page has an ES twin iff getPage(slug, 'es') resolves, which with
-  // fallbackLanguage:null happens only for a real .es.mdx (never an English
-  // fallback). So a Spanish URL / hreflang alternate is emitted exclusively for
-  // pages that are actually translated — never a thin es-labelled EN page.
+  // Localized docs (es, fr) — SOURCE-DERIVED, no hand-kept map (search-ops drift
+  // contract). A page has a twin iff getPage(slug, loc) resolves, which with
+  // fallbackLanguage:null happens only for a real .<loc>.mdx (never an English
+  // fallback). For each EN page we emit one entry per existing twin, and every
+  // entry's hreflang cluster lists EN + all the twins that exist for that page.
+  const DOCS_LOCALES = ['es', 'fr'] as const;
   for (const enPage of source.getPages('en')) {
-    if (!source.getPage(enPage.slugs, 'es')) continue;
+    const twins = DOCS_LOCALES.filter(
+      (loc) => source.getPage(enPage.slugs, loc) != null,
+    );
+    if (!twins.length) continue;
     const enUrl = `${SITE_URL}${enPage.url}`;
-    const esUrl = `${SITE_URL}/es${enPage.url}`;
-    const esMdxRel = `content/docs/${enPage.slugs.join('/')}.es.mdx`;
-    entries.push({
-      url: esUrl,
-      lastModified: lastModFor(esMdxRel),
-      alternates: {
-        languages: { en: enUrl, es: esUrl, 'x-default': enUrl },
-      },
-    });
+    const cluster: Record<string, string> = {
+      en: enUrl,
+      'x-default': enUrl,
+    };
+    for (const loc of twins) cluster[loc] = `${SITE_URL}/${loc}${enPage.url}`;
+    for (const loc of twins) {
+      const mdxRel = `content/docs/${enPage.slugs.join('/')}.${loc}.mdx`;
+      entries.push({
+        url: `${SITE_URL}/${loc}${enPage.url}`,
+        lastModified: lastModFor(mdxRel),
+        alternates: { languages: cluster },
+      });
+    }
   }
 
   // priority and changefreq deliberately omitted — Google has ignored

--- a/src/components/footer-locale-link.tsx
+++ b/src/components/footer-locale-link.tsx
@@ -2,23 +2,35 @@
 
 import { usePathname } from 'next/navigation';
 
-// The global footer lives in the root layout (rendered on every page, EN and
-// ES). A footer link for a page that HAS an ES twin must follow the locale: on
-// any /es surface it points at the Spanish version, everywhere else at the
-// English one. Use this ONLY for pages with an ES twin (today: /docs and
-// /manifesto). The rest of the footer nav stays English until those pages are
-// translated (tracked separately as the "localize global chrome" follow-up,
-// together with <html lang> and the footer labels).
+// The global footer lives in the root layout (rendered on every page, EN, ES
+// and FR). A footer link for a page that HAS a localized twin must follow the
+// locale: on an /es or /fr surface it points at that language's version — but
+// ONLY for the locales that actually have that page. `locales` lists them
+// (default: both es and fr have /docs; /manifesto passes just ['es']). If the
+// current locale has no twin for this path, the link stays English so it never
+// 404s. The rest of the footer nav stays English until those pages are
+// translated (the "localize global chrome" follow-up, with <html lang> + labels).
+type Loc = 'es' | 'fr';
+
 export function FooterLocaleLink({
   path,
+  locales = ['es', 'fr'],
   children,
 }: {
-  /** The EN path (e.g. '/docs', '/manifesto'). The ES twin is '/es' + path. */
+  /** The EN path (e.g. '/docs', '/manifesto'). The twin is '/<loc>' + path. */
   path: string;
+  /** Locales that actually have this page translated. */
+  locales?: Loc[];
   children: React.ReactNode;
 }) {
-  const pathname = usePathname();
-  const href = pathname?.startsWith('/es') ? `/es${path}` : path;
+  const pathname = usePathname() ?? '';
+  const current: 'en' | Loc = pathname.startsWith('/es')
+    ? 'es'
+    : pathname.startsWith('/fr')
+      ? 'fr'
+      : 'en';
+  const href =
+    current !== 'en' && locales.includes(current) ? `/${current}${path}` : path;
   return (
     <a href={href} className="hover:text-fd-foreground hover:underline">
       {children}

--- a/src/components/language-bar.tsx
+++ b/src/components/language-bar.tsx
@@ -5,21 +5,28 @@ import Link from 'next/link';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { X } from 'lucide-react';
 
-// Language button + browser-detection suggestion, both living in the header.
+// Language switcher + browser-detection suggestion, both living in the header.
 // Ported from santifer.io's pattern (cv-santiago): suggest, never auto-redirect
-// (an auto-redirect breaks Google's crawl of the hreflang pair and annoys users
-// whose browser is in a language they don't read — a banner is Google's own
-// guidance). Detection is client-only; the banner never renders in SSR (that
-// caused a React #418 hydration mismatch on santifer.io).
+// (an auto-redirect breaks Google's crawl of the hreflang cluster and annoys
+// users whose browser is in a language they don't read — a banner is Google's
+// own guidance). Detection is client-only; the banner never renders in SSR
+// (that caused a React #418 hydration mismatch on santifer.io).
 //
-// Multi-language ready: add a locale to LOCALES + create its /prefix routes and
-// the pill becomes a menu; detection already walks navigator.languages.
+// N-locale (en/es/fr, 2026-07-21): the switcher shows the current locale plus a
+// link per other locale (stateless, no dropdown). Each link resolves to the
+// SAFE URL for that locale — docs go to /<loc>/docs (the route redirects an
+// untranslated slug to EN), the home to /<loc>, the manifesto to its twin when
+// one exists (es) or the locale home otherwise (fr has no manifesto yet), and
+// any other EN-only page to the locale home. So a toggle never 404s.
 
-type Code = 'en' | 'es';
+type Code = 'en' | 'es' | 'fr';
 const LOCALES: { code: Code; label: string }[] = [
   { code: 'en', label: 'EN' },
   { code: 'es', label: 'ES' },
+  { code: 'fr', label: 'FR' },
 ];
+// Locales whose manifesto is actually translated (has an /<loc>/manifesto route).
+const MANIFESTO_LOCALES: Code[] = ['es'];
 
 /** Circular flag icons (SVG, not emoji — emoji renders inconsistently). */
 function FlagES({ className = 'w-3.5 h-3.5' }: { className?: string }) {
@@ -48,30 +55,53 @@ function FlagEN({ className = 'w-3.5 h-3.5' }: { className?: string }) {
     </svg>
   );
 }
+function FlagFR({ className = 'w-3.5 h-3.5' }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 16 16" aria-hidden="true">
+      <clipPath id="flagCircleFR"><circle cx="8" cy="8" r="8" /></clipPath>
+      <g clipPath="url(#flagCircleFR)">
+        <rect width="6" height="16" fill="#002395" />
+        <rect x="5" width="6" height="16" fill="#fff" />
+        <rect x="10" width="6" height="16" fill="#ed2939" />
+      </g>
+    </svg>
+  );
+}
 const FLAG: Record<Code, (p: { className?: string }) => React.ReactNode> = {
   en: FlagEN,
   es: FlagES,
+  fr: FlagFR,
 };
 
-/** Which locale is this path? (ES surfaces are prefixed /es; everything else EN.) */
+/** Which locale is this path? (localized surfaces are prefixed /es or /fr.) */
 function localeOf(pathname: string): Code {
-  return pathname === '/es' || pathname.startsWith('/es/') ? 'es' : 'en';
+  if (pathname === '/es' || pathname.startsWith('/es/')) return 'es';
+  if (pathname === '/fr' || pathname.startsWith('/fr/')) return 'fr';
+  return 'en';
 }
 
-/** The mirrored URL in the other locale. Routes are prefix-mirrored for the home
- *  and the docs tree; other (EN-only) pages fall back to the locale home. The ES
- *  docs route redirects an untranslated slug to its EN page, so this never 404s. */
-function alternateUrl(pathname: string): string {
-  if (localeOf(pathname) === 'es') {
-    if (pathname === '/es') return '/';
-    if (pathname === '/es/manifesto') return '/manifesto';
-    if (pathname.startsWith('/es/docs')) return pathname.slice(3) || '/';
-    return '/';
+/** The EN-relative base path of the current page (locale prefix stripped). */
+function baseOf(pathname: string): string {
+  const loc = localeOf(pathname);
+  if (loc === 'en') return pathname;
+  return pathname.slice(3) || '/'; // drop '/es' or '/fr'
+}
+
+/** The URL for `target` locale of the page whose EN-relative path is `base`.
+ *  Always resolves to a route that exists (or safely redirects), so no 404. */
+function localeUrl(base: string, target: Code): string {
+  if (target === 'en') {
+    // EN pages are unprefixed. Docs/home/manifesto/etc. all live at `base`.
+    return base;
   }
-  if (pathname === '/') return '/es';
-  if (pathname === '/manifesto') return '/es/manifesto';
-  if (pathname.startsWith('/docs')) return '/es' + pathname;
-  return '/es';
+  if (base === '/') return `/${target}`; // home
+  if (base.startsWith('/docs')) return `/${target}${base}`; // route redirects if untranslated
+  if (base === '/manifesto') {
+    // A manifesto twin exists only for some locales; otherwise send to the home.
+    return MANIFESTO_LOCALES.includes(target) ? `/${target}/manifesto` : `/${target}`;
+  }
+  // Any other EN-only page (about, blog, compare, …) has no localized version.
+  return `/${target}`;
 }
 
 /** Best browser-preferred locale we support (walks navigator.languages in order). */
@@ -90,6 +120,7 @@ function detectLocale(): Code {
 const BANNER: Record<Code, { message: string; prefix: string }> = {
   en: { message: 'This site is available in English', prefix: 'Switch to' },
   es: { message: 'Este sitio está disponible en español', prefix: 'Cambiar a' },
+  fr: { message: 'Ce site est disponible en français', prefix: 'Passer en' },
 };
 
 /**
@@ -100,7 +131,7 @@ const BANNER: Record<Code, { message: string; prefix: string }> = {
  *  banner and expires with the session, so a return visit is re-offered once.
  *  No cookie, no localStorage → zero GDPR surface.
  */
-function useLanguageBanner(current: Code, target: Code, mismatch: boolean) {
+function useLanguageBanner(target: Code, mismatch: boolean) {
   const KEY = `lang-banner-dismissed:${target}`;
   const stored = typeof sessionStorage !== 'undefined' ? sessionStorage.getItem(KEY) : null;
   const [visible, setVisible] = useState(stored === 'shown');
@@ -134,15 +165,15 @@ function useLanguageBanner(current: Code, target: Code, mismatch: boolean) {
 export function LanguageBar() {
   const pathname = usePathname() || '/';
   const current = localeOf(pathname);
-  const alt = alternateUrl(pathname);
-  const other = LOCALES.find((l) => l.code !== current)!; // 2-locale toggle; menu when >2
+  const base = baseOf(pathname);
+  const others = LOCALES.filter((l) => l.code !== current);
 
   // Client-only: don't render the detection banner during SSR (hydration).
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
   const target = mounted ? detectLocale() : current;
   const mismatch = mounted && target !== current;
-  const { showBanner, dismiss, animate } = useLanguageBanner(current, target, mismatch);
+  const { showBanner, dismiss, animate } = useLanguageBanner(target, mismatch);
 
   const CurrentFlag = FLAG[current];
   const TargetFlag = FLAG[target];
@@ -157,13 +188,13 @@ export function LanguageBar() {
             {BANNER[target].message}
           </span>
           <Link
-            href={alt}
+            href={localeUrl(base, target)}
             onClick={dismiss}
             className="inline-flex items-center gap-1 font-medium text-brand hover:text-brand-200 transition-colors"
           >
             {BANNER[target].prefix}
             <TargetFlag className="w-3.5 h-3.5 mx-0.5" />
-            {other.label}
+            {LOCALES.find((l) => l.code === target)!.label}
           </Link>
           <button
             onClick={dismiss}
@@ -174,14 +205,27 @@ export function LanguageBar() {
           </button>
         </div>
       )}
-      <Link
-        href={alt}
-        aria-label={`Idioma: ${current.toUpperCase()} — cambiar a ${other.label}`}
-        className="inline-flex items-center gap-1.5 h-8 px-2.5 rounded-full border bg-fd-card text-sm font-medium text-fd-muted-foreground hover:text-fd-foreground hover:border-fd-primary/40 transition-colors"
-      >
+      {/* Switcher: current locale (highlighted) + a link per other locale. */}
+      <div className="inline-flex items-center gap-1 h-8 px-2 rounded-full border bg-fd-card text-sm">
         <CurrentFlag className="w-3.5 h-3.5" />
-        {LOCALES.find((l) => l.code === current)!.label}
-      </Link>
+        <span className="font-medium text-fd-foreground">
+          {LOCALES.find((l) => l.code === current)!.label}
+        </span>
+        {others.map((l) => {
+          const Flag = FLAG[l.code];
+          return (
+            <Link
+              key={l.code}
+              href={localeUrl(base, l.code)}
+              aria-label={`Switch language to ${l.label}`}
+              className="inline-flex items-center gap-1 pl-1.5 ml-0.5 border-l border-fd-border text-fd-muted-foreground hover:text-fd-foreground transition-colors"
+            >
+              <Flag className="w-3.5 h-3.5" />
+              {l.label}
+            </Link>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/src/lib/i18n-map.ts
+++ b/src/lib/i18n-map.ts
@@ -12,25 +12,38 @@
 
 const ORIGIN = 'https://career-ops.org';
 
-/** Bidirectional hreflang for a docs page that HAS a real ES twin.
- *  Pass the EN page.url (e.g. /docs/introduction/what-is-career-ops); the ES
- *  twin lives at /es + that path. x-default → EN (the canonical language). */
-export function docsHreflang(enUrl: string): Record<string, string> {
-  return {
+/** Non-default locales that can have docs twins. Extend as languages are added
+ *  (each also needs its route group + defineI18n entry). */
+export const DOCS_LOCALES = ['es', 'fr'] as const;
+
+/** Bidirectional hreflang cluster for a docs page, built from the locales that
+ *  actually have a twin. Pass the EN page.url and the subset of DOCS_LOCALES
+ *  whose .<loc>.mdx exists (the caller checks via source.getPage(slug, loc), so
+ *  the cluster is always truthful — never a hand-kept map). Locale URL is
+ *  deterministically /<loc> + the EN path (slugs are not translated). x-default
+ *  → EN (the canonical language). */
+export function docsHreflang(
+  enUrl: string,
+  locales: readonly string[],
+): Record<string, string> {
+  const langs: Record<string, string> = {
     en: `${ORIGIN}${enUrl}`,
-    es: `${ORIGIN}/es${enUrl}`,
     'x-default': `${ORIGIN}${enUrl}`,
   };
+  for (const loc of locales) langs[loc] = `${ORIGIN}/${loc}${enUrl}`;
+  return langs;
 }
 
 /** The home pair: EN at `/`, ES at `/es`. Same bidirectional + x-default → EN
  *  shape, kept explicit because the home is not a Fumadocs docs page. */
 export const HOME_EN = '/';
 export const HOME_ES = '/es';
+export const HOME_FR = '/fr';
 export function hreflangHome(): Record<string, string> {
   return {
     en: `${ORIGIN}/`,
     es: `${ORIGIN}/es`,
+    fr: `${ORIGIN}/fr`,
     'x-default': `${ORIGIN}/`,
   };
 }

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -22,7 +22,10 @@ import { defineI18n } from 'fumadocs-core/i18n';
 //                            hand-kept map (search-ops drift contract, point b).
 export const i18n = defineI18n({
   defaultLanguage: 'en',
-  languages: ['en', 'es'],
+  // 'fr' added 2026-07-21 (French pilot). Same loader-only model: a page has a
+  // French twin iff its .fr.mdx exists; /fr/docs/** is served by an explicit
+  // Next route reusing the EN render. Grows page by page like 'es'.
+  languages: ['en', 'es', 'fr'],
   parser: 'dot',
   hideLocale: 'default-locale',
   fallbackLanguage: null,

--- a/src/lib/layout.shared.tsx
+++ b/src/lib/layout.shared.tsx
@@ -11,7 +11,7 @@ type Options = {
   compact?: boolean;
   // Accepted for backward-compat with the call sites; the language control is
   // now the self-detecting <LanguageBar/>, which reads the locale from the URL.
-  locale?: 'en' | 'es';
+  locale?: 'en' | 'es' | 'fr';
 };
 
 export function baseOptions({ compact = false }: Options = {}): BaseLayoutProps {

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -968,6 +968,45 @@ export function homeFaqSchemaEs() {
   return homeFaqGraph('https://career-ops.org/es/#faq', 'es', HOME_FAQ_ES);
 }
 
+const HOME_FAQ_FR: HomeFaqQA[] = [
+  {
+    q: 'Comment career-ops évalue-t-il les offres d’emploi ?',
+    a: 'career-ops utilise une évaluation par LLM guidée par une grille sur cinq dimensions — adéquation, alignement avec votre cap, rémunération, signaux culturels et red flags — qui produit une note globale de 1.0 à 5.0 avec des citations de lignes précises de votre CV et des exigences de l’offre. En dessous de 4.0, l’agent déconseille de postuler. Pas de formule fermée, pas de candidatures à l’aveugle. La grille complète est publiée sur career-ops.org/methodology.',
+  },
+  {
+    q: 'career-ops postule-t-il à ma place ?',
+    a: 'Il prépare chaque candidature jusqu’au clic : il parcourt les offres, note chacune face à votre CV et adapte un CV. Puis il vous rend la décision. Vous relisez et envoyez chaque candidature vous-même. C’est délibéré : la candidature automatique de masse abîme votre réputation auprès des recruteurs et des ATS ; career-ops vous enlève le travail fastidieux, pas le jugement.',
+  },
+  {
+    q: 'career-ops est-il gratuit ? Quel est le modèle économique ?',
+    a: 'career-ops est gratuit pour toujours, sous licence MIT et financé par la communauté. Pas d’offre payante, pas de liste d’attente, pas de compte, pas de télémétrie, pas de fonctionnalités premium. Vous clonez le dépôt, configurez votre profil et lancez le système en local avec le CLI d’IA que vous utilisez déjà. La pérennité vient du mécénat volontaire de la communauté via GitHub Sponsors, pas d’offres premium, de fonctionnalités payantes ou de données. Le mainteneur a un autre travail rémunéré ; le parrainage lui permet de s’y consacrer davantage. Détails sur career-ops.org/sustain.',
+  },
+  {
+    q: 'Mes données restent-elles sur mon ordinateur ? career-ops est-il privé ?',
+    a: 'Sur votre propre machine, dans des fichiers en clair qui vous appartiennent : votre CV, votre profil, votre pipeline et vos rapports sont du Markdown et du YAML locaux. career-ops tourne entièrement en local via votre CLI d’IA : pas de compte, pas de télémétrie, rien n’est envoyé à un serveur career-ops. Les mises à jour du système ne touchent jamais votre couche de données ; cette séparation est le Data Contract. Les seules données qui quittent votre machine sont celles que votre CLI d’IA envoie à son propre fournisseur.',
+  },
+  {
+    q: 'Qui a créé career-ops ?',
+    a: 'career-ops a été créé par Santiago Fernández de Valderrama Aparicio — un Applied AI Operator avec plus de 16 ans à construire des produits, fondateur et exploitant d’une entreprise espagnole de réparation de téléphones (2009–2025) avant sa revente, et actuellement Head of Applied AI chez Zinkee. Il a créé career-ops début 2026 pour gérer sa propre recherche d’emploi à l’ère de l’IA — 740 offres évaluées, un poste de Head of AI décroché — et l’a publié sous licence MIT une fois qu’il n’en avait plus besoin.',
+  },
+  {
+    q: 'career-ops est-il une skill de Claude Code ou un outil autonome ?',
+    a: 'career-ops est indépendant du CLI. Il fonctionne avec Claude Code, OpenCode, Codex, GitHub Copilot et d’autres — l’agent de codage IA que l’utilisateur paie déjà. Les fichiers de skill (modes/) vivent dans le dépôt sous forme de prompts markdown ; tout agent qui prend en charge le chargement de skills peut les invoquer. Aucune dépendance spécifique à Anthropic. Claude Code est le runtime le plus courant grâce à son chargeur de skills, mais les mêmes modes fonctionnent sans changement dans les autres CLIs.',
+  },
+  {
+    q: 'En quoi career-ops diffère-t-il des correcteurs de CV et des outils de candidature automatique ?',
+    a: 'career-ops est open source et sous licence MIT, tourne en local sur votre propre machine via le CLI de codage IA que vous utilisez déjà, et publie sa grille d’évaluation complète. Un humain garde la main sur chaque candidature ; il n’envoie jamais tout seul. Pas de compte, pas de télémétrie, pas d’abonnement à career-ops lui-même ; le seul coût récurrent est le CLI d’IA que vous choisissez. Pour des comparaisons honnêtes, côte à côte, avec des outils précis, voyez career-ops.org/compare.',
+  },
+  {
+    q: 'Avec quels outils d’IA career-ops fonctionne-t-il ?',
+    a: 'Claude Code, Codex, OpenCode, Antigravity CLI, Grok Build CLI, Qwen, Kimi et GitHub Copilot CLI — huit CLIs de premier plan (Gemini CLI est un wrapper legacy). Les mêmes fichiers de mode fonctionnent sur tous. Chacun choisit le CLI qui correspond à son abonnement et à ses préférences de coût — career-ops ne vous enferme jamais chez un seul fournisseur. Une recherche d’emploi typique tourne sur Claude Pro à 20 $/mois, mais le choix vous appartient.',
+  },
+];
+
+export function homeFaqSchemaFr() {
+  return homeFaqGraph('https://career-ops.org/fr/#faq', 'fr', HOME_FAQ_FR);
+}
+
 // /blog/[slug] — BlogPosting schema. Author is the canonical Person
 // entity via @id; publisher is the same Person (single-author blog).
 // dateModified is the freshness signal Google ranks on.


### PR DESCRIPTION
Rolls **French** out end-to-end as a third locale — the "scale to N languages" the i18n architecture was built for. French headings/questions are **transcreated from search-ops's measured French fan-out** (`fanout-fr-2026-W30`), not calqued.

## Architecture (add-a-locale, reusable for the next language)
- `defineI18n` languages += `'fr'`; `.fr.mdx` sit next to `.mdx` (dot parser), `fallbackLanguage:null` (a page has a FR twin iff its `.fr.mdx` exists).
- New **`/fr/(home)` + `/fr/docs`** routes mirror the ES ones, reusing the SAME render trunks (`HomeContent`+dict, `DocsPageView`). Untranslated `/fr/docs` slugs redirect to EN, so a toggle never 404s.
- **hreflang generalized** to be source-derived across all locales: `docsHreflang` now takes the subset of `DOCS_LOCALES` that actually have a twin, so each doc's `en/es/fr/x-default` cluster is always truthful. Sitemap + `hreflangHome` gain `fr`.
- `translate.mjs` takes `--lang` (fr added; ES prompt corrected to neutral panhispanic per search-ops doctrine). `hash.mjs` CLI guarded (importing `contentHash` was reading a stray `--lang` as a file).
- **Language switcher is now N-locale (EN/ES/FR)** instead of a 2-way toggle: current locale + one link per other, each resolving to a SAFE URL. Footer locale links likewise (manifesto stays EN on `/fr` — no `/fr/manifesto` yet).

## Content (search-ops priority: grounded wins first — what-is + faq)
- **3 docs** auto-translated (`claude -p`) then framed: free-ai-engine leads with the category (M4); faq carries the measured killers **«career-ops postule-t-il à ma place ?»** (auto-apply skepticism answered positive — the French cultural concern), **«Mes données restent-elles sur mon ordinateur ?»**, **«…vraiment gratuit et open source ?»**.
- **/fr home** (`homeFr`): full French copy, FAQ transcreated to the fan-out. The signature **thesis stays literal English** (no official French translation until venture-ops ratifies), so `homeFr` has no `thesisTranslation`. `homeFaqSchemaFr` emits the FR FAQPage.

## Verification
- `npm run build` ✓ · `types:check` ✓
- `/fr` + `/fr/docs/{what-is, free-ai-engine, faq}` generated; hreflang `en/es/fr` verified on `/fr` and `/fr/docs/faq`; FR FAQPage `/fr/#faq` present; sitemap emits the fr cluster.
- **EN URL set unchanged** (the pilot adds only `/fr` URLs).

/cc search-ops for the prod hreflang + copy audit once merged (per the fanout hand-off). URL set: `career-ops.org/fr`, `/fr/docs/introduction/what-is-career-ops`, `/fr/docs/faq`, `/fr/docs/free-ai-engine`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)