### PR TITLE
fix(agent): repair markdown quality + make the .md layer discoverable

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -70,6 +70,22 @@ const config = {
       { hostname: 'avatars.githubusercontent.com' },
     ],
   },
+  async rewrites() {
+    return {
+      // beforeFiles so these land ahead of the /docs/[[...slug]] page route,
+      // which would otherwise 404 on the unknown `.md` slug. A routing rewrite
+      // (not middleware) fires deterministically for file-extension paths.
+      // The mirror route sets Content-Type: text/markdown + X-Robots-Tag:
+      // noindex. Agent-facing markdown — search-ops audit, agent layer.
+      beforeFiles: [
+        { source: '/docs.md', destination: '/llms.mdx/docs/content.md' },
+        {
+          source: '/docs/:slug(.*).md',
+          destination: '/llms.mdx/docs/:slug/content.md',
+        },
+      ],
+    };
+  },
   async headers() {
     return [
       {

--- a/src/app/llms-full.txt/route.ts
+++ b/src/app/llms-full.txt/route.ts
@@ -1,4 +1,4 @@
-import { getLLMText, source } from '@/lib/source';
+import { getLLMText, normalizeAgentMarkdown, source } from '@/lib/source';
 import { blogSource, type BlogPage } from '@/lib/blog-source';
 import comparisonsData from '@/lib/data/comparisons.json';
 import { CANONICAL_IDENTITY } from '@/lib/shared';
@@ -14,7 +14,7 @@ export const revalidate = false;
 const SITE = 'https://career-ops.org';
 
 async function blogLLMText(page: BlogPage) {
-  const processed = await page.data.getText('processed');
+  const processed = normalizeAgentMarkdown(await page.data.getText('processed'));
   const modified = page.data.lastModified ?? page.data.date;
 
   return `# ${page.data.title} (${SITE}${page.url})

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,4 +1,4 @@
-import { source } from '@/lib/source';
+import { source, normalizeAgentMarkdown } from '@/lib/source';
 import { llms } from 'fumadocs-core/source';
 import { getProjectStats } from '@/lib/stats';
 import { MANIFESTO, CAREEROPS_DEFINITION, CANONICAL_IDENTITY } from '@/lib/shared';
@@ -105,10 +105,25 @@ MIT — free forever, no paywalls, no account required.
 `;
 }
 
+// The docs index for agents. fumadocs' llms(source).index() emits one "# Docs"
+// block PER LOCALE with RELATIVE links to the HTML routes — so an agent lands
+// on 126-253KB of HTML instead of the 2-12KB .md mirror (x20-100 tokens), and
+// the ES/FR blocks bloat the file with links whose .md twins don't exist yet.
+// Keep only the EN block and rewrite every /docs link to its absolute .md
+// mirror. (search-ops audit-md-calidad-2026-W30, leak #1 — CRITICAL.)
+function agentDocsIndex(): string {
+  const raw = llms(source).index();
+  const enBlock = raw.split(/^#\s+Docs\s*$/m)[1] ?? raw;
+  return `# Docs (agent-ready markdown)
+
+Each link below is the .md mirror — the same content as the HTML page, ~20-100x fewer tokens. You can also append \`.md\` to any docs URL, or request one with \`Accept: text/markdown\`.
+${normalizeAgentMarkdown(enBlock)}`;
+}
+
 export async function GET() {
   const stats = await getProjectStats();
   return new Response(
     buildPreamble(stats.stars, stats.discordMembers, stats.latestRelease) +
-      llms(source).index(),
+      agentDocsIndex(),
   );
 }

--- a/src/lib/source.ts
+++ b/src/lib/source.ts
@@ -32,10 +32,61 @@ export function getPageMarkdownUrl(page: InferPageType<typeof source>) {
   };
 }
 
+const SITE_URL = 'https://career-ops.org';
+
+// Fumadocs' getText('processed') HTML-escapes punctuation that sits in
+// markdown-syntax positions: a `)` inside a URL becomes `&#x29;` (which breaks
+// the whole link — `https://opencode.ai&#x29;`), `*` becomes `&#x2A;` (breaks
+// bold/italic), a backtick becomes `&#x60;` (breaks inline code). Agents read
+// these entities literally, so the mirror ships broken markdown. Decode them.
+// (search-ops audit-md-calidad-2026-W30, leak #2 — one exporter bug, global.)
+function decodeEntities(md: string): string {
+  return md
+    .replace(/&#x([0-9a-fA-F]+);/g, (_m, hex) => String.fromCodePoint(parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_m, dec) => String.fromCodePoint(parseInt(dec, 10)))
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&'); // last, so a literal &amp;lt; never double-decodes
+}
+
+// Rewrite root-relative links so an agent reading the raw markdown can resolve
+// them, and keep it inside the markdown layer: absolutize every `/…` href, and
+// point internal `/docs/*` links at their `.md` mirror (the site's clean-URL
+// convention). Same-page `#anchors`, protocol-relative `//host`, and
+// already-absolute `http(s)://` links are left untouched. (leak #3.)
+function absolutizeLinks(md: string): string {
+  return md.replace(/\]\((\/(?!\/)[^)\s]*)\)/g, (_m, href) => {
+    const cut = href.search(/[#?]/);
+    const path = cut === -1 ? href : href.slice(0, cut);
+    const suffix = cut === -1 ? '' : href.slice(cut);
+    const clean = path.length > 1 ? path.replace(/\/$/, '') : path;
+    const isDoc =
+      (clean === '/docs' || clean.startsWith('/docs/')) &&
+      !/\.[a-z0-9]+$/i.test(clean); // skip assets like /docs/x.png (no .md twin)
+    return `](${SITE_URL}${clean}${isDoc ? '.md' : ''}${suffix})`;
+  });
+}
+
+// Shared serialization cleanup for any markdown served to agents (the docs
+// mirror below and the blog dump in llms-full.txt). Strips MDX/HTML comments
+// (which have leaked internal repo paths), decodes escaped entities, and
+// absolutizes links.
+export function normalizeAgentMarkdown(md: string): string {
+  const withoutComments = md
+    .replace(/\{\/\*[\s\S]*?\*\/\}/g, '')
+    .replace(/<!--[\s\S]*?-->/g, '');
+  return absolutizeLinks(decodeEntities(withoutComments));
+}
+
 export async function getLLMText(page: InferPageType<typeof source>) {
-  const processed = await page.data.getText('processed');
+  const processed = normalizeAgentMarkdown(await page.data.getText('processed'));
+  const description = page.data.description ? `\n> ${page.data.description}\n` : '';
 
-  return `# ${page.data.title} (${page.url})
+  return `# ${page.data.title}
 
+Source: ${SITE_URL}${page.url} (canonical HTML, identical content)
+${description}
 ${processed}`;
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,15 +8,20 @@ import { NextResponse, type NextRequest } from 'next/server';
 //                               ~59% of agent format-404s in the Mintlify
 //                               docs-url-discovery bench).
 //   2. `Accept: text/markdown` — HTTP content negotiation.
-// A complete, clean markdown mirror already existed at
-// /llms.mdx/docs/<slug>/content.md (see src/app/llms.mdx/docs) — it was just
-// invisible. Both branches below rewrite to that mirror, which returns
-// text/markdown (+ X-Robots-Tag: noindex so the raw markdown never competes
-// with the canonical HTML in search).
+// Both resolve to the clean markdown mirror at /llms.mdx/docs/<slug>/content.md
+// (see src/app/llms.mdx/docs), which returns text/markdown + X-Robots-Tag:
+// noindex so the raw markdown never competes with the canonical HTML in search.
+//
+// Split by mechanism, each using the right tool: `<docs-url>.md` is a
+// next.config `beforeFiles` rewrite (a routing rewrite fires deterministically
+// for file-extension paths — middleware interception of `.md` proved
+// unreliable across the Next 16 middleware→proxy migration, 404'ing on the
+// `.md` before reaching the mirror). This proxy handles ONLY the Accept header,
+// which a static rewrite cannot read.
 //
 // Humans are never affected: a browser always lists `text/html` in Accept and
-// never appends `.md`, so neither branch fires for them. (search-ops audit
-// audit-capa-agentica-2026-W30 §2.)
+// never appends `.md`, so neither path fires for them. (search-ops audits
+// audit-capa-agentica-2026-W30 §2 + audit-md-calidad-2026-W30.)
 
 const DOCS_PREFIX = '/docs/';
 
@@ -36,18 +41,17 @@ function prefersMarkdown(accept: string | null): boolean {
   return accept.includes('text/markdown') && !accept.includes('text/html');
 }
 
-export function middleware(req: NextRequest): NextResponse {
+export function proxy(req: NextRequest): NextResponse {
   const { pathname } = req.nextUrl;
-  const rel = pathname === '/docs' ? '' : pathname.slice(DOCS_PREFIX.length);
 
-  // 1. `<docs-url>.md` → markdown mirror (a distinct, cache-safe URL).
-  if (pathname.endsWith('.md')) {
-    return mirrorRewrite(req, rel.slice(0, -'.md'.length));
-  }
+  // `<docs-url>.md` is served by the next.config rewrite → the markdown mirror.
+  // Leave it for the routing layer (see the file header for why).
+  if (pathname.endsWith('.md')) return NextResponse.next();
 
-  // 2. `Accept: text/markdown` → markdown mirror at the same human URL.
+  // `Accept: text/markdown` on the human URL → the same markdown mirror.
   if (prefersMarkdown(req.headers.get('accept'))) {
-    return mirrorRewrite(req, rel);
+    const slug = pathname === '/docs' ? '' : pathname.slice(DOCS_PREFIX.length);
+    return mirrorRewrite(req, slug);
   }
 
   return NextResponse.next();


### PR DESCRIPTION
Follow-up a #17 (agent-facing markdown), cerrando las **4 fugas** del audit de calidad de search-ops (`audit-md-calidad-2026-W30`). El contenido puntuó **5/5 fidelidad** — la tubería era la que goteaba.

## Las 4 fugas

| # | Fuga | Fix |
|---|------|-----|
| 🔴 1 | **La capa `.md` era invisible en `llms.txt`**: `llms(source).index()` emitía un bloque `# Docs` **por locale** con links **relativos** a las rutas HTML → el agente aterrizaba en 126-253KB de HTML en vez del `.md` de 2-12KB (**×20-100 tokens**), y los bloques ES/FR listaban `.md` que aún no existen | Índice **EN-only**, cada link al **mirror `.md` absoluto** (30 links) |
| 🟠 2 | **Bug del exporter**: `getText('processed')` escapa puntuación en posición de sintaxis markdown — `)` dentro de una URL → `&#x29;` (rompía el link entero de opencode.ai), `*` → `&#x2A;` (negritas/itálicas), `` ` `` → `&#x60;` (inline-code) | `decodeEntities()` global — mirror docs **Y** blog en `llms-full.txt` (0 entidades) |
| 🟠 3 | **Links relativos**: el mirror servía hrefs root-relativos que un agente no resuelve, y nunca enlazaba `.md→.md` | `absolutizeLinks()`: absolutiza todo `/…`, y los `/docs/*` internos apuntan a su `.md`; no-docs a HTML, externos intactos |
| 🟠 4 | (staleness del corpus — CLI/Node) | **PR B aparte** (facts verificados por el maintainer) |

## Bonus (mismo paquete)
- **Routing `.md` movido de middleware → rewrite `beforeFiles` de `next.config`.** La interceptación de `.md` por middleware se rompió en la migración Next 16 `middleware→proxy` (404 antes de llegar al mirror); un rewrite de routing dispara determinista para rutas con extensión. `middleware.ts → proxy.ts` (convención Next 16) ahora solo hace `Accept: text/markdown`.
- Header del mirror enriquecido: **description + `Source:` absoluto** (antes se perdían).
- **Comentarios MDX/HTML stripped** (filtraban rutas internas del repo).

## Verificación local (`next start`)
- 4/4 rutas `.md` (incl. `/docs.md` index) → 200 `text/markdown` + `noindex` ✅
- `Accept: text/markdown` → markdown (proxy) ✅
- Browser HTML intacto ✅
- **0 entidades escapadas** + **0 links relativos** en mirror + `llms-full.txt` ✅
- `llms.txt` índice = 30 links `.md` absolutos, **1 bloque `# Docs`** (EN) ✅
- Link opencode reparado: `[OpenCode](https://opencode.ai)` ✅

Verificación post-deploy de search-ops: re-corre los 2 task-tests ciegos + grep entidades=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)