### PR TITLE
feat(blog): "what do employers think of AI-assisted applications" (D-02 branch #9)

### DIFF
--- a/content/blog/can-an-ai-agent-run-your-job-search.mdx
+++ b/content/blog/can-an-ai-agent-run-your-job-search.mdx
@@ -12,6 +12,8 @@ faq:
     a: "career-ops runs entirely on your own machine, inside the AI CLI you already use, and keeps zero telemetry: your CV, profile, and application history never leave your computer unless you push them somewhere. It reads and prepares; it never submits, deletes, or shares anything without your explicit action."
   - q: "Do I need Claude, or does any AI CLI work?"
     a: "Any supported CLI works. Claude Code is the most common runtime because of its skill loader, but career-ops is engine-agnostic: the same prompt files run on Codex, OpenCode, Qwen, GitHub Copilot CLI, and more, and you can point it at your own or a local model. Several options run at $0."
+  - q: "Do employers reject applications made with AI?"
+    a: "Employers are wary of AI spam, not AI assistance. Surveys of hiring professionals show recruiters are more likely to reject generic, mass-produced résumés that were not personalized, while personalized detail signals genuine interest. career-ops prepares each application scored against your real background and tailored to one role, and you review and submit it yourself. What goes out is the opposite of mass auto-apply: fewer, personal applications, not volume."
 ---
 
 {/* FAQ below is mirrored in the `faq` frontmatter (FAQPage JSON-LD) — edit both together. */}
@@ -51,6 +53,12 @@ Because there is no telemetry, the only numbers we can honestly show are persona
 
 The interesting brick is the middle: **68 applications turned into 12 interviews, a 17.6% interview rate.** That is what "the agent does the work, you make the call" buys you: not more applications, but fewer, better-chosen ones, each prepared well enough that a much larger share of them turned into a conversation.
 
+## What do employers think of AI-assisted applications?
+
+Employers are wary of AI spam, not of AI assistance. What recruiters push back on is the flood of generic, mass-produced applications, not a candidate who used a tool to prepare a genuine, tailored one. In a 2025 survey of 925 hiring professionals, [62% said they are more likely to reject an AI-generated résumé that was not personalized](https://www.resume-now.com/job-resources/careers/ai-applicant-report), while personalized detail is what most said signals real interest. The dividing line is personalization and intent, and that is where a human-in-the-loop workflow lands.
+
+This is why the submit step stays yours. career-ops prepares — it scans, scores, tailors your CV, and can pre-fill ATS application forms — but submitting is always your explicit click. Every application it prepares is scored against your real background and tailored to one role, and you read it before it goes out. That is the opposite of the mass auto-apply employers have learned to filter: fewer applications, each one personal enough to clear the bar recruiters say they are raising.
+
 ## Limitations: where an agent still can't help
 
 An honest page names the edges. career-ops is a strong pipeline, not magic:
@@ -73,6 +81,9 @@ career-ops runs entirely on your own machine, inside the AI CLI you already use,
 
 **Do I need Claude, or does any AI CLI work?**
 Any supported CLI works. Claude Code is the most common runtime because of its skill loader, but career-ops is engine-agnostic: the same prompt files run on Codex, OpenCode, Qwen, GitHub Copilot CLI, and more, and you can point it at your own or a local model. Several options run at $0.
+
+**Do employers reject applications made with AI?**
+Employers are wary of AI spam, not AI assistance. Surveys of hiring professionals show recruiters are more likely to reject generic, mass-produced résumés that were not personalized, while personalized detail signals genuine interest. career-ops prepares each application scored against your real background and tailored to one role, and you review and submit it yourself. What goes out is the opposite of mass auto-apply: fewer, personal applications, not volume.
 
 ---
 


### PR DESCRIPTION
**Item #9** del audit V2 de search-ops (GO de Santiago vía search-ops), cubriendo una rama de fan-out medida que la pared D-02 no respondía. search-ops dio la **puerta pre-estructura**; esto la ejecuta exacta.

## Qué
- **Nuevo H2 "What do employers think of AI-assisted applications?"** entre la sección del funnel y "Limitations" (flujo objeción → respuesta antes del cierre honesto).
- **Liftable-60 de apertura** con la tesis: los empleadores recelan del AI-spam, no de la asistencia con IA. **Anclado en fuente real citada** (encuesta 2025 a 925 profesionales de RRHH: [62% más propensos a rechazar un CV con IA sin personalizar](https://www.resume-now.com/job-resources/careers/ai-applicant-report)) — **cero porcentajes inventados**.
- **Reusa la string canónica anti-auto-submit VERBATIM** de la FAQ para refuerzo cross-superficie, girando hacia la respuesta human-in-the-loop.
- **Entrada FAQ espejo** en el "Frequently asked" visible **y** en el frontmatter `faq` (FAQPage JSON-LD), por la regla de editar ambos.

## Reglas honradas
- **Cero em-dashes** en prosa nueva (solo la cita verbatim los conserva) ✅
- **Cero marcas de competidores** (Resume Now es fuente de survey citada, no lookalike comparado) ✅
- Pared EN-only, sin twins ES/FR que flaggear por hash ✅

## Verificación local
- Sección H2 + liftable en el HTML, link a la fuente real presente ✅
- FAQPage schema JSON-LD incluye "Do employers reject applications made with AI?" ✅
- Aparece en llms-full.txt ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)