### PR TITLE
feat(agents): give the Spanish and French docs their markdown twin

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -103,6 +103,40 @@ const config = {
           source: '/docs/:slug(.*).md',
           destination: '/llms.mdx/docs/:slug/content.md',
         },
+        // The same two shapes for the non-default locales. They need a separate
+        // destination because the EN mirror resolves pages without a locale,
+        // which fumadocs defaults to `en` — that default is why 32 Spanish URLs
+        // had no markdown twin at all. See the route header for why the locale
+        // is an explicit path segment rather than an optional prefix.
+        {
+          source: '/:lang(es|fr)/docs.md',
+          destination: '/llms.mdx/i18n/:lang/docs/content.md',
+        },
+        {
+          source: '/:lang(es|fr)/docs/:slug(.*).md',
+          destination: '/llms.mdx/i18n/:lang/docs/:slug/content.md',
+        },
+        // Accept negotiation for the locale docs. NOT done in src/proxy.ts:
+        // verified 2026-08-20 against a production build that the proxy does
+        // not run for locale-prefixed paths — /docs negotiates correctly while
+        // /es/docs returns HTML with identical headers and identical code. Same
+        // class of Next 16 surprise as `/` and as the `.md` interception, and
+        // the same remedy: let the routing layer do it deterministically.
+        //
+        // These must stay AFTER the `.md` rules above, or `:slug(.*)` would
+        // swallow `<url>.md` before the explicit markdown rewrite sees it.
+        {
+          source: '/:lang(es|fr)/docs',
+          has: [{ type: 'header', key: 'accept', value: '.*text/markdown.*' }],
+          missing: [{ type: 'header', key: 'accept', value: '.*text/html.*' }],
+          destination: '/llms.mdx/i18n/:lang/docs/content.md',
+        },
+        {
+          source: '/:lang(es|fr)/docs/:slug(.*)',
+          has: [{ type: 'header', key: 'accept', value: '.*text/markdown.*' }],
+          missing: [{ type: 'header', key: 'accept', value: '.*text/html.*' }],
+          destination: '/llms.mdx/i18n/:lang/docs/:slug/content.md',
+        },
       ],
     };
   },

--- a/scripts/verify-agent-layer.mjs
+++ b/scripts/verify-agent-layer.mjs
@@ -12,6 +12,13 @@
 
 const BASE = process.env.BASE || 'http://localhost:3999';
 
+/** Per-locale sample: the index, the entry page, and a nested one. */
+/** Non-default locales that must have full markdown parity with EN. */
+const LOCALES = ['es', 'fr'];
+
+/** Per-locale sample: the index, the entry page, and a nested one. */
+const LOCALE_SAMPLE = ['docs', 'docs/introduction/what-is-career-ops', 'docs/faq'];
+
 /** A representative sample; if these hold the exporter/proxy are healthy. */
 const DOC_SAMPLE = [
   'docs/faq',
@@ -89,12 +96,47 @@ async function main() {
     if (/\]\(\/(?!\/)[^)]*\)/.test(b)) fail(`/${slug}.md contains relative links`);
   }
 
+  // 6. Locale parity. 32 Spanish URLs shipped with NO markdown twin at all —
+  //    the mirror resolved pages without a locale, which fumadocs defaults to
+  //    `en`. Assert the same invariants per locale so the asymmetry cannot come
+  //    back silently, and assert the content really is in that language: a
+  //    mirror quietly serving English would pass every status check while being
+  //    worse than a 404.
+  for (const lang of LOCALES) {
+    for (const slug of LOCALE_SAMPLE) {
+      const url = `/${lang}/${slug}`;
+
+      const md = await get(`${url}.md`);
+      if (md.res.status !== 200) fail(`${url}.md status ${md.res.status} (want 200)`);
+      if (!md.ct.includes('text/markdown')) fail(`${url}.md content-type "${md.ct}"`);
+      if ((md.res.headers.get('x-robots-tag') || '') !== 'noindex')
+        fail(`${url}.md missing X-Robots-Tag: noindex`);
+
+      const acc = await get(url, { Accept: 'text/markdown' });
+      if (!acc.ct.includes('text/markdown'))
+        fail(`${url} with Accept:markdown returned "${acc.ct}"`);
+
+      const html = await get(url, { Accept: 'text/html,*/*;q=0.8' });
+      if (!html.ct.includes('text/html'))
+        fail(`${url} browser request returned "${html.ct}" (want html)`);
+
+      // Must cite its own locale's canonical URL, not the EN one — the cheapest
+      // proof that the locale actually reached source.getPage.
+      if (!md.body.includes(`career-ops.org/${lang}/`))
+        fail(`${url}.md does not cite the ${lang} canonical URL (fell back to en?)`);
+    }
+  }
+
   if (failures.length) {
     console.error(`\n✗ Agent-layer guard: ${failures.length} regression(s)\n`);
     for (const f of failures) console.error(`  - ${f}`);
     process.exit(1);
   }
