### PR TITLE
feat(agent): serve markdown to AI agents at /docs/**

### DIFF
--- a/src/app/docs/[[...slug]]/page.tsx
+++ b/src/app/docs/[[...slug]]/page.tsx
@@ -42,6 +42,13 @@ export async function generateMetadata(props: PageProps<'/docs/[[...slug]]'>): P
     alternates: {
       canonical: `https://career-ops.org${page.url}`,
       ...(languages && { languages }),
+      // Advertise the agent-facing markdown representation. Renders
+      // <link rel="alternate" type="text/markdown" href=".../<slug>.md">;
+      // the middleware serves that .md from the markdown mirror. Lets an
+      // agent discover the clean format from the HTML it already fetched.
+      types: {
+        'text/markdown': `https://career-ops.org${page.url}.md`,
+      },
     },
     robots: { index: true, follow: true },
     openGraph: {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -179,6 +179,13 @@ export default async function Layout({ children }: LayoutProps<'/'>) {
                 className="hover:text-fd-foreground transition-colors"
               >
                 discord.gg/8pRpHETxa4
+              </a>{' '}
+              &middot; Agents:{' '}
+              <a
+                href="/llms.txt"
+                className="hover:text-fd-foreground transition-colors"
+              >
+                llms.txt
               </a>
             </div>
           </div>

--- a/src/app/llms.mdx/docs/[[...slug]]/route.ts
+++ b/src/app/llms.mdx/docs/[[...slug]]/route.ts
@@ -10,7 +10,13 @@ export async function GET(_req: Request, { params }: RouteContext<'/llms.mdx/doc
 
   return new Response(await getLLMText(page), {
     headers: {
-      'Content-Type': 'text/markdown',
+      'Content-Type': 'text/markdown; charset=utf-8',
+      // The canonical, indexable representation is the HTML docs page. This
+      // raw-markdown mirror (reached directly, via `<url>.md`, or via
+      // `Accept: text/markdown`) is an alternate format for agents — keep it
+      // out of search so it never dilutes the HTML page as duplicate content.
+      // On-demand agent retrieval (ChatGPT-User, Claude-Web) is unaffected.
+      'X-Robots-Tag': 'noindex',
     },
   });
 }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -34,8 +34,11 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: '*',
         allow: '/',
-        // Internal/asset endpoints, not human content.
-        disallow: ['/api/', '/og/', '/llms.mdx/'],
+        // Internal/asset endpoints, not human content. /llms.mdx/ (the
+        // agent-facing markdown mirror) is deliberately NOT disallowed: agents
+        // must be able to fetch it, and its X-Robots-Tag: noindex keeps the raw
+        // markdown out of the search index without blocking retrieval.
+        disallow: ['/api/', '/og/'],
       },
       ...aiCrawlers.map((userAgent) => ({ userAgent, allow: '/' })),
     ],

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,58 @@
+import { NextResponse, type NextRequest } from 'next/server';
+
+// Agent-facing content negotiation for /docs/**.
+//
+// AI agents (Claude Code, Codex, ChatGPT, Perplexity) reach for markdown two
+// ways that the site silently 404'd or returned HTML for until 2026-07-22:
+//   1. `<docs-url>.md`        — append `.md` to a docs URL (the pattern behind
+//                               ~59% of agent format-404s in the Mintlify
+//                               docs-url-discovery bench).
+//   2. `Accept: text/markdown` — HTTP content negotiation.
+// A complete, clean markdown mirror already existed at
+// /llms.mdx/docs/<slug>/content.md (see src/app/llms.mdx/docs) — it was just
+// invisible. Both branches below rewrite to that mirror, which returns
+// text/markdown (+ X-Robots-Tag: noindex so the raw markdown never competes
+// with the canonical HTML in search).
+//
+// Humans are never affected: a browser always lists `text/html` in Accept and
+// never appends `.md`, so neither branch fires for them. (search-ops audit
+// audit-capa-agentica-2026-W30 §2.)
+
+const DOCS_PREFIX = '/docs/';
+
+function mirrorRewrite(req: NextRequest, slug: string): NextResponse {
+  const url = req.nextUrl.clone();
+  url.search = '';
+  // Mirror route expects the last segment to be `content.md`; a leading slug
+  // may be empty (the /docs index) or nested (reference/modes).
+  url.pathname = `/llms.mdx/docs/${slug ? `${slug}/` : ''}content.md`;
+  return NextResponse.rewrite(url);
+}
+
+function prefersMarkdown(accept: string | null): boolean {
+  if (!accept) return false;
+  // Fire only when markdown is explicitly requested AND html is not — i.e. a
+  // programmatic client. Browsers and Next's own RSC requests never match.
+  return accept.includes('text/markdown') && !accept.includes('text/html');
+}
+
+export function middleware(req: NextRequest): NextResponse {
+  const { pathname } = req.nextUrl;
+  const rel = pathname === '/docs' ? '' : pathname.slice(DOCS_PREFIX.length);
+
+  // 1. `<docs-url>.md` → markdown mirror (a distinct, cache-safe URL).
+  if (pathname.endsWith('.md')) {
+    return mirrorRewrite(req, rel.slice(0, -'.md'.length));
+  }
+
+  // 2. `Accept: text/markdown` → markdown mirror at the same human URL.
+  if (prefersMarkdown(req.headers.get('accept'))) {
+    return mirrorRewrite(req, rel);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/docs', '/docs/:path*'],
+};


### PR DESCRIPTION
## Qué

Hace **visible** el mirror markdown que ya existía (`/llms.mdx/docs/<slug>/content.md`) para los agentes de IA. Antes:
- `GET /docs/faq.md` → **404** (el patrón detrás de ~59% de los format-404 de agentes en el bench Mintlify)
- `GET /docs/faq` con `Accept: text/markdown` → **HTML**
- `/llms.txt` no enlazado desde ninguna página

## Por qué

Audit agent-facing de search-ops (`audit-capa-agentica-2026-W30 §2`): **SUSPENSO con paradoja a favor** — la infra completa ya estaba, solo era invisible. La audiencia instala career-ops **desde dentro de un agente**, así que cada format-404 es fricción en el momento de decisión.

## Fix de 4 partes

| Parte | Fichero | Cambio |
|-------|---------|--------|
| `.md` suffix + content negotiation | `src/middleware.ts` (nuevo) | reescribe `<docs-url>.md` y honra `Accept: text/markdown` al mirror. Browsers nunca matchean (siempre mandan `text/html`, nunca añaden `.md`) |
| anti-duplicado | `llms.mdx/docs/[[...slug]]/route.ts` | `X-Robots-Tag: noindex` en el markdown crudo — no compite con el HTML canónico; el retrieval on-demand de agentes no se ve afectado |
| descubribilidad | `docs/[[...slug]]/page.tsx` | `<link rel="alternate" type="text/markdown" href=".../<slug>.md">` |
| robots | `robots.ts` | deja de bloquear `/llms.mdx/` (los agentes deben alcanzarlo; el `noindex` lo mantiene fuera del índice sin bloquear retrieval) |
| footer | `layout.tsx` | link visible a `/llms.txt` en la línea fingerprint (orientada a máquinas) |

## Verificación local (`next start`, 9/9)

- `/docs/faq.md` → 200 `text/markdown` + `noindex` ✅
- `Accept: text/markdown` → markdown (misma URL) ✅
- Browser `Accept: text/html` → HTML intacto, sin noindex ✅
- `robots.txt` ya no bloquea `/llms.mdx/` ✅
- Nested `.md` (`reference/modes.md`) → markdown ✅
- `<link rel=alternate type=text/markdown>` en `<head>` ✅
- Footer `llms.txt` link presente ✅
- Página inexistente `.md` → 404 (correcto) ✅

## Scope

**Solo EN docs** por ahora (el mirror es EN-only). ES/FR markdown es fast-follow: requiere hacer el mirror locale-aware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)