### PR TITLE
ci: anti-regression guard for the agent-facing layer (#7)

### DIFF
--- a/.github/workflows/agent-layer-guard.yml
+++ b/.github/workflows/agent-layer-guard.yml
@@ -1,0 +1,56 @@
+# Anti-regression guard for the agent-facing layer (search-ops V2 audit, #7).
+#
+# agentic-seo (Osmani) assumes a static docs site and can't score a Next.js SSR
+# build (AGENTS.md / llms.txt / docs .md are all routes, not files), so the GATE
+# is a bespoke check (scripts/verify-agent-layer.mjs) that asserts the exact
+# invariants each agent-layer PR verifies by hand: the .md rewrite, Accept
+# negotiation, browser-HTML intact, /AGENTS.md pointer, one EN llms.txt Docs
+# index with absolute .md links, no escaped entities, no leaked JSX, no relative
+# links, and the mirror left crawlable. agentic-seo runs afterwards as a
+# non-blocking informational score for the Discovery checks it does evaluate.
+name: Agent-layer guard
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'content/**'
+      - 'next.config.mjs'
+      - 'scripts/verify-agent-layer.mjs'
+      - '.github/workflows/agent-layer-guard.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'content/**'
+      - 'next.config.mjs'
+      - 'scripts/verify-agent-layer.mjs'
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - name: Boot server, run the guard (gate) + agentic-seo (informational)
+        run: |
+          PORT=3999 npm start &
+          SERVER_PID=$!
+          for i in $(seq 1 60); do
+            curl -sf http://localhost:3999/docs/faq >/dev/null && break
+            sleep 2
+          done
+          # Gate: bespoke agent-layer invariants. Its exit code is the job's.
+          BASE=http://localhost:3999 node scripts/verify-agent-layer.mjs
+          GUARD_EXIT=$?
+          # Informational: agentic-seo Discovery checks (never blocks).
+          echo "--- agentic-seo (informational) ---"
+          npx --yes agentic-seo --url http://localhost:3999 --checks robots-txt,llms-txt || true
+          kill "$SERVER_PID" 2>/dev/null || true
+          exit $GUARD_EXIT

--- a/scripts/verify-agent-layer.mjs
+++ b/scripts/verify-agent-layer.mjs
@@ -1,0 +1,103 @@
+// Anti-regression guard for the agent-facing layer (search-ops V2 audit, #7).
+//
+// agentic-seo (Osmani) assumes a STATIC docs site — files on disk — but this
+// site is Next.js SSR, where AGENTS.md, llms.txt and every docs .md are
+// dynamic routes. So instead of a black-box score, this asserts the exact
+// invariants each agent-layer PR verified by hand. Any regression (a broken
+// .md rewrite, leaked JSX, escaped entities, a disallowed mirror, a lost
+// AGENTS.md pointer) fails CI.
+//
+// Usage: BASE=http://localhost:3999 node scripts/verify-agent-layer.mjs
+// Run against a `next start` server (the workflow boots one first).
+
+const BASE = process.env.BASE || 'http://localhost:3999';
+
+/** A representative sample; if these hold the exporter/proxy are healthy. */
+const DOC_SAMPLE = [
+  'docs/faq',
+  'docs/free-ai-engine',
+  'docs/introduction/guides/apply-for-a-job',
+  'docs/reference/modes',
+];
+
+const failures = [];
+const fail = (msg) => failures.push(msg);
+
+async function get(path, headers = {}) {
+  const res = await fetch(`${BASE}${path}`, { headers, redirect: 'manual' });
+  const body = await res.text();
+  return { res, body, ct: res.headers.get('content-type') || '' };
+}
+
+async function main() {
+  // 1. /AGENTS.md — 200 markdown, thin pointer to the repo's canonical file.
+  {
+    const { res, body, ct } = await get('/AGENTS.md');
+    if (res.status !== 200) fail(`/AGENTS.md status ${res.status} (want 200)`);
+    if (!ct.includes('text/markdown')) fail(`/AGENTS.md content-type "${ct}" (want text/markdown)`);
+    if (!body.includes('raw.githubusercontent.com/santifer/career-ops/main/AGENTS.md'))
+      fail('/AGENTS.md no longer points to the repo raw AGENTS.md');
+  }
+
+  // 2. /llms.txt — 200, absolute .md links, exactly one EN "# Docs" block.
+  {
+    const { res, body } = await get('/llms.txt');
+    if (res.status !== 200) fail(`/llms.txt status ${res.status} (want 200)`);
+    const mdLinks = (body.match(/\]\(https:\/\/career-ops\.org\/docs[^)]*\.md\)/g) || []).length;
+    if (mdLinks < 20) fail(`/llms.txt has ${mdLinks} absolute .md links (want >= 20)`);
+    const docsBlocks = (body.match(/^# Docs\b/gm) || []).length;
+    if (docsBlocks !== 1) fail(`/llms.txt has ${docsBlocks} "# Docs" blocks (want exactly 1, EN-only)`);
+    if (/\]\(\/(es\/|fr\/)?docs/.test(body)) fail('/llms.txt still has relative /docs links');
+  }
+
+  // 3. /llms-full.txt — no escaped entities anywhere (docs + blog).
+  {
+    const { body } = await get('/llms-full.txt');
+    if (/&#x[0-9a-fA-F]+;|&#\d+;/.test(body)) fail('/llms-full.txt contains escaped HTML entities');
+  }
+
+  // 4. robots.txt must NOT disallow the /llms.mdx/ mirror.
+  {
+    const { body } = await get('/robots.txt');
+    if (/Disallow:\s*\/llms\.mdx\//.test(body)) fail('robots.txt disallows /llms.mdx/ (agents need it)');
+  }
+
+  // 5. Per-doc invariants: .md rewrite, Accept negotiation, browser intact,
+  //    and a clean mirror (no escaped entities, no leaked JSX, no relative links).
+  for (const slug of DOC_SAMPLE) {
+    // 5a. `<url>.md` → markdown mirror + noindex (the next.config rewrite).
+    const md = await get(`/${slug}.md`);
+    if (md.res.status !== 200) fail(`/${slug}.md status ${md.res.status} (want 200)`);
+    if (!md.ct.includes('text/markdown')) fail(`/${slug}.md content-type "${md.ct}"`);
+    if ((md.res.headers.get('x-robots-tag') || '') !== 'noindex')
+      fail(`/${slug}.md missing X-Robots-Tag: noindex`);
+
+    // 5b. Accept: text/markdown on the human URL → markdown (the proxy).
+    const acc = await get(`/${slug}`, { Accept: 'text/markdown' });
+    if (!acc.ct.includes('text/markdown')) fail(`/${slug} with Accept:markdown returned "${acc.ct}"`);
+
+    // 5c. A browser (Accept: text/html) still gets HTML.
+    const html = await get(`/${slug}`, { Accept: 'text/html,*/*;q=0.8' });
+    if (!html.ct.includes('text/html')) fail(`/${slug} browser request returned "${html.ct}" (want html)`);
+
+    // 5d. Mirror body cleanliness.
+    const b = md.body;
+    if (/&#x[0-9a-fA-F]+;|&#\d+;/.test(b)) fail(`/${slug}.md contains escaped entities`);
+    if (/<(div|Tabs?|Steps?|Accordions?|Callout|details|summary)[\s>]/.test(b))
+      fail(`/${slug}.md contains leaked JSX tags`);
+    // Relative links (root-relative, not anchors/absolute) should not survive.
+    if (/\]\(\/(?!\/)[^)]*\)/.test(b)) fail(`/${slug}.md contains relative links`);
+  }
+
+  if (failures.length) {
+    console.error(`\n✗ Agent-layer guard: ${failures.length} regression(s)\n`);
+    for (const f of failures) console.error(`  - ${f}`);
+    process.exit(1);
+  }
+  console.log(`✓ Agent-layer guard passed (AGENTS.md, llms.txt, llms-full.txt, robots, ${DOC_SAMPLE.length} docs × .md/Accept/html/clean)`);
+}
+
+main().catch((e) => {
+  console.error('Agent-layer guard crashed:', e);
+  process.exit(1);
+});


### PR DESCRIPTION
**Item #7** del audit V2 de search-ops (GO'd, "cablealo en CI").

## Hallazgo: agentic-seo no encaja con nuestro stack
search-ops propuso adoptar agentic-seo (Osmani) con un threshold de score. Empíricamente, **la herramienta asume un sitio de docs ESTÁTICO** — escanea el filesystem buscando `AGENTS.md` / `llms.txt` / ficheros `.md`. Nuestro sitio es **Next.js SSR** donde eso son **rutas**, así que:
- Modo URL (local **y producción**, mismo resultado): **21% engañoso** — 6 de 10 checks dan *"no local directory available"*, y `agents-md` falla con *"cannot scan in URL-only mode"* aunque `/AGENTS.md` sirve 200.
- Modo directorio: `framework: None`, no encuentra las rutas-como-ficheros.

## El gate: guardia a medida
`scripts/verify-agent-layer.mjs` arranca el sitio y verifica los **invariantes que cada PR de la capa comprobó a mano**:
- `/AGENTS.md` 200 text/markdown, apuntando al raw canónico del repo
- `/llms.txt`: ≥20 links `.md` absolutos, exactamente 1 bloque `# Docs` EN, 0 relativos
- `/llms-full.txt`: 0 entidades escapadas
- `robots.txt` NO bloquea `/llms.mdx/`
- 4 docs muestra: `.md` → 200 markdown + noindex · `Accept:text/markdown` → markdown · browser → HTML · mirror sin entidades escapadas, sin JSX filtrado, sin links relativos

Cualquier regresión → **exit 1, CI falla** (verificado: exit 1 con server caído/invariante roto, exit 0 sano).

## agentic-seo: informativo, no bloquea
Sigue corriendo, pero como paso **informativo** (`continue-on-error`) limitado a los checks de Discovery que sí evalúa por HTTP (`robots-txt`, `llms-txt`). El threshold se descartó (score no significativo para nuestro stack). Reportado a search-ops con la evidencia. `skill.md`/`agent-permissions` siguen 404 por diseño y la guardia no los exige.

**Este PR toca los paths que disparan el workflow → se auto-prueba en CI.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)