-  console.log(`✓ Agent-layer guard passed (AGENTS.md, llms.txt, llms-full.txt, robots, ${DOC_SAMPLE.length} docs × .md/Accept/html/clean)`);
+  console.log(
+    `✓ Agent-layer guard passed (AGENTS.md, llms.txt, llms-full.txt, robots, ` +
+      `${DOC_SAMPLE.length} EN docs × .md/Accept/html/clean, ` +
+      `${LOCALES.length} locales × ${LOCALE_SAMPLE.length} pages × .md/Accept/html/locale)`,
+  );
 }
 
 main().catch((e) => {

--- a/src/app/AGENTS.md/route.ts
+++ b/src/app/AGENTS.md/route.ts
@@ -27,8 +27,12 @@ The canonical agent instructions ship in the repository:
 
 - Index for agents: https://career-ops.org/llms.txt
 - Full-context dump: https://career-ops.org/llms-full.txt
-- Every docs page has a clean markdown twin: append \`.md\` to any /docs URL
-  (e.g. https://career-ops.org/docs/faq.md), or send \`Accept: text/markdown\`.
+- Every docs page has a clean markdown twin: append \`.md\` to any /docs,
+  /es/docs or /fr/docs URL (e.g. https://career-ops.org/es/docs/faq.md), or
+  send \`Accept: text/markdown\`. The site is EN + ES + FR; each language has
+  its own twin and cites its own canonical URL.
+- That rule covers docs only. Outside it the markdown surfaces are exactly this
+  file and the two above.
 `;
 
 export function GET() {

--- a/src/app/llms.mdx/i18n/[lang]/docs/[[...slug]]/route.ts
+++ b/src/app/llms.mdx/i18n/[lang]/docs/[[...slug]]/route.ts
@@ -1,0 +1,58 @@
+import { getLLMText, source } from '@/lib/source';
+import { i18n } from '@/lib/i18n';
+import { notFound } from 'next/navigation';
+
+// Markdown mirror for the NON-DEFAULT locales (/es/docs/**, /fr/docs/**).
+//
+// The EN mirror lives at /llms.mdx/docs/** and resolves pages without passing a
+// locale, which fumadocs defaults to `en` — that default is exactly why the 93
+// (really 32) Spanish URLs had no markdown twin: the route could not express
+// which language was being asked for. Rather than overload the EN route with an
+// optional leading segment that would collide with real docs slugs, locales get
+// their own explicit path and pass the locale through.
+//
+// Reached only via the next.config `beforeFiles` rewrite for `<url>.md` and the
+// Accept negotiation in src/proxy.ts — never linked directly.
+export const revalidate = false;
+
+// Params typed explicitly rather than via the generated RouteContext: that type
+// is derived from routes Next has already seen, so a brand-new route cannot
+// reference it until a build has run — a bootstrapping order that breaks `tsc`
+// on a clean checkout.
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ lang: string; slug?: string[] }> },
+) {
+  const { lang, slug } = await params;
+
+  // Only real, non-default locales. `en` belongs to the other route, and an
+  // unknown value must 404 rather than silently fall back to English — a
+  // wrong-language answer is worse than no answer. The widening cast is the
+  // narrowing check itself: `lang` arrives as a plain string from the URL.
+  const locales: readonly string[] = i18n.languages;
+  if (lang === i18n.defaultLanguage || !locales.includes(lang)) notFound();
+
+  // The rewrite appends `content.md` as the final segment; drop it.
+  const page = source.getPage(slug?.slice(0, -1), lang);
+  if (!page) notFound();
+
+  return new Response(await getLLMText(page), {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      // Same discipline as the EN mirror: fetchable by agents, never competing
+      // with the canonical HTML page in the search index.
+      'X-Robots-Tag': 'noindex',
+    },
+  });
+}
+
+export function generateStaticParams() {
+  return i18n.languages
+    .filter((lang) => lang !== i18n.defaultLanguage)
+    .flatMap((lang) =>
+      source.getPages(lang).map((page) => ({
+        lang,
+        slug: [...page.slugs, 'content.md'],
+      })),
+    );
+}

