### PR TITLE
fix(agent): repair body cross-links + /AGENTS.md pointer + token counts

### DIFF
--- a/content/docs/introduction/guides/apply-for-a-job.es.mdx
+++ b/content/docs/introduction/guides/apply-for-a-job.es.mdx
@@ -11,7 +11,7 @@ translatedFrom: /docs/introduction/guides/apply-for-a-job
 Esta guía explica cómo usar `/career-ops apply` para rellenar un formulario de candidatura con respuestas adaptadas a tu perfil, tus proof points y el puesto concreto al que te presentas.
 
 <Callout title="Antes de empezar">
-  Asegúrate de haber completado la guía [Escanear portales de empleo](./scan-job-portals.mdx). El comando `apply` depende de un informe de evaluación existente. Si no existe informe para el puesto, ejecuta primero el pipeline.
+  Asegúrate de haber completado la guía [Escanear portales de empleo](/docs/introduction/guides/scan-job-portals). El comando `apply` depende de un informe de evaluación existente. Si no existe informe para el puesto, ejecuta primero el pipeline.
 </Callout>
 
 ## Ejecuta el comando apply
@@ -50,7 +50,7 @@ Por ejemplo:
 career-ops localiza el informe correspondiente en `reports/`, usa Playwright para abrir una ventana del navegador y lee el formulario. Después genera una respuesta para cada campo — lista para copiar y pegar. No necesitas abrir el navegador tú mismo.
 
 <Callout title="Nota">
-  Si Playwright no está disponible, career-ops recurre a WebFetch para leer el formulario. Consulta [Configurar Playwright](./set-up-playwright.mdx) si quieres activar la experiencia completa basada en navegador.
+  Si Playwright no está disponible, career-ops recurre a WebFetch para leer el formulario. Consulta [Configurar Playwright](/docs/introduction/guides/set-up-playwright) si quieres activar la experiencia completa basada en navegador.
 </Callout>
 
 **Si ejecutas el comando `/career-ops apply` sin argumentos**, el sistema te pide que aportes el contexto manualmente:
@@ -110,7 +110,7 @@ Cada respuesta se construye a partir de una parte concreta de tu informe de eval
 </div>
 
 <Callout title="Campos de subida de archivos">
-  Usa el archivo de `output/` generado al crear el informe. Si todavía no existe ningún PDF, ejecuta primero `/career-ops pdf` y vuelve después al formulario. Consulta [Generar un PDF](generate-a-pdf.md).
+  Usa el archivo de `output/` generado al crear el informe. Si todavía no existe ningún PDF, ejecuta primero `/career-ops pdf` y vuelve después al formulario. Consulta [Generar un PDF](/docs/reference/modes/pdf).
 </Callout>
 
 ## Envía la candidatura

--- a/content/docs/introduction/guides/apply-for-a-job.fr.mdx
+++ b/content/docs/introduction/guides/apply-for-a-job.fr.mdx
@@ -11,7 +11,7 @@ translatedFrom: /docs/introduction/guides/apply-for-a-job
 Ce guide vous montre comment utiliser `/career-ops apply` pour remplir un formulaire de candidature avec des réponses adaptées à votre profil, à vos points de preuve et au poste précis auquel vous postulez.
 
 <Callout title="Avant de commencer">
-  Assurez-vous d'avoir terminé le guide [Scanner les portails d'emploi](./scan-job-portals.mdx). La commande `apply` dépend d'un rapport d'évaluation existant. Si aucun rapport n'existe pour le poste, lancez d'abord le pipeline.
+  Assurez-vous d'avoir terminé le guide [Scanner les portails d'emploi](/docs/introduction/guides/scan-job-portals). La commande `apply` dépend d'un rapport d'évaluation existant. Si aucun rapport n'existe pour le poste, lancez d'abord le pipeline.
 </Callout>
 
 ## Lancer la commande apply
