### PR TITLE
fix(perf): sample Speed Insights at 3% instead of measuring every page view

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -191,7 +191,20 @@ export default async function Layout({ children }: LayoutProps<'/'>) {
           </div>
         </footer>
         <Analytics />
-        <SpeedInsights />
+        {/*
+          3% sampling, not the default 1 (= every page view). The site emitted
+          165,640 data points in 30 days — 1,656% of the 10,000 included in the
+          free tier — and Vercel paused collection account-wide on 2026-08-25.
+          At ~5,500 page views/day, 3% lands at ~4,970/month: under the 10,000
+          cap AND under the 5,000 that Vercel requires before it resumes a
+          paused project, with room for traffic to double before this recurs.
+          5% would clear the cap but sit above the resume threshold, which is
+          the trap — it looks fixed and stays paused.
+          ~166 samples/day still give a solid site-wide p75 for Core Web Vitals;
+          measuring everyone adds confidence intervals, not insight. Per-route
+          p75 for the long tail of /docs is the thing this costs us.
+        */}
+        <SpeedInsights sampleRate={0.03} />
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -200,9 +200,21 @@ export default async function Layout({ children }: LayoutProps<'/'>) {
           paused project, with room for traffic to double before this recurs.
           5% would clear the cap but sit above the resume threshold, which is
           the trap — it looks fixed and stays paused.
-          ~166 samples/day still give a solid site-wide p75 for Core Web Vitals;
-          measuring everyone adds confidence intervals, not insight. Per-route
-          p75 for the long tail of /docs is the thing this costs us.
+          What survives at this rate, measured against the real request
+          distribution (search-ops, 7d to 2026-08-25, 146 pages / 731k non-bot
+          requests — the traffic is FLAT, not concentrated: "/" and "/docs"
+          together are 16.4%):
+
+            p75 site-wide  — weekly, defensible. The ~166 samples/day aggregate.
+            p75 per route  — MONTHLY only, and only for the top ~14 pages.
+            everything else — report "insufficient". Never a number.
+
+          Per-route weekly p75 does not survive for ANY route, including the
+          home page (13.9 samples/day, just under the ~14/day floor). That is
+          not a long-tail problem, it is the whole table. A percentile over a
+          handful of observations is not a weak estimate, it is undefined — and
+          an instrument with two states lies when it fails, so the cell must say
+          "insufficient" rather than print a figure.
         */}
         <SpeedInsights sampleRate={0.03} />
       </body>


### PR DESCRIPTION
Vercel paused Speed Insights collection across the whole team on 2026-08-25. The notice:

> Free Speed Insights projects used 165,640 data points over the past 30 days. That is 1656% of the 10,000 included for free.

**It is all us.** Of the eight projects on the team, `career-ops-docs` is the only one where the Speed Insights config reports `hasData: true` — `web`, `cv-santiago`, `mission-control` and the rest are all `false`. career-ops.org serves roughly 5,500 page views a day and, at the default `sampleRate` of 1, every single one emitted a data point.

## Why 3% and not 5%

There are two thresholds, and only the first one is obvious.

| sample | data points/month | under the 10,000 cap | under the 5,000 resume line |
|---|---|---|---|
| 10% | 16,564 | no | no |
| 5% | 8,282 | yes | **no** |
| 3% | 4,969 | yes | yes |
| 2% | 3,313 | yes | yes |

Vercel resumes a paused project only once the rolling 30-day window drops to *half* the allocation. 5% clears the cap but parks us above the resume line — it would look fixed and stay paused. 3% clears both and leaves room for traffic to double before this recurs.

## What it costs

Per-route p75 for the long tail of `/docs` gets thin: ~166 samples a day spread across ~90 routes. Site-wide p75 does not suffer — that is a representative sample, and measuring every visitor buys tighter confidence intervals, not new information.

## What this does not do

Collection stays paused until 2026-09-08 at the earliest no matter what we merge. The 30-day window has to age out on its own. This prevents the next pause; it does not lift this one.

Deployments and Web Analytics are unaffected — only Core Web Vitals collection was paused.

Diagnosed by warpchart, who traced the team-wide notice back to our traffic.