### PR TITLE
i18n: ES panhispanic sweep + FR "sans perdre le contrôle" heading

### DIFF
--- a/content/docs/faq.es.mdx
+++ b/content/docs/faq.es.mdx
@@ -9,7 +9,7 @@ translatedFrom: /docs/faq
 ---
 
 {/* Espejado con src/lib/faq-data.ts (FAQPage JSON-LD) — editar ambos a la vez.
-    Las respuestas están verificadas contra docs/FAQ.md del repo core; el fichero
+    Las respuestas están verificadas contra docs/FAQ.md del repo core; el archivo
     del core es la fuente de verdad del comportamiento técnico. */}
 
 Las preguntas más comunes, respondidas en un solo sitio. Para cualquier cosa que no esté cubierta aquí, pregunta en [Discord](https://discord.gg/8pRpHETxa4) o abre una [GitHub Discussion](https://github.com/santifer/career-ops/discussions).
@@ -26,11 +26,11 @@ No. career-ops es agnóstico respecto a la IA — Claude Code es un motor entre 
 
 ## ¿Dónde se guardan mis datos? ¿career-ops es privado?
 
-En tu máquina, en ficheros planos que son tuyos — tu CV, tu perfil, tu pipeline y tus informes son Markdown/YAML locales. Nada corre en servidores de career-ops. Las actualizaciones del sistema nunca tocan tu capa de datos (`cv.md`, `config/`, `data/`, `reports/`, `output/`): esa separación es el **Data Contract**, y todas las actualizaciones lo respetan.
+En tu máquina, en archivos planos que son tuyos — tu CV, tu perfil, tu pipeline y tus informes son Markdown/YAML locales. Nada corre en servidores de career-ops. Las actualizaciones del sistema nunca tocan tu capa de datos (`cv.md`, `config/`, `data/`, `reports/`, `output/`): esa separación es el **Data Contract**, y todas las actualizaciones lo respetan.
 
 ## ¿Con qué CLIs de programación con IA funciona career-ops?
 
-Ocho, con soporte de primera clase: Claude Code, Codex, OpenCode, Antigravity CLI, Grok Build CLI, Qwen, Kimi y GitHub Copilot CLI (Gemini CLI está soportado como wrapper legacy). career-ops es agnóstico respecto a la IA: distribuye ficheros de prompts que el CLI ejecuta, así que también puedes apuntarlo a cualquier endpoint compatible con OpenAI o a un modelo local sin cambiar una sola línea de código. Consulta [CLIs de IA compatibles](/docs/supported-clis) para ver la lista actual y cómo invocar cada uno.
+Ocho, con soporte de primera clase: Claude Code, Codex, OpenCode, Antigravity CLI, Grok Build CLI, Qwen, Kimi y GitHub Copilot CLI (Gemini CLI está soportado como wrapper legacy). career-ops es agnóstico respecto a la IA: distribuye archivos de prompts que el CLI ejecuta, así que también puedes apuntarlo a cualquier endpoint compatible con OpenAI o a un modelo local sin cambiar una sola línea de código. Consulta [CLIs de IA compatibles](/docs/supported-clis) para ver la lista actual y cómo invocar cada uno.
 
 ## ¿Cuál es la diferencia entre `scan` y `scan:full`?
 
@@ -42,7 +42,7 @@ Acota la ejecución con `./batch/batch-runner.sh --limit 5` para inspeccionar la
 
 ## Las skills no cargan en Windows — error de symlink al instalar
 
-Windows no crea symlinks por defecto, así que al hacer checkout Git deja los puntos de entrada de las skills del CLI como simples ficheros puntero. El instalador y el actualizador lo detectan automáticamente: ejecuta `node update-system.mjs apply` (o `npx @santifer/career-ops init` en una instalación nueva) y el paso de materialización sustituye los ficheros puntero por el contenido completo de cada skill. No hace falta ningún `mklink` manual ni activar el Modo de desarrollador.
+Windows no crea symlinks por defecto, así que al hacer checkout Git deja los puntos de entrada de las skills del CLI como simples archivos puntero. El instalador y el actualizador lo detectan automáticamente: ejecuta `node update-system.mjs apply` (o `npx @santifer/career-ops init` en una instalación nueva) y el paso de materialización sustituye los archivos puntero por el contenido completo de cada skill. No hace falta ningún `mklink` manual ni activar el Modo de desarrollador.
 
 ## ¿Puedo ejecutar career-ops con un modelo más barato o local?
 

--- a/content/docs/free-ai-engine.es.mdx
+++ b/content/docs/free-ai-engine.es.mdx
@@ -15,12 +15,12 @@ career-ops no tiene planes de pago, ni versiones de pago, ni pruebas: es 100% gr
 Tú pones tu propio motor y tu propia clave. Nada corre en nuestros servidores — todo ocurre en tu máquina. Esta página muestra las vías gratuitas, de la más fácil a la más manual. Elige una y estarás listo para el [Inicio rápido](/docs).
 
 <Callout title="¿Qué estoy configurando exactamente?">
-Piensa en career-ops como la receta y en el motor de IA como el cocinero. La receta es gratis para siempre. Esta página va de conseguir un cocinero gratis — ya sea un modelo alojado con free tier o un modelo que corre por completo en tu propio ordenador.
+Piensa en career-ops como la receta y en el motor de IA como el cocinero. La receta es gratis para siempre. Esta página va de conseguir un cocinero gratis — ya sea un modelo alojado con free tier o un modelo que corre por completo en tu propio equipo.
 </Callout>
 
 ## ¿Qué vía me conviene?
 
-| Si quieres… | Usa | ¿Gratis? | ¿Necesita un buen ordenador? |
+| Si quieres… | Usa | ¿Gratis? | ¿Necesita un buen equipo? |
 | --- | --- | --- | --- |
 | El arranque gratuito más fácil | **OpenCode + un proveedor gratuito** | Sí | No |
 | Todo 100 % offline y privado | **Ollama (modelo local)** | Sí | Sí — 16 GB+ de VRAM |
@@ -62,7 +62,7 @@ Eso es todo — OpenCode ya es tu motor. Sigue con el [Inicio rápido](/docs).
 
 ## Vía 3 — 100 % local con Ollama (totalmente offline)
 
-¿Quieres cero nube, cero coste y privacidad total? Ejecuta el modelo en tu propia máquina con [Ollama](https://ollama.com). Nada sale de tu ordenador.
+¿Quieres cero nube, cero coste y privacidad total? Ejecuta el modelo en tu propia máquina con [Ollama](https://ollama.com). Nada sale de tu equipo.
 
 El precio a pagar es el hardware. career-ops le pide al modelo puntuar ofertas en muchas dimensiones y adaptar tu CV — los modelos pequeños sufren con eso.
 

--- a/content/docs/index.es.mdx
+++ b/content/docs/index.es.mdx
@@ -34,7 +34,7 @@ No necesitas saber programar. Solo necesitas sentirte cómodo abriendo una termi
       <Step>
         ### Git
 
-        Instala **[Git](https://git-scm.com/)** — lo usa internamente el scaffolder. La mayoría de los ordenadores ya lo tienen. Para comprobarlo, abre una terminal y ejecuta `git --version`.
+        Instala **[Git](https://git-scm.com/)** — lo usa internamente el scaffolder. La mayoría de los equipos ya lo tienen. Para comprobarlo, abre una terminal y ejecuta `git --version`.
       </Step>
     </Steps>
   </div>

--- a/content/docs/introduction/guides/batch-evaluate-offers.es.mdx
+++ b/content/docs/introduction/guides/batch-evaluate-offers.es.mdx
@@ -12,9 +12,9 @@ Usa esta guía cuando tengas 10 o más ofertas de empleo que revisar y quieras p
 
 Cada oferta recibe su propio worker de Claude. Ese worker lee tu CV, puntúa el encaje, redacta un informe completo y guarda un PDF adaptado — todo sin que muevas un dedo.
 
-## Paso 1: Añade tus ofertas al fichero de entrada
+## Paso 1: Añade tus ofertas al archivo de entrada
 
-El sistema de batch lee las URLs de las ofertas desde un fichero llamado **`batch/batch-input.tsv`**. Piensa en él como una lista de tareas para el evaluador.
+El sistema de batch lee las URLs de las ofertas desde un archivo llamado **`batch/batch-input.tsv`**. Piensa en él como una lista de tareas para el evaluador.
 
 <div className="rounded-lg bg-radial-[at_bottom] from-blue-500/20 p-4 border bg-origin-border border-fd-primary/10 prose-no-margin dark:bg-black/20">
   <div className="rounded-xl bg-fd-background p-3">
@@ -33,7 +33,7 @@ El sistema de batch lee las URLs de las ofertas desde un fichero llamado **`batc
         | `notes` | Una nota opcional — déjala en blanco si no tienes ninguna |
       </Step>
       <Step>
-        Guarda el fichero.
+        Guarda el archivo.
       </Step>
     </Steps>
   </div>
@@ -60,7 +60,7 @@ Antes de procesar nada, ejecuta una comprobación rápida para ver cuántas ofer
 ./batch/batch-runner.sh --dry-run
 ```
 
-Verás una lista de las ofertas pendientes con sus IDs. Si algo no cuadra, corrige el fichero de entrada ahora, antes de dedicar tiempo a una lista incorrecta.
+Verás una lista de las ofertas pendientes con sus IDs. Si algo no cuadra, corrige el archivo de entrada ahora, antes de dedicar tiempo a una lista incorrecta.
 
 ## Paso 3: Ejecuta el batch
 
@@ -98,7 +98,7 @@ No necesitas esperar a que el batch termine. Los resultados aparecen a medida qu
 
 **Informes de evaluación completos** → `reports/`
 
-Cada informe es un fichero con un nombre del tipo `042-company-name-2026-04-14.md`. Ábrelo para ver:
+Cada informe es un archivo con un nombre del tipo `042-company-name-2026-04-14.md`. Ábrelo para ver:
 
 - Un resumen del puesto
 - Cómo de bien encaja tu CV con la oferta
@@ -107,7 +107,7 @@ Cada informe es un fichero con un nombre del tipo `042-company-name-2026-04-14.m
 
 **Entradas de una línea para el tracker** → `batch/tracker-additions/`
 
-Cada oferta deja también aquí un fichero con un resumen breve. Estos se añaden a tu tracker principal en el Paso 6.
+Cada oferta deja también aquí un archivo con un resumen breve. Estos se añaden a tu tracker principal en el Paso 6.
 
 ## Paso 5: Reintenta las ofertas fallidas
 
@@ -137,10 +137,10 @@ node merge-tracker.mjs
 
 Este script:
 
-1. Lee los ficheros de resumen de `batch/tracker-additions/`
+1. Lee los archivos de resumen de `batch/tracker-additions/`
 2. Comprueba duplicados para que nunca acabes con dos filas para la misma oferta
 3. Añade las entradas nuevas a tu tracker de candidaturas
-4. Archiva los ficheros procesados en `batch/tracker-additions/merged/`
+4. Archiva los archivos procesados en `batch/tracker-additions/merged/`
 
 **Para previsualizar los cambios sin escribir nada:**
 

--- a/content/docs/introduction/guides/interview-modes.es.mdx
+++ b/content/docs/introduction/guides/interview-modes.es.mdx
@@ -63,4 +63,4 @@ Ejecuta `interview/debrief` justo después de una entrevista real, con la memori
 
 ## Por qué funciona este bucle
 
-La preparación de entrevistas suele volver a cero con cada ronda. Los modos de entrevista la hacen acumulativa: lo que un entrevistador real preguntó de verdad se convierte en la señal de preparación de máxima prioridad para la siguiente ronda, guardada en ficheros Markdown planos (`interview-prep/question-bank.md`, `story-bank.md`) que son tuyos, en tu máquina, como todo lo demás en career-ops.
+La preparación de entrevistas suele volver a cero con cada ronda. Los modos de entrevista la hacen acumulativa: lo que un entrevistador real preguntó de verdad se convierte en la señal de preparación de máxima prioridad para la siguiente ronda, guardada en archivos Markdown planos (`interview-prep/question-bank.md`, `story-bank.md`) que son tuyos, en tu máquina, como todo lo demás en career-ops.

--- a/content/docs/introduction/guides/scan-job-portals.es.mdx
+++ b/content/docs/introduction/guides/scan-job-portals.es.mdx
@@ -16,7 +16,7 @@ Esta guía explica cómo configurar `portals.yml` y ejecutar el escáner de port
 
 ## Configura portals.yml
 
-`portals.yml` es el fichero que controla qué busca el escáner y dónde lo busca. Lo creas una vez a partir de la plantilla incluida y después lo editas para que coincida con los puestos que buscas.
+`portals.yml` es el archivo que controla qué busca el escáner y dónde lo busca. Lo creas una vez a partir de la plantilla incluida y después lo editas para que coincida con los puestos que buscas.
 
 Ejecuta este comando desde la carpeta del proyecto:
 
@@ -24,13 +24,13 @@ Ejecuta este comando desde la carpeta del proyecto:
 cp templates/portals.example.yml portals.yml
 ```
 
-Abre `portals.yml` en cualquier editor de texto. El fichero tiene tres secciones. Los pasos siguientes recorren cada una de ellas.
+Abre `portals.yml` en cualquier editor de texto. El archivo tiene tres secciones. Los pasos siguientes recorren cada una de ellas.
 
 ### Configura tu filtro de títulos
 
 El filtro de títulos es la forma en que el escáner decide si merece la pena mostrarte una oferta. Compara el título del puesto con dos listas de palabras clave.
 
-Busca la sección `title_filter` cerca del principio del fichero:
+Busca la sección `title_filter` cerca del principio del archivo:
 
 ```yaml title="portals.yml"
 title_filter:
@@ -81,7 +81,7 @@ title_filter:
 
 La sección `tracked_companies` es una lista de empresas concretas que quieres que el escáner compruebe en cada ejecución. El escáner va directamente a la página de empleo de cada empresa y lee los puestos abiertos.
 
-Busca la sección `tracked_companies` cerca del final del fichero. Cada entrada tiene este aspecto:
+Busca la sección `tracked_companies` cerca del final del archivo. Cada entrada tiene este aspecto:
 
 ```yaml title="portals.yml"
 tracked_companies:
@@ -230,7 +230,7 @@ Si **New offers added** es 0, puede que tu filtro de títulos sea demasiado estr
 
 **Adónde van las ofertas nuevas:** cada oferta nueva se añade como una línea en `data/pipeline.md`. Esa es la lista de ofertas pendientes de evaluar.
 
-**Qué hace `data/scan-history.tsv`:** cada URL que el escáner ve — tanto si se añadió, se filtró o se omitió — queda registrada aquí. Así es como el escáner evita mostrarte la misma oferta dos veces en escaneos futuros. No necesitas editar este fichero.
+**Qué hace `data/scan-history.tsv`:** cada URL que el escáner ve — tanto si se añadió, se filtró o se omitió — queda registrada aquí. Así es como el escáner evita mostrarte la misma oferta dos veces en escaneos futuros. No necesitas editar este archivo.
 
 ## Evalúa las ofertas nuevas de un escaneo
 
@@ -271,7 +271,7 @@ Esto es lo que significa cada columna:
 
 **Para leer la evaluación completa de un puesto**, tienes dos opciones:
 
-- **Abre el fichero del informe directamente** — encuéntralo en la carpeta `reports/` usando el número de la tabla.
+- **Abre el archivo del informe directamente** — encuéntralo en la carpeta `reports/` usando el número de la tabla.
 - **Usa el dashboard** — ejecuta `./dashboard/career-dashboard` desde la carpeta del proyecto para navegar por todos tus informes en una interfaz de terminal. Puedes filtrar por puntuación y estado, y abrir cualquier informe sin salir del terminal.
 
 ## Qué hacer después

--- a/content/docs/reference/glossary.es.mdx
+++ b/content/docs/reference/glossary.es.mdx
@@ -39,7 +39,7 @@ Reescribir tu CV para una oferta concreta — reordenando el énfasis, destacand
 
 ## Modo
 
-Un flujo de trabajo enfocado, definido como prompt, que career-ops distribuye como un fichero Markdown plano que tu CLI de IA ejecuta — [scan, apply, tracker](/es/docs/reference/modes), [interview/practice](/es/docs/introduction/guides/interview-modes) y una docena más. Los modos son texto inspeccionable, no código de caja negra.
+Un flujo de trabajo enfocado, definido como prompt, que career-ops distribuye como un archivo Markdown plano que tu CLI de IA ejecuta — [scan, apply, tracker](/es/docs/reference/modes), [interview/practice](/es/docs/introduction/guides/interview-modes) y una docena más. Los modos son texto inspeccionable, no código de caja negra.
 
 ## Pipeline
 
@@ -55,7 +55,7 @@ La CLI de programación con IA que ejecuta los prompts de career-ops — Claude 
 
 ## Banco de preguntas
 
-Un fichero Markdown local (`interview-prep/question-bank.md`) donde career-ops acumula preguntas reales de entrevista y tu desempeño en cada una (✅/🟡/🔴). El [modo interview/debrief](/es/docs/introduction/guides/interview-modes) lo actualiza después de cada entrevista real, de modo que la preparación se acumula ronda tras ronda.
+Un archivo Markdown local (`interview-prep/question-bank.md`) donde career-ops acumula preguntas reales de entrevista y tu desempeño en cada una (✅/🟡/🔴). El [modo interview/debrief](/es/docs/introduction/guides/interview-modes) lo actualiza después de cada entrevista real, de modo que la preparación se acumula ronda tras ronda.
 
 ## Historia STAR+R
 
@@ -63,7 +63,7 @@ Una historia de entrevista estructurada como **S**ituación, **T**area, **A**cci
 
 ## Banco de historias
 
-Un fichero Markdown local (`interview-prep/story-bank.md`) con tus historias STAR+R preparadas. Las sesiones de práctica verifican tus respuestas contra él, y los debriefs extraen historias nuevas de lo que realmente dijiste en las entrevistas reales.
+Un archivo Markdown local (`interview-prep/story-bank.md`) con tus historias STAR+R preparadas. Las sesiones de práctica verifican tus respuestas contra él, y los debriefs extraen historias nuevas de lo que realmente dijiste en las entrevistas reales.
 
 ## Portal
 

--- a/content/docs/reference/modes/pipeline.es.mdx
+++ b/content/docs/reference/modes/pipeline.es.mdx
@@ -37,7 +37,7 @@ Processing 6 live URLs (parallel workers)...
 | 3 | Initech | AI PM        | 2.4/5 | skip | skip              |
 ```
 
-Cada URL procesada pasa de la sección `## Pending` a la sección `## Processed` del fichero, de modo que la bandeja de entrada se mantiene como un registro vivo de lo que queda pendiente.
+Cada URL procesada pasa de la sección `## Pending` a la sección `## Processed` del archivo, de modo que la bandeja de entrada se mantiene como un registro vivo de lo que queda pendiente.
 
 ## Cuándo recurrir a él
 

--- a/content/docs/reference/modes/tracker.es.mdx
+++ b/content/docs/reference/modes/tracker.es.mdx
@@ -12,7 +12,7 @@ translatedFrom: /docs/reference/modes/tracker
 
 ## Qué hace
 
-El modo `tracker` lee todos los ficheros de reports/ y produce un resumen estructurado agrupado por etapa: aplicadas, evaluadas, en entrevista, rechazadas, descartadas. Los recuentos por etapa, la actividad reciente y los seguimientos vencidos aparecen en una sola respuesta.
+El modo `tracker` lee todos los archivos de reports/ y produce un resumen estructurado agrupado por etapa: aplicadas, evaluadas, en entrevista, rechazadas, descartadas. Los recuentos por etapa, la actividad reciente y los seguimientos vencidos aparecen en una sola respuesta.
 
 ## Cuándo usarlo
 
@@ -42,7 +42,7 @@ Una candidatura avanza por un conjunto fijo de estados: Evaluated (informe escri
 
 ## Cómo leer las cifras acumuladas
 
-Para las cifras acumuladas — el funnel completo, los totales del scanner, la cobertura de portales y el cumplimiento de los seguimientos — el modo ejecuta `node stats.mjs --summary` y presenta su salida tal cual. Ese comando lee tus ficheros locales y cuesta cero tokens, así que los números nunca se recalculan a mano ni se estiman de memoria. Usa el resumen en el chat de arriba para una lectura diaria rápida, y el comando de estadísticas cuando quieras los totales acumulados de toda la búsqueda.
+Para las cifras acumuladas — el funnel completo, los totales del scanner, la cobertura de portales y el cumplimiento de los seguimientos — el modo ejecuta `node stats.mjs --summary` y presenta su salida tal cual. Ese comando lee tus archivos locales y cuesta cero tokens, así que los números nunca se recalculan a mano ni se estiman de memoria. Usa el resumen en el chat de arriba para una lectura diaria rápida, y el comando de estadísticas cuando quieras los totales acumulados de toda la búsqueda.
 
 ## Cosas a tener en cuenta
 

--- a/content/docs/supported-clis.es.mdx
+++ b/content/docs/supported-clis.es.mdx
@@ -8,7 +8,7 @@ localized: true
 translatedFrom: /docs/supported-clis
 ---
 
-**career-ops funciona sobre todos los principales CLIs de programación con IA — no estás atado a ningún proveedor.** Como career-ops distribuye ficheros de prompts que el CLI ejecuta (no incluye su propio modelo), lo apuntas al asistente de programación con IA que ya uses y funciona sobre ese motor sin cambios. Cuando salga un modelo mejor, cambias de CLI y conservas tu pipeline, tus datos y tu configuración.
+**career-ops funciona sobre todos los principales CLIs de programación con IA — no estás atado a ningún proveedor.** Como career-ops distribuye archivos de prompts que el CLI ejecuta (no incluye su propio modelo), lo apuntas al asistente de programación con IA que ya uses y funciona sobre ese motor sin cambios. Cuando salga un modelo mejor, cambias de CLI y conservas tu pipeline, tus datos y tu configuración.
 
 <Callout title="Usa lo que ya tienes">
 El mejor CLI para career-ops es el que ya pagas. Si es Claude Code, ya está. Si quieres ejecutarlo gratis, consulta [Configura un motor de IA gratuito](/docs/free-ai-engine).
@@ -16,11 +16,11 @@ El mejor CLI para career-ops es el que ya pagas. Si es Claude Code, ya está. Si
 
 ## ¿Qué CLIs son compatibles?
 
-career-ops ofrece soporte de primer nivel para **Claude Code, Codex, OpenCode, Antigravity CLI, Grok Build CLI, Qwen, Kimi y GitHub Copilot CLI** — ocho CLIs de programación con IA con mantenimiento activo. (Gemini CLI se mantiene como wrapper legacy tras su transición a Antigravity CLI.) La arquitectura es compartida: un único `AGENTS.md` canónico dirige la lógica, y unos ficheros de entrada ligeros por CLI resuelven los matices de invocación de cada herramienta.
+career-ops ofrece soporte de primer nivel para **Claude Code, Codex, OpenCode, Antigravity CLI, Grok Build CLI, Qwen, Kimi y GitHub Copilot CLI** — ocho CLIs de programación con IA con mantenimiento activo. (Gemini CLI se mantiene como wrapper legacy tras su transición a Antigravity CLI.) La arquitectura es compartida: un único `AGENTS.md` canónico dirige la lógica, y unos archivos de entrada ligeros por CLI resuelven los matices de invocación de cada herramienta.
 
 La **lista canónica y siempre actualizada — con el comando exacto para invocar career-ops en cada CLI — vive en el repo del core**, de modo que nunca se queda desfasada:
 
-- [docs/SUPPORTED_CLIS.md](https://github.com/santifer/career-ops/blob/main/docs/SUPPORTED_CLIS.md) — la matriz completa de CLIs compatibles, ficheros de entrada y cómo invocarlos (en modo interactivo y headless/batch).
+- [docs/SUPPORTED_CLIS.md](https://github.com/santifer/career-ops/blob/main/docs/SUPPORTED_CLIS.md) — la matriz completa de CLIs compatibles, archivos de entrada y cómo invocarlos (en modo interactivo y headless/batch).
 
 ## ¿Cuál debería elegir?
 

--- a/content/docs/windows.es.mdx
+++ b/content/docs/windows.es.mdx
@@ -12,9 +12,9 @@ translatedFrom: /docs/windows
 
 ## La única particularidad de Windows, resuelta por ti
 
-Windows no crea symlinks por defecto, así que un checkout recién hecho de Git deja los puntos de entrada de las skills del CLI (`.claude/skills/`, `.opencode/skills/`, etc.) como simples ficheros puntero en lugar de symlinks reales — que es justo lo que provoca el error de "las skills no cargan" que la gente sufre en otras herramientas.
+Windows no crea symlinks por defecto, así que un checkout recién hecho de Git deja los puntos de entrada de las skills del CLI (`.claude/skills/`, `.opencode/skills/`, etc.) como simples archivos puntero en lugar de symlinks reales — que es justo lo que provoca el error de "las skills no cargan" que la gente sufre en otras herramientas.
 
-career-ops lo detecta automáticamente. Al ejecutar el instalador o el actualizador — `npx @santifer/career-ops init` en una instalación nueva, o `node update-system.mjs apply` en una actualización — se ejecuta un paso `materializeSkillEntrypoints` que sustituye esos ficheros puntero por el contenido completo de cada skill. No necesitas permisos de administrador, ni Modo de desarrollador, ni ningún comando `mklink` manual.
+career-ops lo detecta automáticamente. Al ejecutar el instalador o el actualizador — `npx @santifer/career-ops init` en una instalación nueva, o `node update-system.mjs apply` en una actualización — se ejecuta un paso `materializeSkillEntrypoints` que sustituye esos archivos puntero por el contenido completo de cada skill. No necesitas permisos de administrador, ni Modo de desarrollador, ni ningún comando `mklink` manual.
 
 <Callout title="Sin requisito de versión mínima del sistema">
 career-ops no exige ninguna versión concreta de Windows (ni de macOS). Si Node funciona, career-ops funciona. Cualquier afirmación sobre una versión mínima del sistema operativo que hayas podido ver en otro sitio no es correcta.

--- a/src/app/(home)/home-dict.tsx
+++ b/src/app/(home)/home-dict.tsx
@@ -814,6 +814,18 @@ export const homeFr: HomeDict = {
       ),
     },
     {
+      q: 'Comment automatiser sa recherche d’emploi sans perdre le contrôle ?',
+      a: (
+        <>
+          career-ops automatise le travail répétitif — il parcourt les offres,
+          les évalue face à votre CV, adapte votre CV et prépare les réponses —
+          mais vous gardez le dernier mot sur chaque envoi. L’agent prépare, vous
+          décidez : rien n’est envoyé sans votre clic explicite. C’est le principe
+          human-in-the-loop : vous récupérez le temps, pas le contrôle.
+        </>
+      ),
+    },
+    {
       q: 'career-ops est-il gratuit ? Quel est le modèle économique ?',
       a: (
         <>

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -978,6 +978,10 @@ const HOME_FAQ_FR: HomeFaqQA[] = [
     a: 'Il prépare chaque candidature jusqu’au clic : il parcourt les offres, note chacune face à votre CV et adapte un CV. Puis il vous rend la décision. Vous relisez et envoyez chaque candidature vous-même. C’est délibéré : la candidature automatique de masse abîme votre réputation auprès des recruteurs et des ATS ; career-ops vous enlève le travail fastidieux, pas le jugement.',
   },
   {
+    q: 'Comment automatiser sa recherche d’emploi sans perdre le contrôle ?',
+    a: 'career-ops automatise le travail répétitif — il parcourt les offres, les évalue face à votre CV, adapte votre CV et prépare les réponses — mais vous gardez le dernier mot sur chaque envoi. L’agent prépare, vous décidez : rien n’est envoyé sans votre clic explicite. C’est le principe human-in-the-loop : vous récupérez le temps, pas le contrôle.',
+  },
+  {
     q: 'career-ops est-il gratuit ? Quel est le modèle économique ?',
     a: 'career-ops est gratuit pour toujours, sous licence MIT et financé par la communauté. Pas d’offre payante, pas de liste d’attente, pas de compte, pas de télémétrie, pas de fonctionnalités premium. Vous clonez le dépôt, configurez votre profil et lancez le système en local avec le CLI d’IA que vous utilisez déjà. La pérennité vient du mécénat volontaire de la communauté via GitHub Sponsors, pas d’offres premium, de fonctionnalités payantes ou de données. Le mainteneur a un autre travail rémunéré ; le parrainage lui permet de s’y consacrer davantage. Détails sur career-ops.org/sustain.',
   },


### PR DESCRIPTION
Both items from **search-ops's FR audit follow-up** (audit approved complete; two GO'd items).

## ES panhispanic sweep (search-ops doctrine, priority #1)
The 26 auto-translated ES docs still carried strong Iberian-only tells the doctrine vetoed. Swept **11 files**: `fichero(s)` → `archivo(s)`, `ordenador(es)` → `equipo(s)` (35 replacements); zero `vosotros`/`vuestro` found. Code fences left untouched (the sweep skips ``` blocks).

**translationHash unchanged by design**: it tracks the EN **parent** (untouched), so an ES-only register change does not move it — this is a change of *register*, not of *information* (per the drift contract).

## FR: third measured star heading
Adds **«Comment automatiser sa recherche d'emploi sans perdre le contrôle ?»** to the French home FAQ (the *automatiser↔contrôle* tension measured in the fan-out h2, which search-ops flagged as missing in prod), answered human-in-the-loop: *"l'agent prépare, vous décidez"*. `homeFr.faq` + `HOME_FAQ_FR` (FAQPage) both updated.

## Verification
- `npm run build` ✓ — ES docs carry no `fichero`/`ordenador` in prose; `/fr` home surfaces the new heading; FR FAQPage includes it (9 Q).

🤖 Generated with [Claude Code](https://claude.com/claude-code)