@@ -50,7 +50,7 @@ Par exemple :
 career-ops trouve le rapport correspondant dans `reports/`, utilise Playwright pour ouvrir une fenêtre de navigateur et lit le formulaire. Il génère ensuite une réponse pour chaque champ — prête à copier-coller. Vous n'avez pas besoin d'ouvrir le navigateur vous-même.
 
 <Callout title="Remarque">
-  Si Playwright n'est pas disponible, career-ops se rabat sur WebFetch pour lire le formulaire. Consultez [Configurer Playwright](./set-up-playwright.mdx) si vous souhaitez activer l'expérience complète via le navigateur.
+  Si Playwright n'est pas disponible, career-ops se rabat sur WebFetch pour lire le formulaire. Consultez [Configurer Playwright](/docs/introduction/guides/set-up-playwright) si vous souhaitez activer l'expérience complète via le navigateur.
 </Callout>
 
 **Si vous lancez la commande `/career-ops apply` sans arguments**, le système vous invite à fournir le contexte manuellement :
@@ -110,7 +110,7 @@ Chaque réponse est construite à partir d'une partie précise de votre rapport 
 </div>
 
 <Callout title="Champs d'upload">
-  Utilisez le fichier dans `output/` généré lors de la création du rapport. Si aucun PDF n'existe encore, lancez d'abord `/career-ops pdf`, puis revenez au formulaire. Consultez [Générer un PDF](generate-a-pdf.md).
+  Utilisez le fichier dans `output/` généré lors de la création du rapport. Si aucun PDF n'existe encore, lancez d'abord `/career-ops pdf`, puis revenez au formulaire. Consultez [Générer un PDF](/docs/reference/modes/pdf).
 </Callout>
 
 ## Envoyer la candidature

--- a/content/docs/introduction/guides/apply-for-a-job.mdx
+++ b/content/docs/introduction/guides/apply-for-a-job.mdx
@@ -8,7 +8,7 @@ icon: FileInput
 This guide walks through using `/career-ops apply` to fill out a job application form with answers tailored to your profile, proof points, and the specific role you are applying to.
 
 <Callout title="Before you start">
-  Make sure you have completed the [Scan Job Portals](./scan-job-portals.mdx) guide. The `apply` command depends on an existing evaluation report. If no report exists for the role, run the pipeline first.
+  Make sure you have completed the [Scan Job Portals](/docs/introduction/guides/scan-job-portals) guide. The `apply` command depends on an existing evaluation report. If no report exists for the role, run the pipeline first.
 </Callout>
 
 ## Run the apply command
@@ -47,7 +47,7 @@ For example:
 career-ops finds the matching report in `reports/`, uses Playwright to open a browser window, and reads the form. It then generates an answer for every field — ready to copy and paste. You do not need to open the browser yourself.
 
 <Callout title="Note">
-  If Playwright is not available, career-ops falls back to WebFetch to read the form. See [Set up Playwright](./set-up-playwright.mdx) if you want to enable the full browser-based experience.
+  If Playwright is not available, career-ops falls back to WebFetch to read the form. See [Set up Playwright](/docs/introduction/guides/set-up-playwright) if you want to enable the full browser-based experience.
 </Callout>
 
 **If you run the command `/career-ops apply` without arguments**, the system prompts you to provide context manually:
@@ -107,7 +107,7 @@ Each answer is built from a specific part of your evaluation report:
 </div>
 
 <Callout title="Upload fields">
-  Use the file in `output/` generated when the report was created. If no PDF exists yet, run `/career-ops pdf` first, then return to the form. See [Generate a PDF](generate-a-pdf.md).
+  Use the file in `output/` generated when the report was created. If no PDF exists yet, run `/career-ops pdf` first, then return to the form. See the [pdf mode](/docs/reference/modes/pdf).
 </Callout>
 
 ## Submit the application

--- a/content/docs/introduction/guides/scan-job-portals.es.mdx
+++ b/content/docs/introduction/guides/scan-job-portals.es.mdx
@@ -11,7 +11,7 @@ translatedFrom: /docs/introduction/guides/scan-job-portals
 Esta guía explica cómo configurar `portals.yml` y ejecutar el escáner de portales para encontrar nuevas ofertas de empleo automáticamente.
 
 <Callout title="Antes de empezar">