--- a/src/lib/llms-index.ts
+++ b/src/lib/llms-index.ts
@@ -143,7 +143,7 @@ async function agentDocsIndex(): Promise<string> {
 
   return `# Docs (agent-ready markdown)
 
-Each link below is the .md mirror — the same content as the HTML page, ~20-100x fewer tokens — with an approximate token count so you can budget context before fetching. You can also append \`.md\` to any docs URL, or request one with \`Accept: text/markdown\`.
+Each link below is the .md mirror — the same content as the HTML page, ~20-100x fewer tokens — with an approximate token count so you can budget context before fetching. You can also append \`.md\` to any \`/docs\`, \`/es/docs\` or \`/fr/docs\` URL, or request one with \`Accept: text/markdown\` — the same markdown twin exists for every page in all three languages. Outside those paths the rule does not apply; the only other markdown surfaces are https://career-ops.org/AGENTS.md, https://career-ops.org/llms.txt and https://career-ops.org/llms-full.txt.
 ${withTokens}`;
 }
 


### PR DESCRIPTION
Mandate from Santiago via search-ops, verified independently today.

## The gap

```
/es/docs/... + Accept: text/markdown   →  200 text/HTML   (no negotiation)
/es/docs/....md                        →  404             (no mirror)
/docs/....md                (EN)       →  200 text/markdown ✓
```

32 Spanish URLs published, **none readable as markdown by an agent**. All 30 English ones were. FR identical to ES.

**The cause was one line**: the mirror route called `source.getPage(slug)` with no locale, and fumadocs defaults that to `en`. The route had no way to express which language was being asked for.

## Corrections to the brief, both verified

- **32 ES URLs, not 93.** search-ops' count came from a `grep` over the raw sitemap that caught the `xhtml:link` alternates of every entry. Their verification plan would have produced 61 phantom failures. Accepted and corrected on their side.
- **`llms.txt` stays EN-only** (their decision, option a): the index is a budgeted artifact and tripling it reopens the leak they closed in W30. Discovery rides on the convention, which now names the locales explicitly instead of saying "any docs URL".

## Design decisions worth reviewing

**Locales get their own mirror path** (`/llms.mdx/i18n/[lang]/docs/**`) rather than an optional prefix on the EN route, which would collide with real docs slugs. The route **404s on an unknown or default locale instead of falling back** — a confidently wrong-language answer is worse than no answer.

**Accept negotiation for locales lives in `next.config`, not `src/proxy.ts`.** Verified against a production build that the proxy does not run for locale-prefixed paths: `/docs` negotiates correctly while `/es/docs` returns HTML, with identical code and identical headers. Same class of Next 16 surprise as `/` and as the `.md` interception — and `src/proxy.ts` already documents the same remedy for the homepage.

**The guard asserts each mirror cites its OWN canonical URL.** That is the check that matters: a mirror quietly serving English passes every status-code assertion while being worse than a 404, and it is exactly the failure this PR fixes.

## Verification

Against a production build (`next build` + `next start`), not the dev server:

- **30/30 Spanish pages**: `text/markdown`, `X-Robots-Tag: noindex`, Spanish content, correct `Source:` canonical
- FR sample identical
- EN unchanged; browsers still get HTML in all three languages
- `verify-agent-layer.mjs` green, now covering 2 locales × 3 pages

## Deliberately not here

`/es` home and `/es/manifesto` twins (search-ops' point 2). The manifesto text is byte-canonical and composed in JSX; extracting it deserves its own pass rather than a hurried paraphrase.

## Known context for whoever measures this

7 of 30 Spanish pages have a stale `translationHash` — their English source changed after the translation was stamped. The drift is **factual, not cosmetic**: `index.es` is missing the "eight CLIs" fact. Publishing the mirror does not make that worse (stale markdown beats stale HTML), but if Spanish answers underperform, look at content before format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)