### PR TITLE
feat(i18n): full French docs parity (30/30) — fixes English leak on docs entry

### DIFF
--- a/content/docs/index.fr.mdx
+++ b/content/docs/index.fr.mdx
@@ -1,0 +1,253 @@
+---
+title: Démarrage rapide
+description: "Démarrez avec career-ops en cinq minutes : installez le système open source de recherche d'emploi par IA, ouvrez votre CLI d'IA et évaluez votre première offre. Aucune connaissance en code requise."
+seoTitle: "career-ops Démarrage rapide — installez et lancez votre premier scan d'offres par IA en quelques minutes"
+icon: Rocket
+translationHash: 38326ebbdfbb6602
+localized: true
+translatedFrom: /docs
+---
+
+Ce guide vous emmène de zéro à votre première offre évaluée en cinq minutes environ. Vous allez préparer l'espace de travail, ouvrir votre assistant de codage IA, le laisser vous embarquer au fil d'une conversation, puis coller une offre d'emploi — career-ops vous rend un rapport complet, un score et un CV PDF sur mesure.
+
+## Ce qu'il vous faut
+
+Vous n'avez pas besoin de savoir coder. Il vous suffit d'être à l'aise pour ouvrir un terminal et lancer une commande.
+
+<Callout title="Vous débutez avec le terminal ?">
+  Si vous n'avez jamais utilisé de ligne de commande, ce n'est pas un problème — mais ce guide n'est pas le bon endroit pour l'apprendre. Pour vous mettre à niveau rapidement, lisez le manuel [Command Line for Beginners](https://www.freecodecamp.org/news/command-line-for-beginners/) de freeCodeCamp. Il couvre tout ce dont vous avez besoin pour suivre ce guide. Une fois à l'aise pour ouvrir un terminal et lancer une commande, revenez et reprenez à l'étape 1.
+</Callout>
+
+<div className="rounded-lg bg-radial-[at_bottom] from-blue-500/20 p-4 border bg-origin-border border-fd-primary/10 prose-no-margin dark:bg-black/20">
+  <div className="rounded-xl bg-fd-background p-3">
+    <Steps>
+      <Step>
+      ### Assistant de codage IA
+
+      Installez **[Claude Code](https://claude.ai/code)**, **[Gemini CLI](https://github.com/google-gemini/gemini-cli)**, **[Codex](https://developers.openai.com/codex/cli)**, **[Qwen Code](https://qwen.ai/qwencode)**, **[OpenCode](https://opencode.ai/)** ou **[GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli)** — l'assistant de codage IA qui fait tourner ce système. career-ops fonctionne avec tous. Connectez-vous avant de continuer.
+      </Step>
+      <Step>
+        ### Node.js 20 LTS ou ultérieur
+
+        Installez **[Node.js](https://nodejs.org) en version 20 LTS ou ultérieure** — un runtime JavaScript utilisé pour générer les PDF et exécuter les scripts auxiliaires.
+      </Step>
+      <Step>
+        ### Git
+
+        Installez **[Git](https://git-scm.com/)** — utilisé en interne par le scaffolder. La plupart des ordinateurs l'ont déjà. Pour vérifier, ouvrez un terminal et exécutez `git --version`.
+      </Step>
+    </Steps>
+  </div>
+</div>
+
+## Étape 1 : préparer l'espace de travail
+
+Ouvrez un terminal dans le dossier où vous voulez installer career-ops. La voie recommandée tient en une seule commande ; une voie avancée avec `git clone` se trouve juste en dessous. Si Node 20+ ou Git manquent, `npx` refusera de s'exécuter — installez-les d'abord (voir les prérequis ci-dessus).
+
+### Recommandé — une seule commande
+
+```bash title="Terminal"
+npx @santifer/career-ops init
+```
+
+Cette commande clone la dernière release dans `./career-ops`, installe les dépendances et met en place la structure de l'espace de travail. Elle détecte aussi quel CLI de codage IA vous avez installé et vous indique la bonne commande pour démarrer. La commande est idempotente — la relancer n'écrase jamais les fichiers que vous avez déjà.
+
+Une fois terminé, placez-vous dans l'espace de travail :
+
+```bash title="Terminal"
+cd career-ops
+```
+
+<details>
+<summary>Avancé — clonez le dépôt vous-même</summary>
+
+Choisissez cette voie si vous voulez suivre une branche précise, contribuer au projet ou auditer le code avant d'installer les dépendances.
+
+```bash title="Terminal"
+git clone https://github.com/santifer/career-ops.git
+cd career-ops
+npm install
+```
+
+</details>
+
+### Navigateur headless (une seule fois)
+
+career-ops utilise un Chromium headless pour plusieurs tâches : générer les PDF, vérifier si les annonces sont toujours en ligne et exécuter des scans ATS complets. L'installateur le configure automatiquement après les dépendances ; si cette étape a échoué sur votre machine, installez-le manuellement :
+
+```bash title="Terminal"
+npx playwright install chromium
+```
+
+## Étape 2 : ouvrir votre assistant IA
+
+Depuis l'intérieur du dossier `career-ops`, lancez le CLI de codage IA que vous avez installé.
+
+<Tabs items={["Claude Code", "Gemini CLI", "Codex", "Qwen Code", "OpenCode", "GitHub Copilot CLI"]}>
+  <Tab value="Claude Code">
+    ```bash title="Terminal"
+    claude
+    ```
+  </Tab>
+  <Tab value="Gemini CLI">
+    ```bash title="Terminal"
+    gemini
+    ```
+  </Tab>
+  <Tab value="Codex">
+    ```bash title="Terminal"
+    codex
+    ```
+  </Tab>
+  <Tab value="Qwen Code">
+    ```bash title="Terminal"
+    qwen
+    ```
+  </Tab>
+  <Tab value="OpenCode">
+    ```bash title="Terminal"
+    opencode
+    ```
+  </Tab>
+  <Tab value="GitHub Copilot CLI">
+    ```bash title="Terminal"
+    copilot
+    ```
+  </Tab>
+</Tabs>
+
+<Callout title="L'agent se présentera de lui-même">
+  La première fois que vous lancez votre CLI dans l'espace de travail, l'agent career-ops démarre une courte conversation d'onboarding. Il vous demande votre CV, les types de postes que vous visez, votre fourchette de rémunération et vos préférences de localisation. Rien ne s'édite à la main — vous répondez en langage naturel et l'agent écrit les fichiers de configuration pour vous. La session prend environ deux à trois minutes.
+</Callout>
+
+<Callout title="Une question sans rapport que vous pourriez voir">
+  Certains CLI (Claude Code, par exemple) vous demandent si vous faites confiance aux fichiers d'un nouveau dossier la première fois que vous l'ouvrez. Cette question vient du CLI lui-même, pas de career-ops — répondez oui pour continuer. L'onboarding de career-ops démarre juste après.
+</Callout>
+
+## Étape 3 : lancer votre première évaluation
+
+Une fois l'onboarding terminé, vous êtes prêt à évaluer une vraie offre d'emploi. Copiez l'URL de n'importe quelle annonce et collez-la dans le chat. Avec Claude Code, préfixez-la avec la commande explicite ; avec les autres CLI, collez l'URL et demandez à l'agent de lancer l'auto-pipeline :
+
+<Tabs items={["Claude Code", "Gemini CLI", "Codex", "Qwen Code", "OpenCode", "GitHub Copilot CLI"]}>
+  <Tab value="Claude Code">
+    ```bash
+    /career-ops auto-pipeline https://jobs.example.com/senior-engineer-ai
+    ```
+  </Tab>
+  <Tab value="Gemini CLI">
+    ```bash
+    Run the auto-pipeline command with the job URL: https://jobs.example.com/senior-engineer-ai
+    ```
+  </Tab>
+  <Tab value="Codex">
+    ```bash
+    Run the auto-pipeline command with the job URL: https://jobs.example.com/senior-engineer-ai
+    ```
+  </Tab>
+  <Tab value="Qwen Code">
+    ```bash
+    Run the auto-pipeline command with the job URL: https://jobs.example.com/senior-engineer-ai
+    ```
+  </Tab>
+  <Tab value="OpenCode">
+    ```bash
+    Run the auto-pipeline command with the job URL: https://jobs.example.com/senior-engineer-ai
+    ```
+  </Tab>
+  <Tab value="GitHub Copilot CLI">
+    ```bash
+    Run the auto-pipeline command with the job URL: https://jobs.example.com/senior-engineer-ai
+    ```
+  </Tab>
+</Tabs>
+
+Si vous n'avez pas d'URL, collez à la place le texte complet de la description du poste dans le chat. L'agent reconnaît l'un comme l'autre comme une offre d'emploi et exécute automatiquement le pipeline complet — c'est l'**auto-pipeline**.
+
+### Ce qui se passe ensuite
+
+Une fois l'offre collée, career-ops fait tout ce qui suit de lui-même :
+
+<div className="rounded-lg bg-radial-[at_bottom] from-blue-500/20 p-4 border bg-origin-border border-fd-primary/10 prose-no-margin dark:bg-black/20">
+  <div className="rounded-xl bg-fd-background p-3">
+    <Steps>
+      <Step>
+        ### Lecture de la description du poste
+        Il comprend le poste, les exigences et la rémunération.
+      </Step>
+      <Step>
+        ### Lecture de votre CV
+        Il s'appuie sur `cv.md` pour repérer les correspondances et les lacunes par rapport au poste.
+      </Step>
+      <Step>
+        ### Notation de l'offre
+        Il note le poste de 0 à 5 sur plusieurs dimensions, comme l'adéquation au rôle, la rémunération et la politique de télétravail.
+      </Step>
+      <Step>
+        ### Rédaction d'un rapport
+        Il enregistre une analyse détaillée dans le dossier `reports/`.
+      </Step>
+      <Step>
+        ### Génération d'un CV PDF sur mesure
+        Il produit une version de votre CV adaptée à cette offre précise dans le dossier `output/`.
+      </Step>
+      <Step>
+        ### Ajout d'une ligne à votre tracker
+        Il consigne la candidature dans `data/applications.md`.
+      </Step>
+    </Steps>
+  </div>
+</div>
+
+L'ensemble du processus prend environ une à deux minutes. À la fin, career-ops vous montre le score et un résumé du rapport.
+
+## Lire vos résultats
+
+Ouvrez le fichier de rapport dans `reports/`. Le nom du fichier suit le motif `{number}-{company}-{date}.md`. À l'intérieur, vous trouverez :
+
+- **Score** — un nombre de 0.0 à 5.0. En dessous de 4.0, l'offre n'est probablement pas très adaptée à votre profil.
+- **Bloc A** — un résumé du poste en langage clair.
+- **Bloc B** — un tableau montrant comment votre CV répond à chaque exigence du poste, ainsi que les lacunes éventuelles.
+- **Bloc C** — une recommandation de stratégie pour vous positionner sur ce poste.
+- **Bloc D** — une étude de rémunération comparant l'offre aux taux du marché.
+- **Bloc E** — des notes de personnalisation pour votre candidature.
+- **Bloc F** — une préparation à l'entretien avec des histoires STAR adaptées à cette offre.
+- **Bloc G** — légitimité de l'annonce : une vérification que l'offre est réelle et n'est ni une arnaque ni un « ghost job ».
+
+Votre CV PDF sur mesure se trouve dans le dossier `output/`. Relisez-le avant de l'envoyer où que ce soit — career-ops ne soumet jamais rien sans votre accord.
+
+## Et ensuite ?
+
+Maintenant que votre première évaluation est terminée, voici quelques pistes à explorer :
+
+- **Affinez votre profil.** Dites quelque chose de nouveau à l'agent sur vous — *« Voici plus de contexte : je viens de livrer X. »* Il met le profil à jour et les évaluations suivantes gagnent en précision.
+- **Évaluez d'autres offres.** Collez d'autres URL ou descriptions. Chacune vient s'ajouter à votre tracker.
+- **Scannez les job boards.** Tapez `/career-ops scan` pour parcourir d'un coup des dizaines de pages carrières d'entreprises préconfigurées.
+- **Comparez les offres.** Si vous avez plusieurs rapports, tapez `/career-ops ofertas` pour obtenir un comparatif classé.
+
+## Dépannage
+
+<Accordions>
+  <Accordion title="L'agent n'a pas lancé l'onboarding">
+    Vérifiez que vous avez lancé votre CLI depuis l'intérieur du dossier `career-ops` (exécutez `pwd` pour vérifier). Relancez le CLI depuis le bon chemin et dites à l'agent : *« merci de lancer l'onboarding de première utilisation. »* Il reprendra la conversation depuis le début.
+  </Accordion>
+  <Accordion title="Le rapport ne s'est pas généré">
+    Vérifiez que `cv.md` existe à la racine du dossier et qu'il contient bien quelque chose. Si l'onboarding s'est terminé mais que `cv.md` est vide, demandez à l'agent : *« mon cv.md a l'air vide, peux-tu m'aider à le remplir ? »*
+  </Accordion>
+  <Accordion title="Le PDF ne s'est pas généré">
+    Relancez `npx playwright install chromium`. Si cela ne règle pas le problème, vérifiez que Node.js est en version 18 ou supérieure en exécutant `node --version`.
+  </Accordion>
+  <Accordion title="Le score semble incohérent">
+    Les premières évaluations sont approximatives — le système ne vous connaît pas encore bien. Après chaque évaluation, dites à votre assistant IA ce qu'il a mal jugé. Par exemple : *« Ce score est trop élevé — je n'ai aucune expérience avec Kubernetes. »* Il apprendra et s'ajustera.
+  </Accordion>
+  <Accordion title="Autre chose ne fonctionne pas">
+    Demandez directement à votre assistant IA : *« Qu'est-ce qui ne va pas dans mon installation ? »* S'il n'arrive pas à poser un diagnostic, exécutez `npm run doctor` pour un bilan de santé complet.
+  </Accordion>
+</Accordions>
+
+## Un bug ou une question ?
+
+Si quelque chose ne fonctionne pas comme ce guide l'indique, merci de le signaler. Les rapports de bug aident tous ceux qui viendront après vous.
+
+- **Signaler un bug :** ouvrez une issue sur le [dépôt GitHub](https://github.com/santifer/career-ops/issues). Décrivez ce que vous attendiez, ce qui s'est réellement passé, et collez tout message d'erreur que vous avez vu.
+- **Poser une question :** rejoignez la [communauté Discord](https://discord.gg/8pRpHETxa4). C'est le moyen le plus rapide d'obtenir de l'aide auprès des autres utilisateurs et de l'auteur.
+- **Contribuer un correctif :** si vous savez corriger le problème vous-même, lisez [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md) avant d'ouvrir une pull request. En résumé : ouvrez d'abord une issue pour discuter du changement, puis soumettez votre PR.

--- a/content/docs/introduction/guides/apply-for-a-job.fr.mdx
+++ b/content/docs/introduction/guides/apply-for-a-job.fr.mdx
@@ -1,0 +1,147 @@
+---
+title: Postuler à une offre d'emploi
+description: Utilisez career-ops pour remplir vos candidatures avec des réponses adaptées à votre profil et au poste visé.
+seoTitle: "Comment postuler à un emploi avec career-ops — rédigez vos réponses ATS, adaptez votre CV"
+icon: FileInput
+translationHash: f2922090f40c99ec
+localized: true
+translatedFrom: /docs/introduction/guides/apply-for-a-job
+---
+
+Ce guide vous montre comment utiliser `/career-ops apply` pour remplir un formulaire de candidature avec des réponses adaptées à votre profil, à vos points de preuve et au poste précis auquel vous postulez.
+
+<Callout title="Avant de commencer">
+  Assurez-vous d'avoir terminé le guide [Scanner les portails d'emploi](./scan-job-portals.mdx). La commande `apply` dépend d'un rapport d'évaluation existant. Si aucun rapport n'existe pour le poste, lancez d'abord le pipeline.
+</Callout>
+
+## Lancer la commande apply
+
+Ouvrez votre CLI agentique dans le dossier racine de career-ops et tapez :
+
+<Tabs items={["Claude Code", "Codex", "OpenCode", "Qwen CLI"]}>
+  <Tab value="Claude Code">
+    ```bash
+    /career-ops apply {company_name}
+    ```
+  </Tab>
+  <Tab value="Codex">
+    ```bash
+    Run the /career-ops apply command with the {company_name} argument.
+    ```
+  </Tab>
+  <Tab value="OpenCode">
+    ```bash
+    Run the /career-ops apply command with the {company_name} argument.
+    ```
+  </Tab>
+  <Tab value="Qwen CLI">
+    ```bash
+    Run the /career-ops apply command with the {company_name} argument.
+    ```
+  </Tab>
+</Tabs>
+
+Par exemple :
+
+```bash title="Claude Code"
+/career-ops apply Anthropic
+```
+
+career-ops trouve le rapport correspondant dans `reports/`, utilise Playwright pour ouvrir une fenêtre de navigateur et lit le formulaire. Il génère ensuite une réponse pour chaque champ — prête à copier-coller. Vous n'avez pas besoin d'ouvrir le navigateur vous-même.
+
+<Callout title="Remarque">
+  Si Playwright n'est pas disponible, career-ops se rabat sur WebFetch pour lire le formulaire. Consultez [Configurer Playwright](./set-up-playwright.mdx) si vous souhaitez activer l'expérience complète via le navigateur.
+</Callout>
+
+**Si vous lancez la commande `/career-ops apply` sans arguments**, le système vous invite à fournir le contexte manuellement :
+<div className="rounded-lg bg-radial-[at_bottom] from-blue-500/20 p-4 border bg-origin-border border-fd-primary/10 prose-no-margin dark:bg-black/20">
+  <div className="rounded-xl bg-fd-background p-3">
+    | Option                              | Comment                                                                                                     |
+    | ----------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+    | Partager une capture d'écran        | Faites une capture d'écran du formulaire et partagez-la dans le chat. career-ops lit les images directement. |
+    | Coller les questions                | Copiez les questions du formulaire sous forme de texte et collez-les dans le chat.                          |
+    | Indiquer l'entreprise et le poste   | Tapez le nom de l'entreprise et l'intitulé du poste. career-ops recherche la correspondance dans `reports/`. |
+    | Partager l'URL de la candidature    | Collez l'URL et career-ops navigue jusqu'au formulaire.                                                     |
+  </div>
+</div>
+
+## Remplir le formulaire
+
+Le système renvoie une liste numérotée de réponses — une par champ du formulaire — qui suit l'ordre du formulaire. Parcourez la liste de haut en bas et collez chaque réponse dans le champ correspondant.
+
+La sortie comporte deux parties :
+
+**Réponses** — chaque champ du formulaire, dans l'ordre :
+
+```
+1. Name
+   Andres Urdaneta
+
+2. Email
+   andres@example.com
+
+...
+
+12. Cover Letter (optional)
+    I've spent 5+ years shipping production Rails applications...
+```
+
+Les champs simples comme le nom, l'e-mail et les questions oui/non viennent en premier. Les champs de texte libre comme la lettre de motivation arrivent à la fin.
+
+**Key notes** — un court bloc après les réponses avec tout ce qui mérite d'être signalé avant l'envoi :
+
+```
+Key notes:
+- No salary field — you'll negotiate at offer. Anchor to $160K–$175K at offer stage.
+- Add github.com/yourhandle to your resume PDF before uploading.
+- Cover letter is optional but the draft above is tight — worth including.
+```
+
+Chaque réponse est construite à partir d'une partie précise de votre rapport d'évaluation :
+
+<div className="rounded-lg bg-radial-[at_bottom] from-blue-500/20 p-4 border bg-origin-border border-fd-primary/10 prose-no-margin dark:bg-black/20">
+  <div className="rounded-xl bg-fd-background p-3">
+    | Type de champ                              | Source                                                          |
+    | ------------------------------------------ | --------------------------------------------------------------- |
+    | Lettre de motivation, « pourquoi ce poste » | Points de preuve du bloc B + récits STAR du bloc F              |
+    | Questions courtes en texte libre            | Le point de preuve ou le récit le plus pertinent pour la question |
+    | Menus déroulants, oui/non                   | Réponses directes extraites de votre profil                     |
+  </div>
+</div>
+
+<Callout title="Champs d'upload">
+  Utilisez le fichier dans `output/` généré lors de la création du rapport. Si aucun PDF n'existe encore, lancez d'abord `/career-ops pdf`, puis revenez au formulaire. Consultez [Générer un PDF](generate-a-pdf.md).
+</Callout>
+
+## Envoyer la candidature
+
+Relisez chaque réponse, puis envoyez le formulaire vous-même. career-ops ne clique pas sur le bouton Submit.
+
+Après l'envoi, confirmez dans le chat :
+
+> "Submitted."
+
+career-ops va alors :
+
+<div className="rounded-lg bg-radial-[at_bottom] from-blue-500/20 p-4 border bg-origin-border border-fd-primary/10 prose-no-margin dark:bg-black/20">
+  <div className="rounded-xl bg-fd-background p-3">
+    <Steps>
+      <Step title="Mettre à jour le statut de la candidature">
+        Mettre à jour `data/applications.md` — en faisant passer le statut de `Evaluated` à `Applied`
+      </Step>
+      <Step title="Enregistrer les réponses dans le rapport">
+        Enregistrer les réponses finales dans la section G du rapport pour référence ultérieure
+      </Step>
+    </Steps>
+  </div>
+</div>
+
+## Que faire ensuite
+<div className="rounded-lg bg-radial-[at_bottom] from-blue-500/20 p-4 border bg-origin-border border-fd-primary/10 prose-no-margin dark:bg-black/20">
+  <div className="rounded-xl bg-fd-background p-3">
+    | Score              | Étape suivante                                                                                                                                                                                                              |
+    | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | **4.0 ou plus**    | Lancez `/career-ops contacto`. career-ops trouve un responsable du recrutement ou un membre de l'équipe sur LinkedIn et rédige un message de prise de contact. L'envoyer avant que votre candidature ne soit examinée améliore votre visibilité. |
+    | **Quel que soit le score** | Lancez `/career-ops tracker` pour voir le statut actuel de tout ce qui se trouve dans votre pipeline.                                                                                                                |
+  </div>
+</div>

--- a/content/docs/introduction/guides/batch-evaluate-offers.fr.mdx
+++ b/content/docs/introduction/guides/batch-evaluate-offers.fr.mdx
@@ -1,0 +1,157 @@
+---
+title: Évaluer des offres par lot
+description: Traitez plus de 10 offres d'emploi en une seule session avec des workers IA parallèles et des PDF sur mesure.
+seoTitle: "Évaluez des offres d'emploi par lot avec career-ops — notez-en plusieurs à la fois"
+icon: FileStack
+translationHash: 5abe712784127777
+localized: true
+translatedFrom: /docs/introduction/guides/batch-evaluate-offers
+---
+
+Utilisez ce guide lorsque vous avez 10 offres d'emploi ou plus à examiner et que vous souhaitez toutes les traiter en une seule session plutôt qu'une par une.
+
+Chaque offre dispose de son propre worker Claude. Ce worker lit votre CV, note la correspondance, rédige un rapport complet et enregistre un PDF sur mesure — sans que vous ayez à lever le petit doigt.
+
+## Étape 1 : Ajoutez vos offres au fichier d'entrée
+
+Le système de traitement par lot lit les URL des offres depuis un fichier nommé **`batch/batch-input.tsv`**. Voyez-le comme une liste de tâches pour l'évaluateur.
+
+<div className="rounded-lg bg-radial-[at_bottom] from-blue-500/20 p-4 border bg-origin-border border-fd-primary/10 prose-no-margin dark:bg-black/20">
+  <div className="rounded-xl bg-fd-background p-3">
+    <Steps>
+      <Step>
+        Ouvrez **`batch/batch-input.tsv`** dans n'importe quel éditeur de texte.
+      </Step>
+      <Step>
+        Ajoutez une ligne par offre. Chaque ligne comporte quatre colonnes séparées par une tabulation :
+
+        | Colonne | Que saisir |
+        |--------|---------------|
+        | `id` | Un numéro unique pour cette offre (1, 2, 3, …) |
+        | `url` | L'URL complète de l'annonce |
+        | `source` | Où vous l'avez trouvée (par ex. `LinkedIn`, `Greenhouse`) |
+        | `notes` | Une note facultative — laissez vide si vous n'en avez pas |
+      </Step>
+      <Step>
+        Enregistrez le fichier.
+      </Step>
+    </Steps>
+  </div>
+</div>
+
+**Exemple :**
+
+```text title="batch-input.tsv"
+id	url	source	notes
+1	https://jobs.example.com/senior-engineer	LinkedIn	
+2	https://greenhouse.io/jobs/fullstack-dev	Greenhouse	priority
+3	https://builtinaustin.com/job/rails-dev	BuiltIn	
+```
+
+<Callout title="Astuce">
+  Chaque ID doit être un numéro unique. Ne sautez pas de numéros et ne les répétez pas.
+</Callout>
+
+## Étape 2 : Prévisualisez votre lot (recommandé)
+
+Avant de traiter quoi que ce soit, lancez une vérification rapide pour voir combien d'offres sont en attente. Rien n'est encore évalué — il s'agit simplement d'un aperçu.
+
+```bash title="Terminal"
+./batch/batch-runner.sh --dry-run
+```
+
+Vous verrez la liste des offres en attente et leurs ID. Si quelque chose semble incorrect, corrigez le fichier d'entrée maintenant, avant de perdre du temps sur une mauvaise liste.
+
+## Étape 3 : Lancez le lot
+
+Quand vous êtes prêt, démarrez le lot. Vous pouvez traiter une offre à la fois ou plusieurs en même temps.
+
+**Une à la fois (le plus lent, consomme le moins de mémoire) :**
+
+```bash title="Terminal"
+./batch/batch-runner.sh
+```
+
+**Deux à la fois (un bon réglage par défaut) :**
+
+```bash title="Terminal"
+./batch/batch-runner.sh --parallel 2
+```
+
+**Trois à la fois (plus rapide, mais plus lourd pour votre machine) :**
+
+```bash title="Terminal"
+./batch/batch-runner.sh --parallel 3
+```
+
+**Ignorer les offres dont la note est inférieure à un seuil (par ex. en dessous de 4,0 sur 5) :**
+
+```bash title="Terminal"
+./batch/batch-runner.sh --parallel 2 --min-score 4.0
+```
+
+Surveillez le terminal pendant l'exécution du lot. Chaque ligne vous indique quelle offre est en cours de traitement et si elle s'est terminée ou a échoué.
+
+## Étape 4 : Consultez les résultats au fur et à mesure
+
+Vous n'avez pas besoin d'attendre la fin du lot. Les résultats apparaissent à mesure que chaque offre est traitée.
+
+**Rapports d'évaluation complets** → `reports/`
+
+Chaque rapport est un fichier nommé par exemple `042-company-name-2026-04-14.md`. Ouvrez-le pour consulter :
+
+- Un résumé du poste
+- Le degré de correspondance entre votre CV et l'offre
+- Une recherche sur le salaire
+- Un plan de préparation d'entretien suggéré
+
+**Entrées de tracker en une ligne** → `batch/tracker-additions/`
+
+Chaque offre dépose également un court fichier de synthèse ici. Ces fichiers seront ajoutés à votre tracker principal à l'étape 6.
+
+## Étape 5 : Relancez les offres en échec
+
+Il arrive qu'un worker échoue — par exemple si l'URL d'une annonce ne se charge plus. Les offres en échec apparaissent dans le terminal avec un court message d'erreur.
+
+**Relancer uniquement les offres en échec :**
+
+```bash title="Terminal"
+./batch/batch-runner.sh --retry-failed
+```
+
+**Relancer avec jusqu'à 3 tentatives au lieu des 2 par défaut :**
+
+```bash title="Terminal"
+./batch/batch-runner.sh --retry-failed --max-retries 3
+```
+
+Le lot ignore toute offre déjà traitée avec succès — relancer cette commande est donc toujours sans risque.
+
+## Étape 6 : Fusionnez les résultats dans votre tracker
+
+Une fois le lot terminé, exécutez cette commande pour ajouter toutes les nouvelles évaluations à `data/applications.md` :
+
+```bash title="Terminal"
+node merge-tracker.mjs
+```
+
+Ce script :
+
+1. Lit les fichiers de synthèse depuis `batch/tracker-additions/`
+2. Vérifie les doublons pour que vous n'ayez jamais deux lignes pour la même offre
+3. Ajoute les nouvelles entrées à votre tracker de candidatures
+4. Archive les fichiers traités dans `batch/tracker-additions/merged/`
+
+**Pour prévisualiser les changements sans rien écrire :**
+
+```bash title="Terminal"
+node merge-tracker.mjs --dry-run
+```
+
+## Et ensuite ?
+
+Ouvrez **`data/applications.md`** pour voir toutes vos évaluations dans un seul tableau. De là, vous pouvez :
+
+- Trier par note pour repérer vos meilleures correspondances
+- Ouvrir les rapports individuels dans `reports/` pour une analyse approfondie
+- Lancer le processus de candidature pour vos meilleures offres avec `/career-ops apply`

--- a/content/docs/introduction/guides/interview-modes.fr.mdx
+++ b/content/docs/introduction/guides/interview-modes.fr.mdx
@@ -1,0 +1,66 @@
+---
+title: Se préparer aux entretiens
+description: Utilisez les modes interview — plan, practice, debrief — pour préparer un tour d'entretien précis, le répéter avec un intervieweur IA et transformer chaque entretien réel en enseignements pour le suivant.
+seoTitle: "Préparation aux entretiens avec career-ops — une préparation tour par tour"
+icon: GraduationCap
+translationHash: 684f86b0ae8151c2
+localized: true
+translatedFrom: /docs/introduction/guides/interview-modes
+---
+
+Les modes interview constituent le système de préparation aux entretiens de career-ops, livré dans la v1.16.0 : `interview/plan` construit un plan de préparation découpé en blocs horaires pour un tour précis, `interview/practice` mène un entretien blanc réaliste, une question à la fois, et `interview/debrief` consigne ce qui s'est réellement passé pour que le tour suivant démarre plus intelligemment. Ensemble, ils forment une boucle — planifier, s'entraîner, passer l'entretien, débriefer, recommencer — dont les effets se cumulent tout au long d'un processus de recrutement.
+
+Ils complètent le [mode `interview-prep`](/docs/reference/modes/interview-prep), plus ancien, qui construit votre socle durable (banque d'histoires, banque de questions). Les trois modes ciblés, eux, portent sur un *tour précis à venir*.
+
+<Callout title="Ce qu'il vous faut d'abord">
+Un espace de travail avec votre `cv.md` et votre `config/profile.yml` en place (le [Démarrage rapide](/docs) configure les deux). Les modes les lisent pour ancrer chaque plan et chaque retour dans votre expérience réelle — pas dans des conseils d'entretien génériques.
+</Callout>
+
+## La boucle en un coup d'œil
+
+| Mode | Quand | Ce que vous obtenez |
+| --- | --- | --- |
+| `interview/plan` | Dès qu'un tour est programmé | Un plan de préparation en blocs horaires, dimensionné selon les heures dont vous disposez réellement |
+| `interview/practice` | Avant le tour | Un entretien blanc réaliste avec un retour structuré pour chaque réponse |
+| `interview/debrief` | Juste après l'entretien réel | Une évaluation honnête question par question + une banque de questions mise à jour |
+
+## Plan : transformer une date en planning
+
+Donnez à `interview/plan` la description du poste ainsi que la date et l'heure de l'entretien, plus le type de tour et le nom de l'intervieweur si vous les connaissez. Il lit votre CV et votre profil, réalise une évaluation honnête de votre adéquation au poste — points forts sur lesquels vous appuyer, lacunes susceptibles d'être testées — et répartit les heures qu'il vous reste en blocs de préparation concrets.
+
+```txt title="Example"
+/career-ops interview/plan
+
+→ Inputs: JD (pasted), interview Thursday 14:00, HM screen with Ana (Eng Manager)
+→ Fit assessment: 4 strengths to anchor · 2 gaps ranked by test likelihood
+→ Plan (9 hours available):
+   Block 1 — Lock your narrative (~1.5h): timeline, "why us", strongest proof point
+   Block 2 — Gap: event-driven architectures (~3h)
+   Block 3 — Behavioral stories, STAR+R (~2h)
+   Block 4 — Mock run + comp answer (~1.5h)
+```
+
+Le plan se calibre selon le tour : un échange de présélection avec un recruteur reçoit de la logistique et du récit, pas des détails techniques pointus ; un entretien approfondi avec un praticien reçoit de la profondeur sur la compétence centrale de la fiche de poste. Si une banque de questions issue d'un tour précédent existe, tout ce qui vous a posé problème reçoit un bloc dédié — les données de performance réelles priment sur le risque supposé.
+
+## Practice : répéter face à un intervieweur réaliste
+
+`interview/practice` joue le rôle de l'intervieweur — avec son nom et sa fonction si vous les fournissez — et pose une question à la fois, sans sortir de son personnage, avec des relances naturelles là où un véritable intervieweur creuserait. Après chaque réponse, vous recevez un retour structuré : ce qui a fait mouche, ce qu'il faut resserrer, et une version plus solide de votre réponse, ancrée dans votre CV réel et votre banque d'histoires.
+
+Il suit aussi la session comme le ferait un intervieweur : si vous ressortez deux fois la même histoire, il signale que votre répertoire d'exemples paraît mince ; si votre réponse se conclut sur le mauvais domaine pour le poste, il vous indique où la faire atterrir à la place.
+
+<Callout>
+Practice est honnête sur ses propres limites : si vous n'avez pas encore constitué de banque de questions ni de notes de préparation propres au poste, il le dit et propose d'exécuter d'abord `interview-prep` ou `interview/plan`, plutôt que de dérouler en silence une session générique.
+</Callout>
+
+## Debrief : ne jamais perdre les enseignements d'un entretien
+
+Lancez `interview/debrief` juste après un entretien réel, tant que votre mémoire est fraîche. Il passe en revue avec vous chaque question dont vous vous souvenez, note comment l'intervieweur a réagi et produit une évaluation honnête question par question. Puis il accomplit le travail qui se cumule :
+
+- **Il met à jour la banque de questions** — chaque question est marquée ✅ / 🟡 / 🔴 selon votre performance réelle, pas au ressenti.
+- **Il comble les lacunes** — pour chaque 🔴, il explique la bonne réponse avec un exemple détaillé et la relie à une histoire que vous possédez déjà.
+- **Il extrait de nouvelles histoires** — si vous avez raconté en entretien quelque chose qui ne figure pas encore dans votre banque d'histoires, il en fait sur-le-champ une histoire au format STAR+R.
+- **Il anticipe le tour suivant** — si vous en connaissez le format, il prédit les questions probables à partir de la fonction de l'intervieweur et de ce que ce tour a déjà couvert.
+
+## Pourquoi cette boucle fonctionne
+
+La préparation aux entretiens repart d'habitude de zéro à chaque tour. Les modes interview la rendent cumulative : ce qu'un véritable intervieweur a réellement demandé devient le signal de préparation le plus prioritaire pour le tour suivant, stocké dans de simples fichiers Markdown (`interview-prep/question-bank.md`, `story-bank.md`) qui vous appartiennent, sur votre machine, comme tout le reste dans career-ops.

--- a/content/docs/introduction/guides/meta.fr.json
+++ b/content/docs/introduction/guides/meta.fr.json
@@ -1,0 +1,10 @@
+{
+  "title": "Guides",
+  "pages": [
+    "scan-job-portals",
+    "apply-for-a-job",
+    "batch-evaluate-offers",
+    "set-up-playwright",
+    "interview-modes"
+  ]
+}

--- a/content/docs/introduction/guides/scan-job-portals.fr.mdx
+++ b/content/docs/introduction/guides/scan-job-portals.fr.mdx
@@ -1,0 +1,303 @@
+---
+title: Scanner les portails d'emploi
+description: Configurez et lancez le scanner de portails pour trouver automatiquement de nouvelles offres d'emploi.
+seoTitle: "Scanner les portails d'emploi avec career-ops — Greenhouse, Ashby, Lever, zéro token"
+icon: ScanEye
+translationHash: 13f18941c14fa8c0
+localized: true
+translatedFrom: /docs/introduction/guides/scan-job-portals
+---
+
+Ce guide vous accompagne dans la configuration de `portals.yml` et le lancement du scanner de portails pour trouver automatiquement de nouvelles offres d'emploi.
+
+<Callout title="Avant de commencer">
+  Assurez-vous d'avoir terminé le guide [Démarrage rapide](../../index.mdx). Vous devez disposer de `cv.md` et de `modes/_profile.md` avant que le scan ne soit utile.
+</Callout>
+
+## Configurer portals.yml
+
+`portals.yml` est le fichier qui contrôle ce que le scanner recherche et où il le cherche. Vous le créez une seule fois à partir du modèle inclus, puis vous le modifiez pour correspondre aux postes que vous visez.
+
+Exécutez cette commande depuis le dossier du projet :
+
+```bash title="Terminal"
+cp templates/portals.example.yml portals.yml
+```
+
+Ouvrez `portals.yml` dans n'importe quel éditeur de texte. Le fichier comporte trois sections. Les étapes ci-dessous les passent en revue une par une.
+
+### Configurer votre filtre de titres
+
+Le filtre de titres est ce qui permet au scanner de décider si une offre mérite de vous être présentée. Il compare le titre du poste à deux listes de mots-clés.
+
+Repérez la section `title_filter` vers le haut du fichier :
+
+```yaml title="portals.yml"
+title_filter:
+  positive:
+    - "AI"
+    - "ML"
+    - "Product Manager"
+  negative:
+    - "Junior"
+    - "Intern"
+  seniority_boost:
+    - "Senior"
+    - "Staff"
+    - "Lead"
+```
+
+**Remplacez la liste `positive`** par des mots-clés correspondant aux postes que vous visez. Une offre doit correspondre à au moins un mot-clé de cette liste pour être retenue. La vérification n'est pas sensible à la casse : `"AI"` détecte donc aussi `"ai engineer"`.
+
+**Remplacez la liste `negative`** par des mots-clés qui éliminent une offre. Si l'un d'eux apparaît dans le titre, l'offre est écartée — même si elle correspondait à un mot-clé positif.
+
+**Laissez `seniority_boost` tel quel**, sauf si vous souhaitez ajouter ou retirer des niveaux de séniorité. Ces mots-clés ne filtrent rien — ils font simplement remonter les offres correspondantes dans les résultats.
+
+**Exemple :** si vous cherchez des postes d'ingénierie Rails, votre filtre pourrait ressembler à ceci :
+
+```yaml title="portals.yml"
+title_filter:
+  positive:
+    - "Rails"
+    - "Ruby"
+    - "Full Stack"
+    - "Backend"
+  negative:
+    - "Junior"
+    - "Intern"
+    - "PHP"
+    - "Java"
+  seniority_boost:
+    - "Senior"
+    - "Staff"
+    - "Lead"
+```
+
+<Callout title="Astuce">
+  Commencez avec une petite liste `positive` de trois à cinq mots-clés. Vous pourrez toujours en ajouter plus tard. Une longue liste rend plus difficile de comprendre pourquoi une offre a été retenue ou écartée.
+</Callout>
+
+### Ajouter des entreprises à suivre
+
+La section `tracked_companies` est une liste d'entreprises précises que le scanner doit vérifier à chaque exécution. Le scanner se rend directement sur la page emploi de chaque entreprise et lit les postes ouverts.
+
+Repérez la section `tracked_companies` vers le bas du fichier. Chaque entrée ressemble à ceci :
+
+```yaml title="portals.yml"
+tracked_companies:
+  - name: Anthropic
+    careers_url: https://job-boards.greenhouse.io/anthropic
+    api: https://boards-api.greenhouse.io/v1/boards/anthropic/jobs
+    enabled: true
+
+  - name: OpenAI
+    careers_url: https://openai.com/careers
+    enabled: true
+```
+
+**Pour ajouter une entreprise**, copiez une entrée existante et modifiez les valeurs :
+
+<div className="rounded-lg bg-radial-[at_bottom] from-blue-500/20 p-4 border bg-origin-border border-fd-primary/10 prose-no-margin dark:bg-black/20">
+  <div className="rounded-xl bg-fd-background p-3">
+    | Champ         | Ce qu'il faut renseigner                                                                                 |
+    | ------------- | -------------------------------------------------------------------------------------------------------- |
+    | `name`        | Le nom de l'entreprise tel que vous voulez le voir apparaître dans les résultats                         |
+    | `careers_url` | L'URL directe de la page listant les offres d'emploi de l'entreprise                                     |
+    | `api`         | Facultatif. L'URL de l'API Greenhouse si l'entreprise utilise Greenhouse. Omettez-le si vous n'êtes pas sûr. |
+    | `enabled`     | Mettez `true` pour inclure l'entreprise ou `false` pour l'ignorer sans supprimer l'entrée.               |
+  </div>
+</div>
+
+
+**Pour trouver la `careers_url` d'une entreprise**, rendez-vous sur son site web, cliquez sur Careers ou Jobs, et copiez l'URL de la page qui liste les postes ouverts. C'est cette URL qu'il faut utiliser.
+
+**Pour désactiver une entreprise sans la supprimer**, mettez `enabled: false` :
+
+```yaml title="portals.yml"
+  - name: Stripe
+    careers_url: https://stripe.com/jobs/search
+    enabled: false
+```
+
+<Callout title="Remarque">
+  Chaque entreprise de `tracked_companies` doit avoir une `careers_url`. Sans elle, le scanner n'a aucune page à visiter et ignorera cette entrée.
+</Callout>
+
+### Passer en revue les requêtes de recherche
+
+La section `search_queries` lance des recherches web plus larges pour trouver des postes dans des entreprises absentes de votre liste suivie. Le modèle inclut de nombreuses requêtes prédéfinies.
+
+Vous n'avez pas besoin de modifier cette section pour démarrer. Les requêtes prédéfinies couvrent les principaux sites d'emploi, dont Greenhouse et Ashby, entre autres.
+
+Quand vous serez prêt à personnaliser, chaque requête ressemble à ceci :
+
+```yaml title="portals.yml"
+search_queries:
+  - name: Greenhouse — Rails Engineer
+    query: 'site:job-boards.greenhouse.io "Rails Engineer" OR "Ruby on Rails" remote'
+    enabled: true
+```
+
+Pour désactiver une requête dont vous n'avez pas besoin, mettez `enabled: false`. Pour en ajouter une nouvelle, copiez une entrée existante, donnez-lui un nouveau `name` et mettez à jour le texte de `query`.
+
+## Lancer un scan
+
+Il existe deux façons de lancer un scan. Utilisez celle qui correspond à votre besoin.
+
+### Option A — Exécuter le script directement
+
+```bash title="Terminal"
+npm run scan
+```
+
+Exécutez cette commande depuis le dossier du projet. Le script lit `portals.yml`, interroge directement l'API de chaque entreprise et écrit les nouvelles offres dans `data/pipeline.md`. Il n'utilise aucun token d'IA et s'exécute en environ 30 secondes.
+
+Cette option ne fonctionne que pour les entreprises qui utilisent Greenhouse, Ashby ou Lever. Les entreprises sans l'une de ces plateformes sont ignorées.
+
+**Prévisualiser les résultats avant de les enregistrer :**
+
+```bash title="Terminal"
+npm run scan -- --dry-run
+```
+
+Cette commande exécute le scan complet mais n'écrit rien sur le disque. Utilisez-la pour vérifier vos réglages de filtre avant d'enregistrer les résultats.
+
+**Scanner une seule entreprise :**
+
+```bash title="Terminal"
+npm run scan -- --company Anthropic
+```
+
+Remplacez `Anthropic` par n'importe quel nom d'entreprise de votre liste `tracked_companies`. La correspondance n'est pas sensible à la casse.
+
+### Option B — Lancer le scan piloté par l'IA dans Claude Code
+
+Ouvrez Claude Code dans le dossier du projet et tapez :
+
+```bash title="Claude Code"
+/career-ops scan
+```
+
+Cette version visite directement la page emploi de chaque entreprise à l'aide d'un navigateur, elle fonctionne donc même pour les entreprises qui n'ont pas d'API publique. Elle exécute aussi les `search_queries` de votre `portals.yml` pour trouver des postes dans des entreprises absentes de votre liste suivie.
+
+Utilisez cette option quand :
+- Une entreprise de votre liste n'utilise pas Greenhouse, Ashby ou Lever
+- Vous voulez découvrir de nouvelles entreprises, pas seulement vérifier celles que vous connaissez déjà
+- Le scan par script a manqué quelque chose que vous vous attendiez à voir
+
+<Callout title="Astuce">
+  L'option B consomme des tokens de l'API Claude et prend plus de temps que le script. Pour une vérification quotidienne rapide, l'option A est plus rapide.
+</Callout>
+
+## Lire le résultat du scan
+
+Quand le scan se termine, vous verrez un résumé comme celui-ci :
+
+```text title="Terminal"
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Portal Scan — 2026-04-13
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Companies scanned:     42
+Total jobs found:      318
+Filtered by title:     291 removed
+Duplicates:            4 skipped
+New offers added:      23
+
+New offers:
+  + Anthropic | AI Engineer | San Francisco, CA
+  + ElevenLabs | Solutions Architect | Remote
+  ...
+
+→ Run /career-ops pipeline to evaluate new offers.
+```
+
+Voici ce que signifie chaque ligne :
+
+<div className="rounded-lg bg-radial-[at_bottom] from-blue-500/20 p-4 border bg-origin-border border-fd-primary/10 prose-no-margin dark:bg-black/20">
+  <div className="rounded-xl bg-fd-background p-3">
+    | Ligne | Ce qu'elle vous indique |
+    |---|---|
+    | **Companies scanned** | Combien d'entreprises de `tracked_companies` ont été vérifiées |
+    | **Total jobs found** | Tous les postes ouverts vus dans ces entreprises, avant tout filtrage |
+    | **Filtered by title** | Offres écartées parce que le titre ne correspondait pas à votre `title_filter` |
+    | **Duplicates skipped** | Offres déjà présentes dans votre pipeline ou votre tracker — elles ne sont pas ajoutées à nouveau |
+    | **New offers added** | Offres qui ont passé tous les filtres et qui sont nouvelles pour vous |
+  </div>
+</div>
+
+
+Si **New offers added** est à 0, votre filtre de titres est peut-être trop strict. Essayez d'ajouter un mot-clé à votre liste `positive` et relancez le scan.
+
+**Où vont les nouvelles offres :** chaque nouvelle offre est ajoutée sous forme de ligne dans `data/pipeline.md`. C'est la liste des offres en attente d'évaluation.
+
+**À quoi sert `data/scan-history.tsv` :** chaque URL vue par le scanner — qu'elle ait été ajoutée, filtrée ou ignorée — est consignée ici. C'est ainsi que le scanner évite de vous montrer deux fois la même offre lors des scans futurs. Vous n'avez pas besoin de modifier ce fichier.
+
+## Évaluer les nouvelles offres issues d'un scan
+
+Après qu'un scan a ajouté de nouvelles offres à `data/pipeline.md` — votre liste d'offres d'emploi en attente — lancez la commande pipeline pour évaluer chacune d'elles par rapport à votre profil. Cette étape utilise Claude pour lire la description du poste, la comparer à votre `cv.md` et à votre `modes/_profile.md`, et produire un résumé noté pour chaque poste.
+
+Ouvrez Claude Code dans le dossier du projet et tapez :
+
+```bash title="Terminal"
+/career-ops pipeline
+```
+
+Claude lit chaque URL en attente dans `data/pipeline.md`, visite chaque annonce et l'évalue. Les résultats arrivent par lots. Chaque lot affiche un tableau comme celui-ci :
+
+Lot 1 terminé (Anthropic, ElevenLabs, Mistral) :
+
+<div className="rounded-lg bg-radial-[at_bottom] from-blue-500/20 p-4 border bg-origin-border border-fd-primary/10 prose-no-margin dark:bg-black/20">
+  <div className="rounded-xl bg-fd-background p-3">
+    | #   | Entreprise | Poste               | Score | Légitimité                       |
+    | --- | ---------- | ------------------- | ----- | -------------------------------- |
+    | 024 | Anthropic  | AI Engineer         | 4.8/5 | High Confidence                  |
+    | 025 | ElevenLabs | Solutions Architect | 4.1/5 | High Confidence — fast-growing   |
+    | 026 | Mistral AI | Product Manager     | 3.2/5 | Proceed w/ Caution — role closed |
+  </div>
+</div>
+
+
+Voici ce que signifie chaque colonne :
+
+<div className="rounded-lg bg-radial-[at_bottom] from-blue-500/20 p-4 border bg-origin-border border-fd-primary/10 prose-no-margin dark:bg-black/20">
+  <div className="rounded-xl bg-fd-background p-3">
+    | Colonne        | Ce qu'elle vous indique                                                                                                                                                                        |
+    | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | **#**          | Le numéro du rapport. Utilisez-le pour retrouver le rapport complet dans `reports/` — par exemple, le rapport 024 est `reports/024-anthropic-2026-04-13.md`                                    |
+    | **Score**      | Dans quelle mesure le poste correspond à votre profil, de 1.0 à 5.0                                                                                                                            |
+    | **Légitimité** | Si l'annonce semble réelle et active. « High Confidence » signifie que l'offre est en ligne et que les détails sont cohérents. « Proceed w/ Caution » signifie que quelque chose a attiré l'attention — lisez la note à côté. |
+  </div>
+</div>
+
+**Pour lire l'évaluation complète d'un poste**, vous avez deux options :
+
+- **Ouvrir directement le fichier du rapport** — retrouvez-le dans le dossier `reports/` grâce au numéro du tableau.
+- **Utiliser le dashboard** — exécutez `./dashboard/career-dashboard` depuis le dossier du projet pour parcourir tous vos rapports dans une interface en terminal. Vous pouvez filtrer par score et par statut, et ouvrir n'importe quel rapport sans quitter le terminal.
+
+## Que faire ensuite
+
+Quand `/career-ops pipeline` se termine, chaque offre a un score de 1.0 à 5.0. Vous trouverez le rapport complet de chaque poste dans le dossier `reports/`. Le score indique dans quelle mesure le poste correspond à votre profil.
+
+Utilisez le score comme point de départ :
+
+<div className="rounded-lg bg-radial-[at_bottom] from-blue-500/20 p-4 border bg-origin-border border-fd-primary/10 prose-no-margin dark:bg-black/20">
+  <div className="rounded-xl bg-fd-background p-3">
+    | Score             | Action recommandée                                                                                                                     |
+    | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+    | **4.5 ou plus**   | Forte correspondance. Lancez `/career-ops apply` sans attendre.                                                                        |
+    | **4.0 – 4.4**     | Bonne adéquation. Lancez `/career-ops apply`. Vous pouvez aussi lancer d'abord `/career-ops contacto` pour contacter quelqu'un de l'équipe avant de postuler. |
+    | **3.5 – 3.9**     | Ça peut aller dans les deux sens. Lancez `/career-ops deep` pour en savoir plus avant de décider.                                      |
+    | **Moins de 3.5**  | Passez votre chemin, sauf si vous avez une raison précise de postuler.                                                                 |
+  </div>
+</div>
+
+Voici ce que fait chaque commande :
+
+- **`/career-ops apply`** — Ouvre le formulaire de candidature et rédige des réponses adaptées à votre profil. Il s'arrête avant l'envoi pour que vous puissiez tout relire d'abord.
+- **`/career-ops contacto`** — Trouve un responsable du recrutement ou un membre de l'équipe sur LinkedIn et rédige un court message de prise de contact que vous pourrez envoyer.
+- **`/career-ops deep`** — Effectue des recherches approfondies sur l'entreprise et le poste. Utilisez-la quand vous hésitez et que vous voulez plus d'informations avant de décider.
+- **`/career-ops tracker`** — Affiche le statut de chaque poste de votre pipeline. Lancez-la à tout moment pour savoir où vous en êtes.
+
+<Callout title="Astuce">
+  Vous n'êtes pas obligé de suivre l'ordre. Si un poste obtient 4.8 mais que vous n'avez jamais entendu parler de l'entreprise, lancez d'abord `/career-ops deep`. Les commandes fonctionnent indépendamment — utilisez celle qui correspond à votre situation.
+</Callout>

--- a/content/docs/introduction/guides/set-up-playwright.fr.mdx
+++ b/content/docs/introduction/guides/set-up-playwright.fr.mdx
@@ -1,0 +1,141 @@
+---
+title: Configurer Playwright
+description: Installez et configurez Playwright pour l'automatisation du navigateur.
+seoTitle: "Configurer Playwright pour career-ops — scraping d'offres d'emploi et export de CV en PDF"
+icon: Globe
+translationHash: d900e7e8e58ee7f6
+localized: true
+translatedFrom: /docs/introduction/guides/set-up-playwright
+---
+
+Ce guide décrit les trois étapes d'installation qui donnent à career-ops ses capacités d'automatisation du navigateur :
+
+<div className="rounded-lg bg-radial-[at_bottom] from-blue-500/20 p-4 border bg-origin-border border-fd-primary/10 prose-no-margin dark:bg-black/20">
+  <div className="rounded-xl bg-fd-background p-3">
+    <Steps>
+      <Step title="Installer le package Playwright">
+        Installez le package Node de Playwright
+      </Step>
+      <Step title="Télécharger Chromium">
+        Téléchargez le navigateur Chromium que Playwright pilote
+      </Step>
+      <Step title="Configurer le MCP Playwright">
+        Configurez le MCP Playwright pour que Claude puisse piloter le navigateur pendant l'étape apply
+      </Step>
+    </Steps>
+  </div>
+</div>
+
+<Callout title="Avant de commencer">
+  Terminez d'abord le guide de [démarrage rapide](../../index.mdx). Node.js 20 LTS ou une version ultérieure doit être installé et vous devez vous trouver dans le dossier racine de career-ops.
+</Callout>
+
+---
+
+## Installer le package Playwright
+
+Exécutez `npm install` depuis le dossier racine de career-ops :
+
+```bash title="Terminal"
+npm install
+```
+
+Cette commande installe Playwright ainsi que toutes les autres dépendances du projet déclarées dans `package.json`. Passez cette étape si vous l'avez déjà exécutée lors de l'installation initiale.
+
+## Télécharger Chromium
+
+Playwright a besoin de sa propre copie de Chromium pour l'automatisation. L'installeur la télécharge normalement de façon automatique juste après les dépendances ; si `npm run doctor` signale qu'elle est manquante, téléchargez-la en exécutant :
+
+```bash title="Terminal"
+npx playwright install chromium
+```
+
+Cette étape ne s'effectue qu'une seule fois. Vous n'avez pas besoin de la répéter après les mises à jour `npm`.
+
+## Configurer le MCP Playwright
+
+Le MCP Playwright permet à Claude de contrôler directement le navigateur pendant l'étape `/career-ops apply` — naviguer vers les formulaires de candidature, lire les libellés des champs et suggérer des réponses.
+
+### Enregistrer le serveur MCP
+
+Exécutez cette commande depuis n'importe quel emplacement pour enregistrer le MCP Playwright auprès de Claude Code :
+
+```bash title="Terminal"
+claude mcp add playwright npx @playwright/mcp@latest
+```
+
+C'est la méthode d'enregistrement en une seule étape décrite dans la [documentation du MCP Playwright](https://playwright.dev/docs/getting-started-mcp). Elle ajoute automatiquement l'entrée du serveur à vos paramètres Claude.
+
+### Configuration manuelle (alternative)
+
+Si vous préférez le configurer à la main, ajoutez l'entrée suivante à `.claude/settings.local.json` dans la racine de career-ops, ou à vos paramètres Claude globaux :
+
+```json title=".claude/settings.local.json"
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["y", "@playwright/mcp@latest"]
+    }
+  }
+}
+```
+
+Redémarrez Claude Code après avoir enregistré le fichier. career-ops aura alors accès à `browser_navigate` et `browser_snapshot` pendant les sessions apply.
+
+---
+
+## Vérifier l'installation
+
+Exécutez le script doctor pour confirmer que les trois composants sont en place :
+
+```bash title="Terminal"
+npm run doctor
+```
+
+Vérifiez que Playwright, Chromium et le serveur MCP sont tous signalés comme prêts. Si la vérification réussit, l'installation est terminée.
+
+---
+
+## Regarder le navigateur remplir le formulaire
+
+Par défaut, Playwright s'exécute en mode headless — il lit et remplit le formulaire en arrière-plan sans ouvrir de fenêtre visible.
+
+Pour voir le navigateur s'ouvrir et remplir le formulaire en direct, ajoutez une instruction à la commande apply :
+
+<Tabs items={["Claude Code", "Codex", "OpenCode", "Qwen CLI"]}>
+  <Tab value="Claude Code">
+    ```bash
+    /career-ops apply {company_name} open up with playwright the browser and fill out the entire form
+    ```
+  </Tab>
+  <Tab value="Codex">
+    ```bash
+    Run the /career-ops apply command with the {company_name} argument. Then, use the Playwright MCP to open a browser window and fill out the entire form live.
+    ```
+  </Tab>
+  <Tab value="OpenCode">
+    ```bash
+    Run the /career-ops apply command with the {company_name} argument. Then, use the Playwright MCP to open a browser window and fill out the entire form live.
+    ```
+  </Tab>
+  <Tab value="Qwen CLI">
+    ```bash
+    Run the /career-ops apply command with the {company_name} argument. Then, use the Playwright MCP to open a browser window and fill out the entire form live.
+    ```
+  </Tab>
+</Tabs>
+
+Sans cette instruction, career-ops utilise quand même Playwright et le MCP — il opère simplement en silence, en arrière-plan.
+
+## Ce que chaque composant apporte
+
+<div className="rounded-lg bg-radial-[at_bottom] from-blue-500/20 p-4 border bg-origin-border border-fd-primary/10 prose-no-margin dark:bg-black/20">
+  <div className="rounded-xl bg-fd-background p-3">
+    | Composant          | Rôle                                                                                                              |
+    | ------------------ | ----------------------------------------------------------------------------------------------------------------- |
+    | Package Playwright | Bibliothèque principale qui pilote l'automatisation du navigateur                                                 |
+    | Chromium           | Affiche les pages, génère des PDF de qualité impression via `/career-ops pdf`, vérifie si les offres d'emploi sont toujours en ligne et alimente les scans ATS complets |
+    | MCP Playwright     | Permet à career-ops de naviguer dans les formulaires et de suggérer des réponses aux champs pendant `/career-ops apply` |
+  </div>
+</div>

--- a/content/docs/reference/glossary.fr.mdx
+++ b/content/docs/reference/glossary.fr.mdx
@@ -1,0 +1,82 @@
+---
+title: Glossaire
+description: Le vocabulaire de la recherche d'emploi assistée par IA, défini — ATS, score A–F, Data Contract, spray-and-pray, liveness check, tailoring, scan zéro token, histoires STAR+R, et chaque terme utilisé par career-ops.
+seoTitle: "Glossaire career-ops — les termes de la recherche d'emploi assistée par IA, définis"
+icon: BookOpen
+translationHash: 908b3fb3fc8e8f13
+localized: true
+translatedFrom: /docs/reference/glossary
+---
+
+{/* Mirrored with src/lib/glossary-data.ts (DefinedTermSet JSON-LD) — edit
+    both together. Definitions must stay verifiable against the core repo. */}
+
+Chaque terme utilisé par career-ops, défini en un seul endroit. Les termes renvoient à la référence plus détaillée lorsqu'elle existe.
+
+## ATS (Applicant Tracking System)
+
+Le logiciel que les entreprises utilisent pour recevoir, stocker et filtrer les candidatures — [Greenhouse](/docs/reference/portals/greenhouse), [Ashby](/docs/reference/portals/ashby) et [Lever](/docs/reference/portals/lever) en sont des exemples courants. career-ops lit leurs API publiques d'offres pour découvrir les postes ouverts et peut pré-remplir leurs formulaires de candidature, mais ne soumet jamais rien automatiquement.
+
+## Score A–F
+
+La note que career-ops attribue à une offre d'emploi après l'avoir évaluée, sur plusieurs dimensions, par rapport à votre CV et à votre profil. Un **A** signifie « postulez maintenant, avec une forte conviction » ; un **F** signifie que l'offre échoue face à vos propres critères. La grille de notation est publique sur la [page méthodologie](https://career-ops.org/methodology).
+
+## Data Contract
+
+La promesse architecturale centrale de career-ops : la **couche système** (scripts, modes, templates) peut être mise à jour à tout moment, tandis que la **couche utilisateur** — `cv.md`, `config/profile.yml`, `data/`, `reports/`, `output/` — n'est jamais touchée par une mise à jour. Vos données survivent à toutes les versions.
+
+## Spray-and-pray
+
+La stratégie de candidature de masse qui consiste à envoyer le même CV à des centaines d'offres sans aucun ciblage. career-ops la rejette explicitement : le pipeline évalue et classe d'abord les offres, pour que l'effort se concentre sur le petit nombre de postes qui valent vraiment la peine.
+
+## Liveness check
+
+Une heuristique que career-ops exécute pour détecter si une offre d'emploi est encore ouverte avant que vous n'y consacriez du temps ou des tokens. C'est un signal best-effort — des annonces expirées traînent parfois sur les job boards — et les offres peuvent être marquées manuellement lorsque l'heuristique se trompe.
+
+## Tailoring
+
+Réécrire votre CV pour une offre d'emploi précise — réorganiser les priorités, mettre en avant les compétences et les chiffres qui correspondent, aligner le vocabulaire sur la description du poste — tout en gardant chaque affirmation fidèle à votre expérience réelle. career-ops génère un CV sur mesure par candidature, en Markdown, que vous pouvez modifier.
+
+## Mode
+
+Un workflow ciblé, défini par un prompt, que career-ops livre sous forme de simple fichier Markdown que votre CLI d'IA exécute — [scan, apply, tracker](/docs/reference/modes), [interview/practice](/docs/introduction/guides/interview-modes) et une douzaine d'autres. Les modes sont du texte inspectable, pas du code boîte noire.
+
+## Pipeline
+
+Le workflow career-ops de bout en bout : scan des portails → évaluation des offres de A à F → CV sur mesure → candidature → suivi → préparation des entretiens. Chaque étape est un mode que vous pouvez exécuter indépendamment ou par lot.
+
+## Scan zéro token
+
+Une passe de découverte qui ne consomme aucun token de LLM : `scan.mjs` appelle directement les API des ATS (Greenhouse, Ashby, Lever) en HTTP — trouver de nouvelles offres est donc gratuit, quel que soit le moteur d'IA que vous utilisez.
+
+## Moteur d'IA
+
+Le CLI de codage IA qui exécute les prompts de career-ops — Claude Code, OpenCode, Codex, GitHub Copilot CLI et [les autres CLI pris en charge](/docs/supported-clis) — ou n'importe quel endpoint compatible OpenAI. career-ops est agnostique quant au moteur et [fonctionne aussi avec des moteurs gratuits](/docs/free-ai-engine).
+
+## Banque de questions
+
+Un fichier Markdown local (`interview-prep/question-bank.md`) où career-ops accumule les questions posées lors de vrais entretiens et votre performance sur chacune (✅/🟡/🔴). Le [mode interview/debrief](/docs/introduction/guides/interview-modes) le met à jour après chaque entretien réel, si bien que la préparation se cumule d'un tour à l'autre.
+
+## Histoire STAR+R
+
+Une histoire d'entretien structurée en **S**ituation, **T**âche, **A**ction, **R**ésultat, plus **R**éflexion — le format que career-ops utilise dans sa banque d'histoires pour que les réponses comportementales soient concrètes, chiffrées et réutilisables d'un entretien à l'autre.
+
+## Banque d'histoires
+
+Un fichier Markdown local (`interview-prep/story-bank.md`) contenant vos histoires STAR+R préparées. Les sessions d'entraînement vérifient vos réponses par rapport à ce fichier, et les débriefs en extraient de nouvelles histoires à partir de ce que vous avez réellement dit lors de vos entretiens réels.
+
+## Portail
+
+Un site carrières d'entreprise adossé à un ATS que career-ops peut scanner. Vos portails suivis vivent dans `portals.yml` ; le scanner lit leurs API publiques à chaque exécution.
+
+## Évaluation par lot
+
+Noter de nombreuses offres sauvegardées en une seule exécution plutôt qu'une par une, avec des flags pour garder le contrôle : `--limit` plafonne la taille du lot, `--dry-run` prévisualise ce qui serait traité, et `--resume-paused` reprend une exécution interrompue sans dépenser de nouveau des tokens.
+
+## Local-first
+
+Le principe architectural de career-ops : tout — vos données, les prompts, les scripts, le CLI d'IA — s'exécute sur votre machine. Il n'y a pas de backend hébergé, pas de compte, et rien qui nécessite une inscription.
+
+## CareerOps
+
+CareerOps est la pratique qui consiste à mener une recherche d'emploi comme les ingénieurs font tourner la production : avec des preuves, avec de la discipline, et avec des outils du côté du candidat. Le terme désigne la pratique, pas un produit ; career-ops en est la première implémentation de référence. Forgé par Santiago Fernández de Valderrama Aparicio dans [The CareerOps Manifesto](https://career-ops.org/manifesto) (14 juillet 2026).

--- a/content/docs/reference/meta.fr.json
+++ b/content/docs/reference/meta.fr.json
@@ -1,0 +1,7 @@
+{
+  "title": "Référence",
+  "pages": [
+    "modes",
+    "portals"
+  ]
+}

--- a/content/docs/reference/modes/apply.fr.mdx
+++ b/content/docs/reference/modes/apply.fr.mdx
@@ -1,0 +1,66 @@
+---
+title: apply
+description: "Assistant de candidature en direct. Il lit les questions ouvertes posées par les formulaires Greenhouse, Ashby et Lever, et rédige des brouillons de réponses fondés sur votre CV et l'offre d'emploi."
+seoTitle: "Mode apply de career-ops — brouillons automatiques de réponses aux questions de candidature ATS"
+icon: Send
+date: "2026-05-19"
+lastModified: "2026-05-19"
+translationHash: 2b3d824399a29c66
+localized: true
+translatedFrom: /docs/reference/modes/apply
+---
+
+## Ce que fait ce mode
+
+Le mode `apply` lit un formulaire de candidature ouvert (Greenhouse, Ashby, Lever), identifie les questions ouvertes — « Pourquoi ce poste ? », « Parlez-nous d'un projet », « Quelles sont vos prétentions salariales ? » — et rédige des réponses fondées sur votre CV et la description du poste. Vous retouchez les brouillons directement, vous les copiez dans le portail, puis vous envoyez.
+
+## Quand l'utiliser
+
+Ouvrez l'offre d'emploi et le formulaire de candidature côte à côte. Lancez apply une fois le formulaire chargé. Le résultat est prêt à coller, pas une candidature terminée — vous restez aux commandes pour le ton, les faits et tout champ supplémentaire que le portail ajoute par-dessus. apply fonctionne au mieux avec Playwright en mode visible, où il lit la page en direct telle que vous la voyez ; sans Playwright, collez les questions ou partagez une capture d'écran, et il rédigera à partir de là.
+
+## À quoi ressemble une exécution
+
+Lancez apply avec le formulaire de candidature ouvert dans Chrome. Avant d'écrire la moindre réponse, le mode lit l'onglet actif, le rapproche du rapport que vous avez déjà généré pour cette offre, vérifie que l'annonce est toujours en ligne et analyse le formulaire à la recherche de questions éliminatoires qui pourraient entraîner un rejet automatique.
+
+```txt title="Exemple"
+> /career-ops apply
+
+Detected tab: Notion — Applied AI Engineer (Greenhouse)
+Matched report #072 · score 4.6/5 · archetype: Applied AI operator
+Preflight: posting live — company and role match the report.
+
+Pre-scan flagged 1 knock-out question:
+  KNOCK-OUT: "Will you now or in the future require visa sponsorship?"
+  Your profile does not record work authorization. Confirm before I draft.
+
+Responses for Notion — Applied AI Engineer
+
+1. Why this role?
+   > Your agent-tooling team is where I want to apply the production
+   > AI pipelines I have shipped this year. (paste-ready)
+
+2. Tell us about a relevant project
+   > Built and sold an AI-workflow company in 2025; the pipeline
+   > behind it is the same one I would bring here. (paste-ready)
+
+Notes: I filled text fields only. Tick the checkboxes, solve the
+captcha, and submit yourself.
+```
+
+## Pièges à connaître
+
+apply n'envoie pas les formulaires et ne clique sur aucun bouton. Il lit les questions et produit des brouillons de réponses dans le chat. L'étape d'envoi vous revient. Les champs fermés (listes déroulantes, boutons radio, envois de fichiers) sont hors périmètre. Si la vérification préalable détecte que l'annonce est fermée, apply refuse de rédiger un texte final à moins que vous ne l'y forciez explicitement — un lien mort ne vaut pas une réponse sur mesure.
+
+## Particularités connues des ATS
+
+apply a été éprouvé sur le terrain à travers une douzaine de candidatures pilotées par Playwright, et quelques portails font échouer une exécution si vous n'en tenez pas compte :
+
+- **Ashby** déduplique les candidats par adresse e-mail au sein de chaque entreprise : une seconde candidature peut donc fusionner silencieusement avec la première. Si un rapport existe déjà pour cette entreprise, apply vous suggère un alias e-mail `+tag`.
+- **Lever** déclenche un captcha lorsqu'une case à cocher ou un bouton radio est cliqué de façon programmatique : apply ne remplit donc que les champs texte et vous laisse cocher le reste.
+- **Workday** ignore les valeurs saisies sans véritables frappes clavier : apply tape donc les réponses caractère par caractère et vous demande de vérifier les listes déroulantes d'autorisation de travail avant d'enregistrer.
+
+## Pages liées
+
+- [auto-pipeline](/docs/reference/modes/auto-pipeline)
+- [pdf](/docs/reference/modes/pdf)
+- [tracker](/docs/reference/modes/tracker)

--- a/content/docs/reference/modes/auto-pipeline.fr.mdx
+++ b/content/docs/reference/modes/auto-pipeline.fr.mdx
@@ -1,0 +1,52 @@
+---
+title: auto-pipeline
+description: "Flux par défaut lorsque vous collez l'URL d'une description de poste ou son texte brut. Exécute l'évaluation A–G, génère le rapport, exporte un PDF personnalisé et écrit une entrée dans le tracker — sans intervention manuelle entre les étapes."
+seoTitle: "career-ops auto-pipeline — évaluer une offre et générer CV + tracker à partir d'une seule URL"
+icon: Zap
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: a103f3feac73a799
+localized: true
+translatedFrom: /docs/reference/modes/auto-pipeline
+---
+
+## Ce que fait ce mode
+
+career-ops invoque auto-pipeline dès que vous déposez l'URL d'une description de poste (JD) ou un texte collé dans le prompt. Le mode lit l'annonce, la note selon la grille d'évaluation — cinq dimensions plus un score global holistique — écrit l'évaluation dans reports/, génère le PDF personnalisé via Playwright et met à jour l'entrée du tracker — le tout en un seul tour d'agent.
+
+## Quand l'utiliser
+
+Utilisez auto-pipeline lorsque vous souhaitez que le pipeline complet s'exécute automatiquement. C'est le mode par défaut pour les nouvelles offres qui entrent dans votre recherche.
+
+## À quoi ressemble une exécution
+
+Collez l'URL d'une offre sans sous-commande et auto-pipeline déroule toute la chaîne de bout en bout : il extrait la description, vérifie que l'annonce est toujours en ligne, la note, enregistre le rapport, exporte un PDF personnalisé et consigne l'entrée dans votre tracker.
+
+```txt title="Terminal"
+> https://job-boards.greenhouse.io/notion/jobs/4523451008
+
+Extracting JD with Playwright... done.
+Liveness gate: posting is live.
+Evaluation: 4.6/5 — legitimacy verified.
+Saved reports/072-notion-applied-ai-engineer-2026-05-18.md
+Generated the tailored PDF via Playwright.
+Score >= 4.5 — drafted Section H application answers in the report.
+Updated data/applications.md (Report and PDF marked done).
+```
+
+## Bon à savoir
+
+- Collez une URL et auto-pipeline se charge de l'extraction pour vous : Playwright d'abord pour les portails à page unique comme Lever, Ashby, Greenhouse et Workday, puis WebFetch pour les pages statiques, et WebSearch en dernier recours.
+- Un contrôle de disponibilité (liveness gate) s'exécute avant l'évaluation. Si le lien est mort ou si la page n'est qu'une coquille vide « poste pourvu », le mode s'arrête là au lieu de noter un contenu fantôme — et si l'entrée provenait de `data/pipeline.md`, il marque cette ligne comme fermée.
+- Les brouillons de réponses de candidature ne sont rédigés que lorsque le score atteint 4.5 ou plus, afin que les postes peu pertinents ne consomment pas de tokens pour un texte que vous n'enverrez pas.
+
+## Pièges à éviter
+
+Si vous ne voulez que l'évaluation, sans le PDF (plus rapide et moins coûteux), invoquez `/career-ops oferta` à la place. auto-pipeline consomme davantage de tokens car il exécute la chaîne complète.
+
+## Pages liées
+
+- [pipeline](/docs/reference/modes/pipeline)
+- [oferta](/docs/reference/modes/oferta)
+- [pdf](/docs/reference/modes/pdf)
+- [tracker](/docs/reference/modes/tracker)

--- a/content/docs/reference/modes/contacto.fr.mdx
+++ b/content/docs/reference/modes/contacto.fr.mdx
@@ -1,0 +1,51 @@
+---
+title: contacto
+description: "Le power move LinkedIn. À partir d'un nom d'entreprise et du contexte de votre réseau, contacto fait remonter les contacts probablement chauds (relations communes, 2e niveau) et rédige un court message de prise de contact adapté au poste auquel vous candidatez."
+seoTitle: "Mode contacto de career-ops — trouver des contacts LinkedIn chauds et rédiger une prise de contact"
+icon: UserPlus
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: ef2b573d6f41f444
+localized: true
+translatedFrom: /docs/reference/modes/contacto
+---
+
+## Ce qu'il fait
+
+Le mode contacto lit le nom de l'entreprise et le contexte de l'offre, puis suggère des cibles de prise de contact qu'il trouve via WebSearch — le hiring manager, le recruteur assigné, deux ou trois pairs dans l'équipe et un interviewer connu. Il rédige un message court — trois phrases, moins de 300 caractères — adapté au poste et à l'identité du contact.
+
+## Quand l'utiliser
+
+Utilisez contacto lorsque vous avez déjà candidaté à un poste et que vous voulez faire émerger une piste de cooptation. Ou utilisez-le avant de candidater, quand une introduction chaleureuse peut vous faire passer devant la pile du recruteur. Par défaut, c'est le power move LinkedIn ; pour une plateforme avec une limite stricte de caractères — la messagerie d'un job board, l'accroche d'un cold email, le 打招呼 de BOSS Zhipin — demandez un « greeting » et contacto rédige un tout premier message ultra-court, sans recherche de contacts.
+
+## À quoi ressemble une exécution
+
+Donnez une entreprise à contacto : il trouve les personnes qui valent la peine d'être contactées, choisit celle qui a le plus à gagner à votre arrivée, et rédige un message construit pour ce persona : un recruteur entend que les prérequis sont remplis, un hiring manager entend l'impact.
+
+```txt title="Example"
+> /career-ops contacto notion
+
+Targets found (WebSearch):
+  • Hiring manager — Head of Applied AI
+  • Recruiter — Technical Talent Partner
+  • 2 peers — AI Engineers on the team
+
+Primary target: Hiring Manager
+
+Draft (287/300 chars):
+> Saw Notion is scaling agent tooling inside the editor. I built and
+> sold an AI-workflow company in 2025 that shipped the same kind of
+> pipeline. Would love to hear how your team is approaching it.
+
+Alternative: message the recruiter first if you want a faster screen
+than a cold note to the manager.
+```
+
+## Points d'attention
+
+contacto ne scrape pas LinkedIn (approche rejetée — voir l'issue #238). Il travaille à partir du contexte que vous fournissez — votre CV, vos anciens employeurs, les relations communes que vous mentionnez — plus les résultats publics de WebSearch. L'agent n'a aucun accès à votre graphe LinkedIn privé. Chaque message reste sous la limite des 300 caractères des demandes de connexion LinkedIn et n'inclut jamais votre numéro de téléphone.
+
+## Voir aussi
+
+- [deep](/docs/reference/modes/deep)
+- [interview-prep](/docs/reference/modes/interview-prep)

--- a/content/docs/reference/modes/deep.fr.mdx
+++ b/content/docs/reference/modes/deep.fr.mdx
@@ -1,0 +1,52 @@
+---
+title: deep
+description: "Génère un document de recherche approfondie sur une entreprise — historique des levées de fonds, équipe dirigeante, presse récente, trajectoire produit, signaux de fourchette de rémunération, signaux d'alerte. Utilisez-le avant de postuler dans une entreprise en série B ou plus que vous ne connaissez pas déjà bien."
+seoTitle: "Mode deep de career-ops — recherche approfondie sur une entreprise avant de postuler"
+icon: Search
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: cef52678d1e8b67a
+localized: true
+translatedFrom: /docs/reference/modes/deep
+---
+
+## Ce que fait ce mode
+
+Le mode `deep` génère un prompt de recherche structuré sur une entreprise que vous évaluez, organisé autour de six axes : sa stratégie IA, ses mouvements des six derniers mois, sa culture d'ingénierie, les défis techniques auxquels elle est probablement confrontée, ses concurrents et sa différenciation, et votre angle en tant que candidat. Vous collez ce prompt dans un outil de recherche — Perplexity, Claude ou ChatGPT — qui vous renvoie un brief à lire avant l'entretien. deep personnalise chaque axe avec le poste et l'entreprise concernés.
+
+## Quand l'utiliser
+
+Utilisez deep lorsque vous postulez dans une entreprise en série B ou au-delà, quand la décision de postuler — ou la manière d'aborder l'entretien — demande plus que ce que la fiche de poste vous apprend. L'axe consacré à votre angle de candidat s'appuie sur vos fichiers cv.md et profile.yml, de sorte que le brief renvoyé se conclut sur ce que vous apportez spécifiquement plutôt que sur des faits génériques concernant l'entreprise.
+
+## À quoi ressemble une exécution
+
+Donnez à deep une entreprise et un poste, et il rédige un prompt de recherche prêt à coller. Chacun des six axes est une checklist de questions auxquelles l'outil de recherche doit répondre, et le dernier axe retourne les conclusions vers vous.
+
+```txt title="Example"
+> /career-ops deep notion
+
+Deep Research: Notion — Applied AI Engineer
+Paste the block below into Perplexity, Claude, or ChatGPT.
+
+1. AI strategy — which products use AI/ML, the stack behind them,
+   the engineering blog, any papers or talks.
+2. Recent moves (last 6 months) — AI/ML hires, acquisitions,
+   product launches, funding or leadership changes.
+3. Engineering culture — ship cadence, monorepo vs multirepo,
+   languages, remote posture, Glassdoor/Blind signals.
+4. Likely challenges — scaling, reliability, cost, latency, any
+   migration in flight.
+5. Competitors and differentiation — main rivals and the moat.
+6. Candidate angle — given my cv.md and profile.yml, the unique
+   value I bring and the story to tell in the interview.
+```
+
+## Pièges à connaître
+
+Le brief ne vaut que ce que valent les informations publiques que l'outil de recherche peut trouver. Les startups en mode furtif produisent des résultats maigres, et n'importe quel outil peut halluciner une levée de fonds ou le nom d'un dirigeant. Vérifiez tout auprès de sources primaires avant de prendre une décision à fort enjeu sur cette base.
+
+## Pages associées
+
+- [oferta](/docs/reference/modes/oferta)
+- [contacto](/docs/reference/modes/contacto)
+- [interview-prep](/docs/reference/modes/interview-prep)

--- a/content/docs/reference/modes/followup.fr.mdx
+++ b/content/docs/reference/modes/followup.fr.mdx
@@ -1,0 +1,53 @@
+---
+title: followup
+description: "Signale les candidatures et les entretiens dont la relance est en retard, selon les règles de cadence que vous configurez. Rédige les messages de relance pour que vous puissiez les relire et les envoyer."
+seoTitle: "Mode followup de career-ops — suivre les relances en retard et rédiger les messages"
+icon: CalendarClock
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: b1eb8003f10d7ed3
+localized: true
+translatedFrom: /docs/reference/modes/followup
+---
+
+## Ce que fait ce mode
+
+Le mode followup lit votre tracker de candidatures, compare la date du dernier contact avec la cadence configurée (par défaut : une première relance 7 jours après votre candidature, et 1 jour après un entretien pour un message de remerciement), et signale les entrées en retard ou urgentes. Pour chaque entrée signalée, il rédige un message de relance contextuel, fondé sur le rapport correspondant et sur votre CV.
+
+## Quand l'utiliser
+
+Lancez followup le lundi matin, comme un rituel hebdomadaire. Chaque lundi, il fait remonter les relances à effectuer dans la semaine, avec des brouillons prêts à envoyer. Il est volontairement conservateur : il ne signale pas une entrée tant que le seuil de cadence n'est pas clairement dépassé, si bien que le tableau de bord reste court et que chaque élément qui y figure mérite réellement une relance.
+
+## À quoi ressemble une exécution
+
+followup exécute un script de cadence sur votre tracker, affiche un tableau de bord trié par urgence et rédige un message pour chaque ligne en retard ou urgente. Les brouillons s'ouvrent sur une preuve concrète, pas sur la demande, et ne disent jamais « just checking in ».
+
+```txt title="Terminal"
+> /career-ops followup
+
+Follow-up Cadence Dashboard — 2026-05-18
+14 applications tracked, 3 actionable
+
+| # | Company | Role                | Status    | Days | Sent | Urgency |
+|---|---------|---------------------|-----------|------|------|---------|
+| 1 | Notion  | Applied AI Engineer | Applied   | 9    | 0    | OVERDUE |
+| 2 | Ramp    | Forward-Deployed    | Applied   | 8    | 0    | OVERDUE |
+| 3 | Linear  | Product Engineer    | Responded | 1    | 0    | URGENT  |
+
+Draft — Notion (overdue):
+> Subject: Re: Applied AI Engineer — Notion
+>
+> Hi team, I applied for the Applied AI Engineer role on May 9th.
+> The AI-workflow company I built and sold in 2025 shipped the same
+> agent pipeline your posting describes. Would any time this week
+> work for a short conversation?
+```
+
+## Pièges à éviter
+
+Une candidature au statut Applied reçoit au maximum deux relances ; si la seconde reste sans réponse, followup cesse de rédiger et vous suggère de clore l'entrée ou d'essayer un autre contact via `contacto`. Vous voulez un rythme plus serré que les sept jours par défaut ? Passez un flag au script de cadence — `node followup-cadence.mjs --applied-days 5` — plutôt que de modifier les brouillons à la main.
+
+## Pages associées
+
+- [tracker](/docs/reference/modes/tracker)
+- [patterns](/docs/reference/modes/patterns)

--- a/content/docs/reference/modes/index.fr.mdx
+++ b/content/docs/reference/modes/index.fr.mdx
@@ -1,0 +1,46 @@
+---
+title: Modes
+description: "Les 14 modes career-ops invocables par l'utilisateur — évaluer, adapter, postuler, suivre et préparer — chacun un skill en markdown qui s'exécute dans n'importe quel CLI de codage IA pris en charge."
+seoTitle: "Modes career-ops — les 14 commandes de recherche d'emploi (évaluer, adapter, postuler, suivre, préparer)"
+icon: Layers
+translationHash: 4d490714e084c6f4
+localized: true
+translatedFrom: /docs/reference/modes
+---
+
+## Les 14 modes
+
+career-ops embarque **14 modes invocables par l'utilisateur**. Chacun est un skill en markdown pur que l'agent charge et exécute dans le CLI de codage IA que vous utilisez déjà — Claude Code, Codex, OpenCode, Gemini CLI, Qwen ou GitHub Copilot. Vous invoquez un mode avec `/career-ops <mode>`, et chacun couvre une étape de la recherche d'emploi : évaluer une offre selon la grille (cinq dimensions plus un score global holistique), adapter un CV, rédiger une candidature, suivre les résultats ou préparer les entretiens. Les modes relèvent de la System Layer au sens du [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) — ils évoluent avec l'outil et ne modifient jamais votre `cv.md`, votre profil ni vos rapports.
+
+## Évaluer
+
+La boucle de scoring centrale — lire une offre d'emploi et la noter sur les cinq dimensions plus un score global holistique, avant d'y investir le moindre effort.
+
+- **[auto-pipeline](/docs/reference/modes/auto-pipeline)** — le flux par défaut. Collez l'URL ou le texte d'une offre ; il exécute l'évaluation A–F, rédige le rapport, exporte un PDF adapté et consigne une entrée dans le tracker, sans aucune étape manuelle entre les deux.
+- **[pipeline](/docs/reference/modes/pipeline)** — exécute auto-pipeline sur chaque URL en file d'attente dans `data/pipeline.md`, de quoi traiter une journée entière d'offres en une seule session.
+- **[oferta](/docs/reference/modes/oferta)** — l'évaluation A–F d'une offre unique, quand vous n'avez besoin que de la décision de scoring, pas du pipeline complet.
+- **[ofertas](/docs/reference/modes/ofertas)** — classe deux offres concurrentes ou plus — rémunération, adéquation, potentiel de progression et red flags — dans une matrice de décision unique.
+- **[deep](/docs/reference/modes/deep)** — un document de recherche approfondie sur l'entreprise (levées de fonds, équipe dirigeante, presse, signaux de rémunération, red flags) avant de postuler auprès d'une entreprise que vous connaissez mal.
+
+## Adapter & postuler
+
+Transformez une offre bien notée en candidature envoyée.
+
+- **[pdf](/docs/reference/modes/pdf)** — génère via Playwright un CV en PDF adapté à une offre précise et propre pour les ATS.
+- **[apply](/docs/reference/modes/apply)** — lit les questions ouvertes d'un formulaire de candidature affiché à l'écran et rédige des réponses ancrées dans votre CV et dans l'offre.
+- **[contacto](/docs/reference/modes/contacto)** — fait remonter les contacts LinkedIn susceptibles d'être réceptifs et rédige un court message de prise de contact propre au poste.
+- **[followup](/docs/reference/modes/followup)** — repère les candidatures et les entretiens dont la relance est en retard et rédige les messages correspondants.
+
+## Suivre & progresser
+
+Gardez votre recherche organisée et calibrez-la dans la durée.
+
+- **[tracker](/docs/reference/modes/tracker)** — un récapitulatif d'état, directement dans la conversation, de toutes vos candidatures regroupées par étape.
+- **[patterns](/docs/reference/modes/patterns)** — analyse vos candidatures rejetées ou écartées pour faire émerger des schémas de ciblage et des angles morts.
+- **[interview-prep](/docs/reference/modes/interview-prep)** — des documents de préparation propres à chaque tour d'entretien (recruteur, hiring manager, entretien technique entre pairs, panel), avec les questions probables et des récits STAR.
+- **[training](/docs/reference/modes/training)** — évalue un cours ou une certification au regard du cap de carrière que vous vous êtes fixé et de son coût d'opportunité.
+- **[project](/docs/reference/modes/project)** — évalue une idée de projet de portfolio au regard de vos postes cibles et du temps qu'il faudrait pour le construire.
+
+## Portails
+
+Les trois scanners de portails zéro token — Greenhouse, Ashby et Lever — disposent de leur propre [référence des portails](/docs/reference/portals).

--- a/content/docs/reference/modes/interview-prep.fr.mdx
+++ b/content/docs/reference/modes/interview-prep.fr.mdx
@@ -1,0 +1,67 @@
+---
+title: interview-prep
+description: "career-ops interview-prep génère un document d'intelligence d'entretien spécifique à l'entreprise et au poste, segmenté selon qui est dans la salle — recruteur, hiring manager, pair technique ou panel — avec les questions probables, les points à mettre en avant et des récits STAR tirés de votre propre profil."
+seoTitle: "career-ops interview-prep — préparation d'entretien spécifique à l'entreprise, round par round"
+icon: GraduationCap
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: 43a22bcddda1882a
+localized: true
+translatedFrom: /docs/reference/modes/interview-prep
+---
+
+career-ops **interview-prep** transforme un entretien planifié en un document d'intelligence opérationnel. Vous indiquez une entreprise et un poste — ou vous lui passez une offre d'emploi pour un poste que vous n'avez jamais formellement évalué — et il recherche le processus de recrutement, classe chaque round selon qui le mène (présélection recruteur, hiring manager, pair technique ou panel), et rédige les questions que chacun est susceptible de poser, chacune accompagnée d'une ébauche de réponse tirée de votre propre parcours. Il n'invente jamais une question : chacune est soit sourcée (Glassdoor, Blind), soit marquée `[inferred from JD]`. Le résultat est un document de préparation sauvegardé, pas une conversation.
+
+## Ce que fait ce mode
+
+interview-prep lit le contexte de l'entreprise (idéalement déjà enrichi via `deep` ou `oferta`), la description du poste et votre profil, puis produit un document de préparation unique, limité aux rounds que cette entreprise organise réellement. Le document couvre les schémas de questions attendus par audience, des points à mettre en avant spécifiques à votre parcours, et des récits STAR pré-rédigés que vous pouvez adapter en direct. Lorsqu'un rapport d'évaluation existe déjà pour le poste, ce rapport fait autorité ; lorsque vous passez une URL pour un poste jamais évalué, interview-prep récupère lui-même la description du poste — d'abord via l'API structurée de l'ATS, puis via Playwright, avec un repli en mode headless — et n'invente jamais une offre.
+
+## Quand l'utiliser
+
+Lancez interview-prep dès qu'un round est au calendrier — il produit un document unique avec une section par audience impliquée dans le processus : la section présélection recruteur couvre la préparation à la négociation de rémunération, celle du hiring manager couvre l'adéquation au poste, celle du pair technique couvre l'architecture et le code, et celle du panel couvre les signaux de leadership. Il se déclenche aussi automatiquement lorsque vous faites passer à `Interview` dans votre tracker un poste noté 4.0 ou plus.
+
+interview-prep est l'étape de **recherche** — le document d'intelligence que vous étudiez en amont. C'est un mode distinct des exercices d'entretien interactifs `plan`, `practice` et `debrief`, qui vous font répéter en direct et reviennent sur un round après coup ; ils se complètent (un debrief alimente en retour le matériau qu'interview-prep lira la prochaine fois). Pour ces exercices, consultez le [guide des modes d'entretien](/docs/introduction/guides/interview-modes).
+
+## À quoi ressemble une exécution
+
+Vous indiquez l'entreprise et le poste, et le mode renvoie un rapport d'intelligence d'entretien limité aux rounds que cette entreprise organise réellement. Il recherche le processus, classe chaque round par audience — présélection recruteur, hiring manager, pair technique ou panel — et rédige les questions probables, en marquant chacune d'une citation de source ou d'une étiquette `[inferred from JD]`.
+
+```bash title="Terminal"
+/career-ops interview-prep Anthropic "Applied AI Engineer"
+```
+
+```txt title="interview-prep/anthropic-applied-ai-engineer.md (excerpt)"
+# Interview Intel: Anthropic — Applied AI Engineer
+
+**Legitimacy:** High Confidence
+**Researched:** 2026-05-18
+**Sources:** 12 Glassdoor reviews, 4 Blind posts, 3 other
+**Audiences covered:** recruiter-screen, hiring-manager, peer-tech
+
+## Process Overview
+- Rounds: 4 rounds, ~18 days end-to-end
+- Difficulty: 3.5/5 (Glassdoor avg, 12 reviews)
+- Known quirks: pair programming, not whiteboard
+
+## Likely Questions — recruiter-screen
+- "Why are you looking, and why us?" — 60-90s, anchored to your narrative
+- Comp expectation — defer to the band if leverage is thin
+- Location / visa / notice period — numbers, not vibes
+```
+
+Le rapport associe également les récits de votre `story-bank.md` à chaque question probable et signale les lacunes pour lesquelles vous n'avez pas encore de récit préparé.
+
+## Quand y recourir
+
+Recourez à interview-prep dès qu'un round est planifié et que vous voulez un document de travail plutôt que des conseils génériques. Quelques éléments affûtent le résultat :
+
+- Lancez d'abord `oferta` ou `deep` sur l'entreprise. La préparation lit le rapport d'évaluation pour en tirer l'archétype, les lacunes et les preuves correspondantes : plus de contexte produit des questions plus spécifiques.
+- Collez les noms de vos interlocuteurs ou le planning des entretiens quand vous les avez. Pour un panel, le mode construit une lecture par interlocuteur et rédige une question de clôture sur mesure pour chaque créneau.
+- Si vous avez déjà annoncé un chiffre de rémunération pour le poste, la section présélection recruteur l'intègre — career-ops lit le chiffre que vous avez indiqué, de sorte que la préparation à la négociation salariale s'appuie sur ce que vous avez réellement dit, pas sur une supposition.
+- Faites confiance aux étiquettes : les questions sourcées citent Glassdoor ou Blind, les questions inférées portent `[inferred from JD]`. Le mode n'invente jamais une question pour l'attribuer à un candidat.
+
+## Voir aussi
+
+- [deep](/docs/reference/modes/deep)
+- [contacto](/docs/reference/modes/contacto)
+- [oferta](/docs/reference/modes/oferta)

--- a/content/docs/reference/modes/meta.fr.json
+++ b/content/docs/reference/modes/meta.fr.json
@@ -1,0 +1,19 @@
+{
+  "title": "Modes",
+  "pages": [
+    "auto-pipeline",
+    "pipeline",
+    "apply",
+    "oferta",
+    "ofertas",
+    "contacto",
+    "deep",
+    "interview-prep",
+    "pdf",
+    "training",
+    "project",
+    "tracker",
+    "patterns",
+    "followup"
+  ]
+}

--- a/content/docs/reference/modes/oferta.fr.mdx
+++ b/content/docs/reference/modes/oferta.fr.mdx
@@ -1,0 +1,62 @@
+---
+title: oferta
+description: "Exécute l'évaluation A–G sur une seule annonce. Saute la génération du PDF et l'écriture dans le tracker. À utiliser quand vous n'avez besoin que de la décision de scoring, et pas du pipeline complet."
+seoTitle: "Mode oferta de career-ops — noter une offre d'emploi avant de postuler"
+icon: Target
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: 1d733a23b8c520f8
+localized: true
+translatedFrom: /docs/reference/modes/oferta
+---
+
+## Ce que fait ce mode
+
+Le mode oferta lit une seule fiche de poste (URL ou texte collé), la note selon la grille — cinq dimensions plus un score global holistique — avec des preuves citées à l'appui, puis rédige le rapport d'évaluation. Pas de PDF, pas d'entrée dans le tracker. Rapide et peu coûteux.
+
+## Quand l'utiliser
+
+Utilisez oferta pour trancher rapidement le cas d'une annonce limite. Si le score dépasse 4.0 et que vous décidez de postuler, passez au mode auto-pipeline ou apply.
+
+## À quoi ressemble une exécution
+
+Vous confiez une annonce au mode et il renvoie l'évaluation en sept blocs — les blocs A à F, plus un bloc G de lecture de légitimité — avec un score et un raisonnement sourcé. Collez directement le texte de la fiche de poste, ou passez une URL : le mode confirme alors d'abord que l'annonce est toujours en ligne, pour qu'un lien mort ne consomme jamais une évaluation complète.
+
+```bash title="Terminal"
+/career-ops oferta https://boards.greenhouse.io/acme/jobs/4021
+```
+
+```txt title="Extrait d'évaluation"
+# Evaluation: Acme — Staff AI Engineer
+
+**Score:** 4.3/5
+**Archetype:** LLMOps
+**Legitimacy:** High Confidence
+
+## A) Role Summary
+| Field      | Value  |
+|------------|--------|
+| Domain     | LLMOps |
+| Seniority  | Staff  |
+| Remote     | Full   |
+
+## G) Posting Legitimacy
+Assessment: High Confidence — posted 3 days ago, apply button active,
+JD names specific tools and first-6-month scope.
+```
+
+Les blocs B à F couvrent l'adéquation du CV et ses lacunes, la stratégie de niveau, la rémunération et la demande du marché, un plan de personnalisation, et des histoires d'entretien STAR+R alignées sur les exigences du poste.
+
+## Quand y recourir
+
+Recourez à oferta pour noter rapidement une seule annonce sans vous engager dans le pipeline complet. Bon à savoir :
+
+- Passez une URL et une vérification de disponibilité s'exécute en premier — une annonce expirée ou renvoyant une 404 est arrêtée avant le bloc A, si bien que vous ne dépensez jamais une exécution sur un contenu fantôme.
+- La recherche sur l'entreprise et la rémunération est limitée à cinq recherches web au maximum ; il s'agit d'une évaluation, pas d'une recherche approfondie. Lancez `/career-ops deep` séparément quand vous voulez un tableau plus complet de l'entreprise.
+- Le bloc G renvoie l'un de trois niveaux — High Confidence, Proceed with Caution ou Suspicious — de sorte que les probables offres fantômes ressortent avant que vous n'investissiez des efforts de préparation d'entretien.
+
+## Pages liées
+
+- [auto-pipeline](/docs/reference/modes/auto-pipeline)
+- [ofertas](/docs/reference/modes/ofertas)
+- [pdf](/docs/reference/modes/pdf)

--- a/content/docs/reference/modes/ofertas.fr.mdx
+++ b/content/docs/reference/modes/ofertas.fr.mdx
@@ -1,0 +1,56 @@
+---
+title: ofertas
+description: "À utiliser lorsque vous avez deux offres concurrentes ou plus en main et que vous avez besoin d'une comparaison normalisée portant sur la rémunération, l'adéquation du poste, la trajectoire de progression et les signaux d'alerte. Produit une recommandation classée."
+seoTitle: "Mode ofertas de career-ops — comparez des offres d'emploi concurrentes côte à côte"
+icon: GitCompare
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: b51253649996ab03
+localized: true
+translatedFrom: /docs/reference/modes/ofertas
+---
+
+## Ce que fait ce mode
+
+Le mode `ofertas` lit plusieurs évaluations de fiches de poste (déjà produites par oferta ou auto-pipeline) et les classe les unes par rapport aux autres selon les cinq dimensions, complétées par un score global holistique et une matrice de décision normalisée. Le résultat est un rapport de comparaison côte à côte et une recommandation classée.
+
+## Quand l'utiliser
+
+Utilisez ofertas lorsque vous atteignez les dernières étapes d'entretien pour plusieurs postes et que vous avez besoin d'une méthode structurée pour trancher. Particulièrement utile pour les offres de niveau staff, où les packages de rémunération et les trajectoires de progression diffèrent sensiblement.
+
+## À quoi ressemble une exécution
+
+Vous fournissez au mode deux offres ou plus ; il note chacune d'elles selon dix dimensions pondérées, puis les classe. Le poids le plus important revient à l'alignement North Star (25 %), suivi de la correspondance avec le CV et de la séniorité (15 % chacune) ; la rémunération et la trajectoire de progression pèsent 10 % chacune, tandis que la réputation, la qualité du remote, la stack technique, le time-to-offer et les signaux culturels se répartissent le reste.
+
+```bash title="Terminal"
+/career-ops ofertas
+```
+
+```txt title="Comparison excerpt"
+# Offer Comparison — 3 roles
+
+| Dimension (weight)       | Acme | Globex | Initech |
+|--------------------------|------|--------|---------|
+| North Star align (25%)   | 5    | 3      | 4       |
+| CV match (15%)           | 4    | 4      | 3       |
+| Compensation (10%)       | 3    | 5      | 4       |
+| Growth trajectory (10%)  | 5    | 3      | 3       |
+| ...                      |      |        |         |
+| Weighted total           | 4.4  | 3.6    | 3.5     |
+
+Recommendation: Acme — strongest North Star fit and growth path.
+Globex pays more but ranks lower on trajectory and time-to-offer.
+```
+
+## Quand y recourir
+
+Recourez à ofertas lorsque vous détenez deux offres concurrentes ou plus et qu'il vous faut une méthode normalisée pour choisir. Ce mode est le plus utile au niveau staff, où les packages de rémunération et les trajectoires de progression divergent suffisamment pour que l'intuition seule induise en erreur.
+
+- Fournissez les annonces sous forme de texte collé, d'URLs ou de références à des postes déjà présents dans votre tracker ; si aucune n'est disponible dans le contexte, le mode vous les demande.
+- Notez d'abord chaque offre individuellement — avec `oferta` ou `auto-pipeline` — afin que la comparaison classe des évaluations homogènes plutôt que de mélanger des niveaux de profondeur.
+- L'alignement North Star étant pondéré à 25 %, un salaire plus élevé ne suffit pas à lui seul à dominer le classement ; un poste qui correspond à votre trajectoire cible peut surclasser un détour mieux rémunéré.
+
+## Pages associées
+
+- [oferta](/docs/reference/modes/oferta)
+- [auto-pipeline](/docs/reference/modes/auto-pipeline)

--- a/content/docs/reference/modes/patterns.fr.mdx
+++ b/content/docs/reference/modes/patterns.fr.mdx
@@ -1,0 +1,52 @@
+---
+title: patterns
+description: "Analyse vos candidatures rejetées et écartées et fait émerger des schémas récurrents — des types d'offres qui obtiennent de bons scores mais ne convertissent jamais, des décalages d'archétype, des problèmes de fourchette de rémunération. Le résultat est un signal de calibrage pour votre filtre de ciblage."
+seoTitle: "Mode patterns de career-ops — comprenez pourquoi vos candidatures ne convertissent pas"
+icon: TrendingDown
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: 392fb9e40a5ff463
+localized: true
+translatedFrom: /docs/reference/modes/patterns
+---
+
+## Ce que fait ce mode
+
+Le mode `patterns` lit chaque rapport des étapes rejetées et écartées, recherche des caractéristiques communes (secteur, taille d'entreprise, niveau de séniorité, mots-clés spécifiques) et produit une analyse structurée de ce qui fonctionne — ou non — dans votre ciblage.
+
+## Quand l'utiliser
+
+Lancez patterns après chaque série de 20 à 30 refus pour recalibrer. Le mode révèle les angles morts de votre profil et vous aide à éviter d'envoyer des candidatures dans les mêmes impasses.
+
+## À quoi ressemble une exécution
+
+Vous lancez le mode après une série de résultats et il renvoie un rapport d'analyse de patterns daté, accompagné d'un court résumé des trois constats les plus importants. En coulisses, il exécute `analyze-patterns.mjs` sur votre tracker et vos rapports, puis restitue un funnel de conversion, un tableau croisant scores et résultats, les principaux points de blocage et un score plancher recommandé.
+
+```bash title="Terminal"
+/career-ops patterns
+```
+
+```txt title="Pattern Analysis summary"
+Pattern Analysis Complete (24 applications, Apr 7 - May 18)
+
+Key findings:
+- Geo-restricted roles: 0% conversion (7 of 24) — stop evaluating US-only postings
+- Regional/global remote roles convert at 57-67% — your sweet spot
+- No positive outcomes below 4.2/5 — treat that as your score floor
+
+Full report: reports/pattern-analysis-2026-05-18.md
+```
+
+Après avoir présenté le résumé, le mode propose d'agir sur ces constats — mettre à jour les filtres de `portals.yml`, définir un seuil de score ou repondérer les archétypes que vous ciblez.
+
+## Quand y faire appel
+
+Faites appel à patterns une fois qu'un nombre suffisant de candidatures a dépassé le stade de l'évaluation pour que les résultats portent un vrai signal. Le seuil strict est de cinq entrées ayant un statut au-delà de « Evaluated » — Applied, Responded, Interview, Offer, Rejected ou Discarded ; en dessous, le mode s'arrête et vous demande de revenir avec davantage de données. Plus vous avez de résultats, plus les schémas sont nets : le mode prend donc toute sa valeur après un mois de candidatures régulières.
+
+- Si vous conservez des transcriptions d'entretien dans `interview-prep/sessions/`, le mode ajoute un signal de ciblage supplémentaire : l'endroit où se concentrent vos réponses les plus fluides et les plus précises — ce qui permet de repérer les cas où le type de poste où vous êtes le plus fort diffère de celui auquel vous continuez de candidater.
+- Le rapport ne cite jamais le nom d'un intervieweur réel ni d'une entreprise issue de ces sessions — il ne résume que des groupes de compétences, si bien que tout ce qui est commité reste privé.
+
+## Pages associées
+
+- [tracker](/docs/reference/modes/tracker)
+- [followup](/docs/reference/modes/followup)

--- a/content/docs/reference/modes/pdf.fr.mdx
+++ b/content/docs/reference/modes/pdf.fr.mdx
@@ -1,0 +1,52 @@
+---
+title: pdf
+description: "Génère un CV PDF adapté à une JD précise en utilisant Playwright pour rendre le markdown à travers un modèle typographique épuré. Le résultat est structurellement simple — pas de tableaux, pas de colonnes, pas de graphiques — exactement ce que les parseurs ATS traitent de manière fiable."
+seoTitle: "Mode pdf de career-ops — générer un CV personnalisé compatible ATS"
+icon: FileText
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: beb822061e860203
+localized: true
+translatedFrom: /docs/reference/modes/pdf
+---
+
+## Ce qu'il fait
+
+Le mode pdf lit votre cv.md maître ainsi que le contexte de la JD, puis exécute l'étape de personnalisation (réécriture des puces, réorganisation des sections, intégration des mots-clés prioritaires) avant l'export en PDF via Playwright, avec un modèle CSS qui respecte les conventions des parseurs ATS. Le résultat est prêt à être téléversé.
+
+## Quand l'utiliser
+
+Utilisez pdf lorsque vous avez déjà évalué l'annonce et décidé de postuler, et que vous souhaitez uniquement le PDF personnalisé sans relancer l'étape d'évaluation.
+
+## À quoi ressemble une exécution
+
+Vous pointez le mode vers une annonce déjà évaluée et il produit un seul PDF personnalisé, prêt pour les ATS — sans réévaluation. Il extrait 15 à 20 mots-clés de la JD, choisit le format de papier selon la localisation de l'entreprise, réécrit votre résumé et réorganise les puces autour du poste, puis convertit le HTML en PDF et indique la couverture des mots-clés.
+
+```bash title="Terminal"
+/career-ops pdf acme
+
+# detected JD language: en · paper: letter (US) · 18 keywords extracted
+node generate-pdf.mjs output/cv-jane-doe-acme.html \
+  output/cv-jane-doe-acme-2026-05-18.pdf --format=letter --report=008
+
+PDF:   output/cv-jane-doe-acme-2026-05-18.pdf
+Pages: 2 · Keyword coverage: 16/18 (89%)
+```
+
+La mise en page reste sur une seule colonne, avec des en-têtes de section standard et du texte sélectionnable — la structure que les parseurs ATS lisent sans difficulté — et les mots-clés sont intégrés à de véritables réalisations, jamais inventés.
+
+## Quand y recourir
+
+Recourez à pdf lorsque vous avez décidé de postuler et que vous souhaitez uniquement le CV personnalisé, en sautant l'étape d'évaluation. Quelques comportements à connaître :
+
+- Le format de papier suit automatiquement la localisation de l'entreprise : `letter` pour les postes aux États-Unis et au Canada, `a4` partout ailleurs.
+- L'injection de mots-clés repose sur la vérité. Le mode reformule une expérience réelle dans le vocabulaire exact de la JD, mais n'ajoute jamais une compétence que vous ne possédez pas.
+- Pour la région DACH et une grande partie de l'Europe continentale, vous pouvez opter pour une photo en renseignant `candidate.photo` dans `config/profile.yml` ; laissez ce champ vide et le CV s'affiche à l'identique, au pixel près, sans photo — le choix par défaut le plus sûr pour les États-Unis, le Royaume-Uni et les marchés centrés sur les ATS.
+
+## Pièges à connaître
+
+Nécessite Playwright installé en local. Le script de build peut échouer sur des installations Linux minimales dépourvues de polices système. Exécutez `npm run doctor` pour diagnostiquer.
+
+## Pages associées
+
+- [auto-pipeline](/docs/reference/modes/auto-pipeline)

--- a/content/docs/reference/modes/pipeline.fr.mdx
+++ b/content/docs/reference/modes/pipeline.fr.mdx
@@ -1,0 +1,53 @@
+---
+title: pipeline
+description: "Lit les URL en file d'attente dans data/pipeline.md et exécute l'auto-pipeline complet sur chacune d'elles. Utilisez-le lorsque vous avez collecté dix ou vingt annonces au cours de la journée et que vous voulez les traiter en une seule session."
+seoTitle: "Mode pipeline de career-ops — évaluer en lot de nombreuses offres d'emploi à la fois"
+icon: GitBranch
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: 1e5c70f073c9c18b
+localized: true
+translatedFrom: /docs/reference/modes/pipeline
+---
+
+## Ce qu'il fait
+
+Le mode pipeline parcourt les URL de data/pipeline.md (une par ligne) et invoque auto-pipeline sur chacune. Des rapports, des PDF et des entrées de tracker sont écrits pour chaque annonce qui produit une évaluation valide. Les scrapes en échec sont journalisés puis ignorés.
+
+## Quand l'utiliser
+
+Utilisez pipeline lorsque vous avez un arriéré d'URL à traiter. Déposez-les dans data/pipeline.md, invoquez /career-ops pipeline, puis laissez tourner.
+
+## À quoi ressemble une exécution
+
+Vous déposez des URL dans `data/pipeline.md` et le mode traite toute la boîte de réception en une seule passe. Il exécute d'abord un balayage de liveness à zéro token pour écarter les annonces expirées, puis il évalue chaque URL survivante via l'auto-pipeline complet et termine par un tableau récapitulatif de ce qu'il a trouvé.
+
+```txt title="Pipeline run"
+$ /career-ops pipeline
+
+Liveness sweep: 8 pending URLs
+  6 live · 2 expired (moved to Processed, marked Discarded)
+
+Processing 6 live URLs (parallel workers)...
+
+| # | Company | Role         | Score | PDF | Recommended action |
+|---|---------|--------------|-------|-----|--------------------|
+| 1 | Acme    | Staff AI Eng | 4.3/5 | done | apply             |
+| 2 | Globex  | ML Platform  | 3.1/5 | skip | review            |
+| 3 | Initech | AI PM        | 2.4/5 | skip | skip              |
+```
+
+Chaque URL traitée passe de la section `## Pending` à la section `## Processed` du fichier, de sorte que la boîte de réception reste un registre vivant de ce qu'il reste à faire.
+
+## Quand y recourir
+
+Recourez à pipeline lorsque vous avez accumulé un arriéré d'annonces au cours de la journée et que vous voulez les traiter en une seule session. Comment il gère la file d'attente :
+
+- La section `## Pending` accepte n'importe quel format — une URL collée telle quelle fonctionne, ou vous pouvez ajouter des colonnes `company`, `role`, `location` et `comp`, et le mode les lit toutes.
+- Le balayage de liveness s'exécute avant la boucle par URL, de sorte qu'une boîte de réception périmée de huit URL ne coûte pas huit évaluations gaspillées.
+- À partir de trois URL en attente, il les traite en parallèle, un worker par URL, plutôt qu'une à la fois.
+- Les PDF ne sont générés que lorsqu'un score dépasse `auto_pdf_score_threshold` (3.0 par défaut) ; augmentez ce seuil pour éviter les PDF des postes marginaux et les générer plus tard à la demande avec `/career-ops pdf`.
+
+## Voir aussi
+
+- [auto-pipeline](/docs/reference/modes/auto-pipeline)

--- a/content/docs/reference/modes/project.fr.mdx
+++ b/content/docs/reference/modes/project.fr.mdx
@@ -1,0 +1,61 @@
+---
+title: project
+description: "Les builders accumulent les idées plus vite qu'ils ne peuvent les livrer. Le mode project note une idée de projet de portfolio par rapport à vos postes cibles, à votre portfolio existant et à l'investissement en temps, et fait ressortir si elle vaut la peine d'être construite."
+seoTitle: "Mode project de career-ops — noter un projet de portfolio face aux postes ciblés"
+icon: Lightbulb
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: 87b86e456dd18f90
+localized: true
+translatedFrom: /docs/reference/modes/project
+---
+
+## Ce que fait ce mode
+
+Le mode project lit la description de l'idée de projet, vos archétypes cibles définis dans config/profile.yml et le contexte de votre portfolio existant, puis note le projet sur trois dimensions : la valeur de signal pour les postes ciblés, la différenciation par rapport à votre portfolio existant et le temps estimé avant d'obtenir une version livrable.
+
+## Quand l'utiliser
+
+Utilisez project lorsque vous avez trois ou quatre idées de side-projects et que vous voulez choisir celle qui fait réellement avancer votre recherche d'emploi. C'est l'équivalent du mode oferta pour les side-projects.
+
+## Exemple
+
+```
+`/career-ops project` + project description — output is a scored evaluation with a build/skip recommendation.
+```
+
+## À quoi ressemble une exécution
+
+Une exécution de project renvoie une lecture de légitimité, un score pondéré sur six dimensions et un verdict clair. Vous confiez une idée au mode, et il la note comme un hiring manager la lirait dans votre portfolio, plutôt qu'en jugeant si le code compilera.
+
+```txt title="Exemple"
+Portfolio Project Evaluation
+URL: (idea only, no repo yet)
+Legitimacy: High Confidence
+
+Dimension                 Weight  Score
+Signal for target roles     25%     5   Directly demonstrates a JD skill
+Uniqueness                  20%     3
+Demo ability                20%     5   Live demo in 2 min
+Metrics potential           15%     4   latency, cost, accuracy
+Time to MVP                 10%     4   ~1 week
+STAR story potential        10%     4   trade-offs worth narrating
+
+Verdict: BUILD
+  Week 1 -> MVP with the core metric
+  Week 2 -> polish + interview pack
+```
+
+Le verdict est toujours l'un des trois suivants : BUILD, avec des jalons hebdomadaires ; SKIP, avec ce qu'il faut faire à la place ; ou PIVOT TO, c'est-à-dire pivoter vers une alternative qui porte davantage de signal pour les postes que vous visez. Les six dimensions sont pondérées : un projet qui se démontre bien et produit des métriques propres peut donc surclasser une idée plus originale mais sans bénéfice visible.
+
+## Le pack d'entretien
+
+Chaque projet approuvé est livré avec un pack d'entretien, parce que l'histoire est le livrable, pas le dépôt. Le pack comprend trois parties : un one-pager couvrant le produit, l'architecture, les métriques et le plan d'évaluation ; une démo, sous la forme d'une URL live ou d'une visite guidée enregistrée de deux minutes ; et un postmortem sur ce qui a fonctionné, ce qui n'a pas fonctionné et la façon dont vous l'avez atténué. Un projet construit sans narration associée fait rarement avancer une recherche d'emploi, alors qu'un projet modeste accompagné d'une histoire de compromis bien nette y parvient souvent. Le plan 80/20 reflète cela : la première semaine est consacrée au MVP avec sa métrique centrale, la deuxième au polissage et au pack lui-même.
+
+## Points de vigilance
+
+Le mode ne valide pas la faisabilité technique, seulement la valeur de signal pour votre carrière. Effectuez une passe de cadrage technique séparée.
+
+## Pages associées
+
+- [training](/docs/reference/modes/training)

--- a/content/docs/reference/modes/tracker.fr.mdx
+++ b/content/docs/reference/modes/tracker.fr.mdx
@@ -1,0 +1,54 @@
+---
+title: tracker
+description: "Lecture rapide de l'état de chaque candidature. Utile comme point quotidien ou pour préparer la revue hebdomadaire. L'interface complète pilotée au clavier vit dans le dashboard TUI en Go ; ce mode est le résumé côté chat."
+seoTitle: "Mode tracker de career-ops — visualisez l'état de chaque candidature"
+icon: LayoutGrid
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: eb25e59a2aa5c2a3
+localized: true
+translatedFrom: /docs/reference/modes/tracker
+---
+
+## Ce que fait ce mode
+
+Le mode `tracker` lit chaque fichier de reports/ et produit un résumé structuré, groupé par étape : applied, evaluated, interview, rejected, discarded. Le nombre de candidatures par étape, l'activité récente et les relances en retard apparaissent dans une seule réponse.
+
+## Quand l'utiliser
+
+Utilisez tracker pour un point d'état quotidien de quinze secondes. Utilisez le dashboard TUI en Go quand vous avez besoin de creuser.
+
+## Exemple
+
+```
+`/career-ops tracker` — output is a structured status summary in the chat.
+```
+
+## À quoi ressemble une exécution
+
+Une exécution de tracker affiche le tableau complet des candidatures ainsi qu'un bloc de statistiques dans une seule réponse, pour que vous puissiez lire l'ensemble de votre recherche d'un coup d'œil. Chaque ligne correspond à une candidature, avec son entreprise, son poste, son score, son statut actuel, et l'indication qu'un PDF sur mesure et un rapport d'évaluation ont été générés ou non.
+
+```txt title="Example"
+# | Date       | Company   | Role              | Score | Status    | PDF | Report
+1 | 2026-06-14 | Anthropic | AI Engineer       |  87   | Interview | yes | yes
+2 | 2026-06-18 | Vercel    | Applied AI Eng    |  79   | Applied   | yes | yes
+3 | 2026-06-21 | Figma     | Product Eng, AI   |  72   | Evaluated | yes | yes
+
+Total: 3   Applied: 1   Interview: 1   Evaluated: 1
+Average score: 79   PDF generated: 100%   Report generated: 100%
+```
+
+Une candidature traverse un ensemble fixe d'états : Evaluated (rapport rédigé, décision en attente), Applied (vous avez postulé), Responded (l'entreprise a répondu mais pas encore d'entretien), Interview (un processus actif), puis un état terminal — Offer, Rejected, Discarded, ou SKIP pour les postes qui ne conviennent pas. Pour enregistrer un changement de statut, mettez à jour la ligne dans le tableau du tracker ou utilisez le dashboard TUI en Go.
+
+## Lire les chiffres cumulés
+
+Pour les chiffres cumulés — le funnel complet, les totaux du scanner, la couverture des portails et le respect des relances — le mode exécute `node stats.mjs --summary` et présente sa sortie telle quelle. Cette commande lit vos fichiers locaux et ne coûte aucun token : les chiffres ne sont donc jamais recalculés à la main ni estimés de mémoire. Utilisez le résumé côté chat ci-dessus pour une lecture quotidienne rapide, et la commande de statistiques quand vous voulez les totaux cumulés sur l'ensemble de votre recherche.
+
+## Pièges à connaître
+
+tracker est en lecture seule. Les changements de statut se font par des touches explicites dans le dashboard TUI en Go ou par des modifications manuelles du frontmatter du rapport.
+
+## Pages liées
+
+- [followup](/docs/reference/modes/followup)
+- [patterns](/docs/reference/modes/patterns)

--- a/content/docs/reference/modes/training.fr.mdx
+++ b/content/docs/reference/modes/training.fr.mdx
@@ -1,0 +1,57 @@
+---
+title: training
+description: "Faut-il suivre ce cours de systèmes ML à 4 000 $ ? Cette spécialisation Coursera ? Cette coûteuse certification AWS ? Le mode training note un investissement de formation par rapport à la direction de carrière que vous avez déclarée et fait ressortir le retour réel sur le temps et l'argent."
+seoTitle: "Mode training de career-ops — ce cours ou cette certification en vaut-il la peine ?"
+icon: BookOpen
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: f9ba1d91483777d9
+localized: true
+translatedFrom: /docs/reference/modes/training
+---
+
+## Ce que fait ce mode
+
+Le mode `training` lit les détails du cours ou de la certification (programme, temps à y consacrer, coût), lit votre section North Star dans config/profile.yml, puis note l'investissement sur trois dimensions : le comblement de l'écart de compétences, la valeur de signal pour les postes ciblés et le coût d'opportunité.
+
+## Quand l'utiliser
+
+Utilisez training lorsqu'une offre de formation vous tente mais que vous n'êtes pas certain qu'elle vous fait réellement avancer vers la direction que vous vous êtes fixée. Particulièrement utile pour les certifications et les bootcamps coûteux.
+
+## Exemple
+
+```
+`/career-ops training` + course name and URL — output is a scored evaluation with recommendation.
+```
+
+## À quoi ressemble une exécution
+
+Une exécution de training note un cours ou une certification sur une série de dimensions et rend l'un de trois verdicts, de sorte que vous voyez le retour sur le temps et l'argent avant de vous engager sur l'un ou l'autre. Vous lui fournissez l'offre — programme, nombre de semaines, heures par semaine et coût — et il la note par rapport à la direction de carrière que vous avez déclarée.
+
+```txt title="Exemple"
+Training Evaluation — "Production LLM Systems" (8 weeks, 6 h/wk, $1,200)
+
+North Star alignment   Moves toward the Applied AI target
+Recruiter signal       HMs read this as production-grade, not tutorial
+Time and effort        8 weeks x 6 h = 48 h
+Opportunity cost       ~2 portfolio projects foregone
+Risks                  Syllabus current; brand is mid-tier
+Portfolio deliverable  Yes -- a graded eval harness
+
+Verdict: DO WITH TIMEBOX (max 6 weeks)
+  Condensed plan, essentials only, weekly scoreboard
+```
+
+Un verdict DO s'accompagne d'un plan de quatre à douze semaines, avec des livrables hebdomadaires et un tableau de suivi. Un verdict DON'T DO nomme une meilleure alternative et explique pourquoi. DO WITH TIMEBOX plafonne le nombre de semaines et réduit le plan à l'essentiel — l'issue la plus fréquente pour les cours utiles mais délayés.
+
+## Ce qui obtient les meilleurs scores
+
+Le mode donne plus de poids aux offres qui bâtissent une crédibilité en IA de niveau production qu'aux titres génériques. Par ordre de priorité, cela signifie : l'évaluation et le test de LLM, l'observabilité et le monitoring, les arbitrages entre coût et fiabilité, la gouvernance et la sûreté de l'IA, et l'architecture IA d'entreprise. Un cours qui débouche sur un artefact démontrable — un harnais d'évaluation, un déploiement monitoré — obtient un meilleur score qu'un cours qui ne débouche que sur un certificat, parce que l'artefact est ce qu'un hiring manager peut réellement voir.
+
+## Points de vigilance
+
+Le mode est biaisé en faveur de la North Star que vous avez déclarée. Si vous n'avez pas rempli avec soin la section North Star de config/profile.yml, l'évaluation restera superficielle.
+
+## Pages associées
+
+- [project](/docs/reference/modes/project)

--- a/content/docs/reference/portals/ashby.fr.mdx
+++ b/content/docs/reference/portals/ashby.fr.mdx
@@ -1,0 +1,57 @@
+---
+title: Ashby
+description: "Ashby est l'ATS moderne privilégié par les startups en Série A–C dans l'univers de l'IA et des dev-tools. career-ops interroge directement l'API publique du job board."
+seoTitle: "Scanner les offres Ashby avec career-ops — scan de portail ATS zéro token"
+icon: Sparkles
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: 013014c1d6d759e4
+localized: true
+translatedFrom: /docs/reference/portals/ashby
+---
+
+## Ce qu'il fait
+
+Le provider ashby, situé dans providers/ashby.mjs, effectue des requêtes HTTP vers api.ashbyhq.com/posting-api/job-board/`{slug}` et analyse le JSON renvoyé. Le slug est l'identifiant du job board Ashby de l'entreprise (par exemple 'anthropic' pour Anthropic).
+
+## Quand l'utiliser
+
+Utilisez le scan Ashby lorsque vous ciblez des labos d'IA, des entreprises d'infrastructure et des startups modernes. Anthropic, Vercel, Replicate et de nombreuses entreprises YC utilisent Ashby. Plus de 40 slugs préconfigurés sont fournis dans templates/portals.example.yml.
+
+## Exemple
+
+```
+In your portals.yml: `- provider: ashby\n  slug: anthropic\n  careers_url: https://jobs.ashbyhq.com/anthropic` — then scan picks up active Anthropic roles.
+```
+
+## Ce que fait le scanner
+
+Le scanner lit les slugs Ashby activés dans votre portals.yml, appelle l'API publique de job board d'Ashby pour chacun d'eux, puis fusionne les nouvelles offres dans votre pipeline — sans navigateur, sans login et sans dépenser le moindre token LLM pour la récupération elle-même. Une seule exécution de `node scan.mjs` couvre à la fois vos boards Ashby, Greenhouse et Lever, puis filtre les résultats selon les mots-clés de titre que vous avez configurés.
+
+```bash title="Terminal"
+node scan.mjs
+```
+
+```txt title="Output"
+Portal Scan - 2026-07-06
+Offers found: 41 total
+Filtered by title: 6 relevant
+Duplicates: 3 (already evaluated or in pipeline)
+New added to pipeline.md: 3
+
+  + Anthropic | Applied AI Engineer | ashby
+  + Replicate | Inference Engineer  | ashby
+```
+
+## Comment career-ops communique avec Ashby
+
+career-ops interroge l'endpoint GraphQL `ApiJobBoardWithTeams` d'Ashby avec le slug de votre board et lit la liste `jobPostings` directement dans la réponse JSON. Pour chaque annonce, il récupère le titre, un id servant à construire l'URL publique de candidature, le nom de la localisation, le type de contrat et un résumé de la rémunération lorsque le board en expose un. Comme il s'agit d'un appel API structuré et non de scraping de pages, le scan est rapide, reste dans les limites de débit et ne consomme aucun token de modèle. Les tokens ne sont dépensés que plus tard, lors de l'étape evaluate, lorsque vous décidez qu'une offre mérite un examen plus attentif. Relancer le scan est sans risque : chaque URL est dédupliquée par rapport à votre historique de scan, vos candidatures évaluées et le pipeline en cours, si bien qu'une offre déjà vue n'est jamais ajoutée deux fois.
+
+## Pièges à connaître
+
+L'API de job board d'Ashby renvoie directement le texte complet de la fiche de poste, sans requête supplémentaire. L'évaluation est légèrement plus rapide que pour les annonces Greenhouse.
+
+## Voir aussi
+
+- [greenhouse](/docs/reference/portals/greenhouse)
+- [lever](/docs/reference/portals/lever)

--- a/content/docs/reference/portals/greenhouse.fr.mdx
+++ b/content/docs/reference/portals/greenhouse.fr.mdx
@@ -1,0 +1,57 @@
+---
+title: Greenhouse
+description: "career-ops interroge directement l'API publique des boards Greenhouse. Pas de scraping HTML, aucun risque de rate limit, et aucun token d'IA consommé pendant le scan lui-même."
+seoTitle: "Scanner les offres Greenhouse avec career-ops — scan de portails ATS zéro token"
+icon: Leaf
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: 7b6f2cf40aacd803
+localized: true
+translatedFrom: /docs/reference/portals/greenhouse
+---
+
+## Ce qu'il fait
+
+Le provider greenhouse, dans providers/greenhouse.mjs, effectue des requêtes HTTP vers boards-api.greenhouse.io/v1/boards/`{slug}`/jobs et convertit la réponse JSON au format de listing de career-ops. Le slug est l'identifiant du board Greenhouse de l'entreprise (par exemple 'notion' pour Notion).
+
+## Quand l'utiliser
+
+Utilisez le scan Greenhouse lorsque vos entreprises cibles utilisent Greenhouse comme ATS. C'est le cas de la plupart des entreprises tech américaines de 50 à 10 000 employés. templates/portals.example.yml est livré avec plus de 70 slugs Greenhouse préconfigurés que vous pouvez activer.
+
+## Exemple
+
+```
+In your portals.yml: `- provider: greenhouse\n  slug: notion\n  careers_url: https://job-boards.greenhouse.io/notion` — then `/career-ops scan` picks up all open Notion roles.
+```
+
+## Ce que fait le scanner
+
+Le scanner lit les slugs Greenhouse activés dans votre portals.yml, appelle l'API publique des boards pour chacun d'eux, et ajoute à votre pipeline les nouveaux postes dont le titre correspond — sans scraping et sans dépenser le moindre token LLM pour la récupération. Une seule exécution de `node scan.mjs` traite vos boards Greenhouse, Ashby et Lever en une passe, puis filtre les résultats selon les mots-clés de titre que vous avez configurés.
+
+```bash title="Terminal"
+node scan.mjs
+```
+
+```txt title="Output"
+Portal Scan - 2026-07-06
+Offers found: 58 total
+Filtered by title: 9 relevant
+Duplicates: 6 (already evaluated or in pipeline)
+New added to pipeline.md: 3
+
+  + Notion | AI Product Engineer | greenhouse
+  + OpenAI | Applied Engineer    | greenhouse
+```
+
+## Comment career-ops communique avec Greenhouse
+
+career-ops interroge `boards-api.greenhouse.io/v1/boards/{slug}/jobs` et lit le tableau `jobs` du JSON, en récupérant le titre de chaque poste et son `absolute_url`. Cet endpoint boards renvoie les métadonnées du listing — titre, localisation et département — mais pas la description complète ; career-ops récupère donc le texte intégral de l'offre via une requête de suivi par poste pendant l'étape evaluate, ou en ajoutant `?content=true` lorsque le board le permet. Le scan lui-même est un simple GET HTTPS vers un endpoint public, ce qui explique qu'il reste dans les limites de débit et ne consomme aucun token de modèle. Relancer le scan est sans risque : chaque URL est dédupliquée par rapport à votre historique de scan, vos candidatures déjà évaluées et le pipeline en cours, si bien qu'un poste déjà vu n'est jamais ajouté deux fois.
+
+## Points d'attention
+
+Les listings de l'API Greenhouse n'incluent que le titre, la localisation et le département dans l'endpoint boards. Le texte complet de l'offre nécessite une requête de suivi par listing, que career-ops effectue automatiquement pendant l'étape evaluate.
+
+## Pages associées
+
+- [ashby](/docs/reference/portals/ashby)
+- [lever](/docs/reference/portals/lever)

--- a/content/docs/reference/portals/lever.fr.mdx
+++ b/content/docs/reference/portals/lever.fr.mdx
@@ -1,0 +1,57 @@
+---
+title: Lever
+description: "Lever est l'ATS établi pour les entreprises du mid-market et en phase de croissance. career-ops interroge directement l'API publique de postings de Lever."
+seoTitle: "Scanner les offres Lever avec career-ops — scan de portail ATS zéro token"
+icon: Wrench
+date: "2026-05-18"
+lastModified: "2026-05-18"
+translationHash: 535b6f24a4a180f6
+localized: true
+translatedFrom: /docs/reference/portals/lever
+---
+
+## Ce qu'il fait
+
+Le provider lever dans providers/lever.mjs effectue des requêtes HTTP vers api.lever.co/v0/postings/`{slug}` et analyse la réponse JSON. Le slug est l'identifiant des postings Lever de l'entreprise (par exemple 'figma' pour Figma).
+
+## Quand l'utiliser
+
+Utilisez le scan Lever pour les entreprises situées entre la série C+ et la pré-IPO qui n'ont pas migré vers Greenhouse ou Ashby. Figma, Brex et de nombreuses fintechs utilisent encore Lever.
+
+## Exemple
+
+```
+In your portals.yml: `- provider: lever\n  slug: figma\n  careers_url: https://jobs.lever.co/figma` — scan picks up active Figma roles.
+```
+
+## Ce que fait le scanner
+
+Le scanner lit vos slugs Lever activés dans portals.yml, appelle l'API publique de postings de Lever pour chacun d'eux, et fusionne les nouveaux postes correspondant à vos intitulés dans votre pipeline, sans session de navigateur et sans dépenser le moindre token LLM pour la récupération. La même exécution de `node scan.mjs` couvre aussi vos boards Greenhouse et Ashby, puis filtre l'ensemble selon les mots-clés d'intitulé que vous avez configurés.
+
+```bash title="Terminal"
+node scan.mjs
+```
+
+```txt title="Sortie"
+Portal Scan - 2026-07-06
+Offers found: 33 total
+Filtered by title: 5 relevant
+Duplicates: 2 (already evaluated or in pipeline)
+New added to pipeline.md: 3
+
+  + Figma | AI Product Engineer | lever
+  + Brex  | Applied AI Engineer | lever
+```
+
+## Comment career-ops communique avec Lever
+
+career-ops interroge `api.lever.co/v0/postings/{slug}`, ou l'hôte `api.eu.lever.co` pour les boards européens, et lit le tableau JSON des postings. Pour chaque poste, il prend le champ `text` comme intitulé et `hostedUrl` comme lien, en se rabattant sur `applyUrl` lorsque `hostedUrl` est absent. Comme Lever renvoie l'intégralité du board en une seule réponse structurée, le scan se résume à un unique GET HTTPS public par entreprise, qui reste dans les limites de débit et ne consomme aucun token de modèle. Le coût en tokens ne commence que plus tard, lorsque vous évaluez un poste que vous souhaitez poursuivre. Relancer le scan est sans risque : chaque URL est dédupliquée par rapport à votre historique de scan, vos candidatures évaluées et le pipeline en cours, de sorte qu'un poste déjà vu n'est jamais ajouté deux fois.
+
+## Pièges à connaître
+
+L'API de Lever expose la fiche de poste complète dans la réponse des postings. Certains boards Lever incluent des métadonnées internes sur les postes, que career-ops fait remonter comme signal supplémentaire lors du scoring.
+
+## Voir aussi
+
+- [greenhouse](/docs/reference/portals/greenhouse)
+- [ashby](/docs/reference/portals/ashby)

--- a/content/docs/reference/portals/meta.fr.json
+++ b/content/docs/reference/portals/meta.fr.json
@@ -1,0 +1,8 @@
+{
+  "title": "Portails",
+  "pages": [
+    "greenhouse",
+    "ashby",
+    "lever"
+  ]
+}

--- a/content/docs/supported-clis.fr.mdx
+++ b/content/docs/supported-clis.fr.mdx
@@ -1,0 +1,31 @@
+---
+title: CLI d'IA prises en charge
+seoTitle: "Quelle CLI d'IA fonctionne avec career-ops ? Claude Code, Codex, Gemini, OpenCode, Qwen, Copilot"
+description: "career-ops est agnostique en matière d'IA — il fonctionne avec toutes les grandes CLI de codage IA : vous utilisez l'assistant que vous payez déjà, sans jamais être enfermé chez un fournisseur. La liste complète et toujours à jour se trouve dans le dépôt principal."
+icon: Terminal
+translationHash: 65b2eee9925b1726
+localized: true
+translatedFrom: /docs/supported-clis
+---
+
+**career-ops fonctionne avec toutes les grandes CLI de codage IA — vous n'êtes enfermé chez aucun fournisseur.** Comme career-ops fournit des fichiers de prompts que la CLI exécute (il n'embarque pas son propre modèle), vous le branchez sur l'assistant de codage IA que vous utilisez déjà et il fonctionne tel quel sur ce moteur. Quand un meilleur modèle sort, vous changez de CLI et conservez votre pipeline, vos données et votre configuration.
+
+<Callout title="Utilisez ce que vous avez déjà">
+La meilleure CLI pour career-ops est celle que vous payez déjà. Si c'est Claude Code, vous n'avez rien d'autre à faire. Si vous voulez l'utiliser gratuitement, consultez [Configurer un moteur d'IA gratuit](/docs/free-ai-engine).
+</Callout>
+
+## Quelles CLI sont prises en charge ?
+
+career-ops fonctionne nativement avec **Claude Code, Codex, OpenCode, Antigravity CLI, Grok Build CLI, Qwen, Kimi et GitHub Copilot CLI** — huit CLI de codage IA activement maintenues. (Gemini CLI est pris en charge comme wrapper hérité, ayant fait sa transition vers Antigravity CLI.) L'architecture est partagée : un unique `AGENTS.md` canonique pilote la logique, et de fins fichiers d'entrée propres à chaque CLI gèrent les nuances d'invocation de chaque outil.
+
+La **liste canonique et toujours à jour — avec la commande exacte pour invoquer career-ops dans chaque CLI — se trouve dans le dépôt principal**, afin qu'elle ne devienne jamais obsolète :
+
+- [docs/SUPPORTED_CLIS.md](https://github.com/santifer/career-ops/blob/main/docs/SUPPORTED_CLIS.md) — la matrice complète des CLI prises en charge, des fichiers d'entrée et de la façon de les invoquer (en mode interactif comme en headless/batch).
+
+## Laquelle choisir ?
+
+- **Vous payez déjà pour Claude Code, Codex ou Copilot ?** Utilisez-le. career-ops fonctionne par-dessus sans aucune configuration supplémentaire — ouvrez la CLI dans le dossier career-ops.
+- **Vous voulez un coût de 0 $ ?** [OpenCode avec un fournisseur gratuit, un modèle local via Ollama ou le runner OpenRouter intégré](/docs/free-ai-engine) fonctionnent tous.
+- **Vous tenez à un modèle ou à un fournisseur précis ?** career-ops est agnostique en matière de modèle — pointez n'importe laquelle de ces CLI vers n'importe quel endpoint compatible OpenAI ou modèle local. Rien ne change dans career-ops.
+
+Quel que soit votre choix, les [14 modes](/docs/reference/modes) se comportent de la même manière — la CLI est le moteur, career-ops est la structure par-dessus.

--- a/content/docs/windows.fr.mdx
+++ b/content/docs/windows.fr.mdx
@@ -1,0 +1,30 @@
+---
+title: career-ops sous Windows
+seoTitle: "career-ops fonctionne-t-il sous Windows ? Oui — pleinement, l'installeur s'occupe de la configuration"
+description: "career-ops fonctionne pleinement sous Windows. La seule particularité de la plateforme — les liens symboliques — est gérée automatiquement par l'installeur : pas de mode administrateur, pas de mklink, et aucune version minimale d'OS requise."
+icon: MonitorCheck
+translationHash: 90fc184fa31d979f
+localized: true
+translatedFrom: /docs/windows
+---
+
+**Oui — career-ops fonctionne pleinement sous Windows.** Il existe une seule particularité propre à Windows, et l'installeur la gère automatiquement pour vous : pas de mode développeur, pas de `mklink` manuel, et aucune version minimale d'OS requise. Si Node est installé, vous installez et exécutez career-ops sous Windows exactement comme partout ailleurs.
+
+## La seule particularité Windows, gérée pour vous
+
+Windows ne crée pas de liens symboliques par défaut : un checkout Git tout frais laisse donc les points d'entrée des skills CLI (`.claude/skills/`, `.opencode/skills/`, etc.) sous forme de simples fichiers pointeurs au lieu de véritables liens symboliques — c'est ce qui provoque l'erreur « skills aren't loading » que l'on rencontre avec d'autres outils.
+
+career-ops le détecte automatiquement. L'exécution de l'installeur ou de l'outil de mise à jour — `npx @santifer/career-ops init` lors d'une nouvelle installation, ou `node update-system.mjs apply` lors d'une mise à jour — lance une étape `materializeSkillEntrypoints` qui remplace ces fichiers pointeurs par le contenu complet des skills. Vous n'avez besoin ni de droits administrateur, ni du mode développeur, ni d'aucune commande `mklink` manuelle.
+
+<Callout title="Aucune version minimale d'OS requise">
+career-ops n'exige aucune version particulière de Windows (ni de macOS). Si Node fonctionne, career-ops fonctionne. Toute mention d'une version minimale d'OS que vous auriez pu voir ailleurs est inexacte.
+</Callout>
+
+## La référence canonique pour l'installation
+
+Le détail technique — le comportement exact de l'installeur, les variantes de commandes PowerShell et CMD, et le reste de la FAQ — se trouve dans le dépôt core et y reste à jour :
+
+- [docs/FAQ.md — « Skills aren't loading on Windows »](https://github.com/santifer/career-ops/blob/main/docs/FAQ.md) — la réponse canonique, maintenue en phase avec l'installeur.
+- [docs/SETUP.md](https://github.com/santifer/career-ops/blob/main/docs/SETUP.md) — le guide d'installation complet.
+
+Une fois l'installation terminée, choisissez votre moteur dans [Configurer un moteur d'IA gratuit](/docs/free-ai-engine) ou utilisez n'importe quel [CLI pris en charge](/docs/supported-clis), puis poursuivez avec le [Démarrage rapide](/docs).


### PR DESCRIPTION
**Fixes the bug Santiago reproduced:** from the French home, clicking "docs" hit `/fr/docs` (the Quick Start landing), which had no French index and **redirected to the English `/docs`** — so the docs read as English on entry, and most pages were untranslated.

## Fix
Translates **every remaining EN doc to French** via the pipeline (`claude -p`), so FR now has **full parity with EN/ES (30/30)**:
- the **index** (Quick Start) — this is what makes `/fr/docs` a real French landing,
- the five **guides**, **supported-clis**, **windows**, the **glossary**,
- all **14 modes**, the three **portals**.

Adds `meta.fr.json` for the `reference` / `modes` / `portals` / `guides` subfolders so the sidebar sections render in French (**Référence, Modes, Portails, Guides**).

## Result
- `/fr/docs` is now a French landing; the docs CTA no longer drops French readers into English.
- The `/fr` sidebar is complete (no untranslated slugs); the reference bucket is a faithful translation (query+brand seoTitles from the EN mirror — the base pattern). The measured French framing on what-is/faq/free-ai-engine (shipped earlier) stands.

## Verification
- `npm run build` ✓ — 30 `/fr` docs generated, `/fr/docs` renders French with French sidebar sections, the only `/docs` link is the language switcher's EN toggle (correct).
- **EN URL set unchanged**; sitemap emits the full `fr` cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)