-  Asegúrate de haber completado la guía de [Inicio rápido](../../index.mdx). Necesitas tener `cv.md` y `modes/_profile.md` en su sitio para que el escaneo sea útil.
+  Asegúrate de haber completado la guía de [Inicio rápido](/docs). Necesitas tener `cv.md` y `modes/_profile.md` en su sitio para que el escaneo sea útil.
 </Callout>
 
 ## Configura portals.yml

--- a/content/docs/introduction/guides/scan-job-portals.fr.mdx
+++ b/content/docs/introduction/guides/scan-job-portals.fr.mdx
@@ -11,7 +11,7 @@ translatedFrom: /docs/introduction/guides/scan-job-portals
 Ce guide vous accompagne dans la configuration de `portals.yml` et le lancement du scanner de portails pour trouver automatiquement de nouvelles offres d'emploi.
 
 <Callout title="Avant de commencer">
-  Assurez-vous d'avoir terminé le guide [Démarrage rapide](../../index.mdx). Vous devez disposer de `cv.md` et de `modes/_profile.md` avant que le scan ne soit utile.
+  Assurez-vous d'avoir terminé le guide [Démarrage rapide](/docs). Vous devez disposer de `cv.md` et de `modes/_profile.md` avant que le scan ne soit utile.
 </Callout>
 
 ## Configurer portals.yml

--- a/content/docs/introduction/guides/scan-job-portals.mdx
+++ b/content/docs/introduction/guides/scan-job-portals.mdx
@@ -8,7 +8,7 @@ icon: ScanEye
 This guide walks through setting up `portals.yml` and running the portal scanner to find new job openings automatically.
 
 <Callout title="Before you start">
-  Make sure you have completed the [Quick Start](../../index.mdx) guide. You need `cv.md` and `modes/_profile.md` in place before scanning is useful.
+  Make sure you have completed the [Quick Start](/docs) guide. You need `cv.md` and `modes/_profile.md` in place before scanning is useful.
 </Callout>
 
 ## Set up portals.yml

--- a/content/docs/introduction/guides/set-up-playwright.es.mdx
+++ b/content/docs/introduction/guides/set-up-playwright.es.mdx
@@ -27,7 +27,7 @@ Esta guía recorre los tres pasos de configuración que dan a career-ops sus cap
 </div>
 
 <Callout title="Antes de empezar">
-  Completa la guía de [inicio rápido](../../index.mdx). Node.js 20 LTS o posterior debe estar instalado y debes estar dentro de la carpeta raíz de career-ops.
+  Completa la guía de [inicio rápido](/docs). Node.js 20 LTS o posterior debe estar instalado y debes estar dentro de la carpeta raíz de career-ops.
 </Callout>
 
 ---

--- a/content/docs/introduction/guides/set-up-playwright.fr.mdx
+++ b/content/docs/introduction/guides/set-up-playwright.fr.mdx
@@ -27,7 +27,7 @@ Ce guide décrit les trois étapes d'installation qui donnent à career-ops ses 
 </div>
 
 <Callout title="Avant de commencer">
-  Terminez d'abord le guide de [démarrage rapide](../../index.mdx). Node.js 20 LTS ou une version ultérieure doit être installé et vous devez vous trouver dans le dossier racine de career-ops.
+  Terminez d'abord le guide de [démarrage rapide](/docs). Node.js 20 LTS ou une version ultérieure doit être installé et vous devez vous trouver dans le dossier racine de career-ops.
 </Callout>
 
 ---

--- a/content/docs/introduction/guides/set-up-playwright.mdx
+++ b/content/docs/introduction/guides/set-up-playwright.mdx
@@ -24,7 +24,7 @@ This guide walks through three setup steps that give career-ops its browser auto
 </div>
 
 <Callout title="Before you start">
-  Complete the [Quick Start](../../index.mdx) guide. Node.js 20 LTS or later must be installed and you must be inside the career-ops root folder.
+  Complete the [Quick Start](/docs) guide. Node.js 18 or later (22.5+ recommended) must be installed and you must be inside the career-ops root folder.
 </Callout>
 
 ---

--- a/src/app/AGENTS.md/route.ts
+++ b/src/app/AGENTS.md/route.ts
@@ -1,0 +1,43 @@
+// Agent entry point for career-ops.org. A thin POINTER, never a copy: the
+// canonical agent instructions for the tool live in the repo and must not be
+// mirrored here (zero drift). Served at /AGENTS.md — the path agent tooling
+// probes (agentic-seo etc.). GO'd by the maintainer via search-ops
+// (audit-md-calidad-2026-W30). Kept in sync only with the surface URLs it
+// lists, not with any external content.
+export const dynamic = 'force-static';
+
+const AGENTS = `# AGENTS.md — career-ops.org
+
+career-ops.org is the documentation and narrative site for **career-ops**, an
+open-source, local-first AI job-search tool. This file is a pointer, not a
+copy — the canonical, always-current agent instructions live in the repo.
+
+## Using the tool (career-ops)
+
+The tool runs entirely on the user's machine, inside their AI coding CLI
+(Claude Code, Codex, OpenCode, and others). There is no hosted product, no
+account, and no API to call on this domain — you install and run it locally.
+The canonical agent instructions ship in the repository:
+
+- https://raw.githubusercontent.com/santifer/career-ops/main/AGENTS.md (raw)
+- https://github.com/santifer/career-ops/blob/main/AGENTS.md (rendered)
+- Repository: https://github.com/santifer/career-ops
+
+## Reading this site (career-ops.org)
+
+- Index for agents: https://career-ops.org/llms.txt
+- Full-context dump: https://career-ops.org/llms-full.txt
+- Every docs page has a clean markdown twin: append \`.md\` to any /docs URL
+  (e.g. https://career-ops.org/docs/faq.md), or send \`Accept: text/markdown\`.
+`;
+
+export function GET() {
+  return new Response(AGENTS, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      // Alternate representation of repo-canonical instructions; keep the
+      // pointer out of the search index (same discipline as the .md mirror).
+      'X-Robots-Tag': 'noindex',
+    },
+  });
+}

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,4 +1,4 @@
-import { source, normalizeAgentMarkdown } from '@/lib/source';
+import { source, normalizeAgentMarkdown, getLLMText } from '@/lib/source';
 import { llms } from 'fumadocs-core/source';
 import { getProjectStats } from '@/lib/stats';
 import { MANIFESTO, CAREEROPS_DEFINITION, CANONICAL_IDENTITY } from '@/lib/shared';
@@ -59,6 +59,7 @@ Details: https://career-ops.org/sustain
 
 ## Authority pages
 
+- https://career-ops.org/AGENTS.md — agent entry point: a thin pointer to the repo's canonical AGENTS.md plus this site's markdown surfaces (append .md to any /docs URL, or Accept: text/markdown)
 - https://career-ops.org/manifesto — The CareerOps Manifesto: canonical definition of the CareerOps practice, coined July 14, 2026, with community signatures
 - https://career-ops.org/about — author bio, press references, stack, entity links
 - https://career-ops.org/press — press & brand kit: boilerplate copy (3 lengths), key facts, downloadable logos, media coverage, usage guidelines
@@ -111,19 +112,45 @@ MIT — free forever, no paywalls, no account required.
 // the ES/FR blocks bloat the file with links whose .md twins don't exist yet.
 // Keep only the EN block and rewrite every /docs link to its absolute .md
 // mirror. (search-ops audit-md-calidad-2026-W30, leak #1 — CRITICAL.)
-function agentDocsIndex(): string {
+function fmtTokens(t: number): string {
+  return t >= 1000
+    ? `~${(t / 1000).toFixed(1).replace(/\.0$/, '')}k tokens`
+    : `~${t} tokens`;
+}
+
+async function agentDocsIndex(): Promise<string> {
   const raw = llms(source).index();
   const enBlock = raw.split(/^#\s+Docs\s*$/m)[1] ?? raw;
+
+  // Approximate token count per page (~4 chars/token on the .md we actually
+  // serve) so an agent can budget context before fetching. (search-ops
+  // audit-md-calidad addendum #6 — Osmani agentic-seo recommendation.)
+  const tokensByUrl = new Map<string, number>();
+  await Promise.all(
+    source.getPages('en').map(async (p) => {
+      const md = await getLLMText(p);
+      tokensByUrl.set(p.url, Math.round(md.length / 4));
+    }),
+  );
+
+  const withTokens = normalizeAgentMarkdown(enBlock).replace(
+    /\]\((https:\/\/career-ops\.org(\/docs[^)]*?))\.md\)/g,
+    (full, url, path) => {
+      const t = tokensByUrl.get(path);
+      return t ? `](${url}.md) (${fmtTokens(t)})` : full;
+    },
+  );
+
   return `# Docs (agent-ready markdown)
 
-Each link below is the .md mirror — the same content as the HTML page, ~20-100x fewer tokens. You can also append \`.md\` to any docs URL, or request one with \`Accept: text/markdown\`.
-${normalizeAgentMarkdown(enBlock)}`;
+Each link below is the .md mirror — the same content as the HTML page, ~20-100x fewer tokens — with an approximate token count so you can budget context before fetching. You can also append \`.md\` to any docs URL, or request one with \`Accept: text/markdown\`.
+${withTokens}`;
 }
 
 export async function GET() {
   const stats = await getProjectStats();
   return new Response(
     buildPreamble(stats.stars, stats.discordMembers, stats.latestRelease) +
-      agentDocsIndex(),
+      (await agentDocsIndex()),
   );
 }


### PR DESCRIPTION
**Batch A del audit V2 de search-ops** (`audit-md-calidad-2026-W30` re-run — que confirmó que **PRs #18/#19 pasan** los task-tests ciegos de instalación en Claude Code Y Codex). Los items críticos + baratos + sin-gating de mi lane.

| Item | Fix |
|------|-----|
| 🔴 **#1 cross-links del cuerpo** | `apply` enlazaba `./scan-job-portals.mdx`, `./set-up-playwright.mdx` (relativos con extensión → HTML, sin grafo `.md`) y `generate-a-pdf.md` (**404, no existe**). `scan`+`playwright` enlazaban `../../index.mdx`. Todos → root-relativos sin extensión (`absolutizeLinks` del PR#18 los `.md`-ifica; el HTML también resuelve). `generate-a-pdf` → el modo `pdf` real. **EN + 6 twins ES/FR** (los links son URLs invariantes, no prosa → co-update permitido por el contrato). + maté un "Node.js 20 LTS" residual en playwright |
| **/AGENTS.md** (GO maintainer) | route thin-**pointer** (~20 líneas, jamás copia) → AGENTS.md canónico del repo en raw + superficies markdown del sitio. Cierra el 404 del checker agentic-seo |
| 🟡 **#6 token counts** | cada link `.md` de llms.txt lleva ahora `(~N tokens)` (~4 chars/token del `.md` real) para presupuesto de contexto. + /AGENTS.md enlazado desde el índice |

## Verificación local
- apply.md enlaza solo `.md` válidos, 0 links rotos, destinos 200 markdown ✅
- `/AGENTS.md` → 200 text/markdown + noindex, thin pointer ✅
- llms.txt con `(~3.1k tokens)`, `(~636 tokens)`… + /AGENTS.md mencionado ✅

## Scope / follow-up
La staleness NO-link de los twins ES/FR (Node/CLI/prosa) sigue flagged por `translationHash` para el pipeline W31 de search-ops.

Pendiente del Paquete V2 (secuenciado, no en este PR): #2 CV-onboarding, #3 fuga JSX en mirrors, #4 contradicciones editoriales, #5 límite de capa, #7 CI agentic-seo, y contenido nuevo #8/#9/#10 (tras puerta pre-estructura).

🤖 Generated with [Claude Code](https://claude.com/claude-code)