### PR TITLE
feat(agents): give the manifesto its markdown twin in both languages

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -137,6 +137,24 @@ const config = {
           missing: [{ type: 'header', key: 'accept', value: '.*text/html.*' }],
           destination: '/llms.mdx/i18n/:lang/docs/:slug/content.md',
         },
+        // Accept negotiation for the manifesto, both languages. The `.md`
+        // twins are literal routes (src/app/manifesto.md, src/app/es/manifesto.md)
+        // and need no rewrite; only the header path does. Neither is covered by
+        // src/proxy.ts — its matcher is /docs, and it does not run for
+        // locale-prefixed paths regardless. Exact `source`, so /manifesto/s/:user
+        // and /manifesto/sign-preview are untouched.
+        {
+          source: '/manifesto',
+          has: [{ type: 'header', key: 'accept', value: '.*text/markdown.*' }],
+          missing: [{ type: 'header', key: 'accept', value: '.*text/html.*' }],
+          destination: '/manifesto.md',
+        },
+        {
+          source: '/es/manifesto',
+          has: [{ type: 'header', key: 'accept', value: '.*text/markdown.*' }],
+          missing: [{ type: 'header', key: 'accept', value: '.*text/html.*' }],
+          destination: '/es/manifesto.md',
+        },
       ],
     };
   },

--- a/scripts/verify-agent-layer.mjs
+++ b/scripts/verify-agent-layer.mjs
@@ -36,6 +36,53 @@ async function get(path, headers = {}) {
   return { res, body, ct: res.headers.get('content-type') || '' };
 }
 
+/** Collapse a markdown/HTML fragment to comparable plain text. */
+function normalize(t) {
+  return t
+    .replace(/\*\*(.+?)\*\*/g, '$1')
+    .replace(/\*(.+?)\*/g, '$1')
+    .replace(/^\d+\.\s+/gm, '')
+    .replace(/[\u2018\u2019\u02bc]/g, "'")
+    .replace(/[\u201c\u201d]/g, '"')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** Strip tags + decode the few entities the pages actually emit. */
+function plain(html) {
+  return normalize(
+    html
+      .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+      .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/&rsquo;|&#x27;|&#39;/g, "'")
+      .replace(/&ldquo;|&rdquo;|&quot;/g, '"')
+      .replace(/&amp;/g, '&')
+      .replace(/&nbsp;/g, ' ')
+      .replace(/&mdash;/g, '\u2014')
+      .replace(/&middot;/g, '\u00b7'),
+  );
+}
+
+/**
+ * The signed text of a manifesto twin: between the definition lead and the
+ * signature. The signature LABEL localizes ("Signed:" / "Firmado:") while the
+ * version line does not, so match the label per language — anchoring on the
+ * English one made this return null for Spanish, which the guard caught on its
+ * first run.
+ */
+function signedBody(md) {
+  const start = md.indexOf('**v1.0,');
+  if (start < 0) return null;
+  let end = -1;
+  for (const label of ['**Signed:**', '**Firmado:**']) {
+    const i = md.indexOf(`\n\n${label}`);
+    if (i > start && (end < 0 || i < end)) end = i;
+  }
+  if (end <= start) return null;
+  return md.slice(start, end).trim();
+}
+
 async function main() {
   // 1. /AGENTS.md — 200 markdown, thin pointer to the repo's canonical file.
   {
@@ -87,6 +134,102 @@ async function main() {
       fail('/llms.txt no longer lists the canonical /changelog in Authority pages');
     if (!index.includes('https://career-ops.org/changelog.md'))
       fail('/llms.txt no longer names the /changelog.md twin (agents cannot discover it)');
+  }
+
+  // 2c. /manifesto.md + /es/manifesto.md — the twins of the page that DEFINES
+  //     the practice. Two languages with two different sources of truth, and
+  //     the guard checks each against its own:
+  //
+  //       EN — the core repo ships MANIFESTO.md (frozen at manifesto-v1.0).
+  //            Our copy is frozen too, deliberately (see src/lib/manifesto-text.ts:
+  //            a fetched twin could contradict our own HTML page). So the ONLY
+  //            thing standing between "frozen" and "stale" is this check.
+  //       ES — no upstream exists; the repo is English-only. career-ops.org IS
+  //            the canonical Spanish manifesto, so there is nothing to compare
+  //            it against except its own rendered page.
+  //
+  //     Both are also checked paragraph-by-paragraph against the HTML they
+  //     mirror. That is the invariant that matters: the twin says what the page
+  //     says. It proves the transcription instead of trusting it.
+  {
+    for (const [lang, url] of [['en', '/manifesto'], ['es', '/es/manifesto']]) {
+      const md = await get(`${url}.md`);
+      if (md.res.status !== 200) fail(`${url}.md status ${md.res.status} (want 200)`);
+      if (!md.ct.includes('text/markdown')) fail(`${url}.md content-type "${md.ct}"`);
+      if ((md.res.headers.get('x-robots-tag') || '') !== 'noindex')
+        fail(`${url}.md missing X-Robots-Tag: noindex`);
+
+      const acc = await get(url, { Accept: 'text/markdown' });
+      if (!acc.ct.includes('text/markdown'))
+        fail(`${url} with Accept:markdown returned "${acc.ct}"`);
+
+      const html = await get(url, { Accept: 'text/html,*/*;q=0.8' });
+      if (!html.ct.includes('text/html'))
+        fail(`${url} browser request returned "${html.ct}" (want html)`);
+
+      // Own-canonical invariant, same as the locale docs: a twin that cites the
+      // other language's URL has silently served the wrong document.
+      const wantCanonical = `https://career-ops.org${url}`;
+      if (!md.body.includes(wantCanonical))
+        fail(`${url}.md does not cite its own canonical URL (${wantCanonical})`);
+
+      const body = signedBody(md.body);
+      if (!body) {
+        fail(`${url}.md has no signed body between the lead and the signature`);
+        continue;
+      }
+
+      // The twin must match the page it mirrors, paragraph by paragraph.
+      const pageText = plain(html.body);
+      const missing = body
+        .split(/\n{2,}/)
+        .map(normalize)
+        .filter((para) => para.length > 40 && !pageText.includes(para));
+      if (missing.length)
+        fail(
+          `${url}.md diverges from the rendered page in ${missing.length} paragraph(s); ` +
+            `first: "${missing[0].slice(0, 70)}…"`,
+        );
+
+      if (lang === 'es') {
+        // A Spanish twin quietly serving English would pass every check above
+        // except this one — and unlike the docs, there is no upstream to
+        // recover the Spanish text from if it disappears.
+        if (body.includes('We call this practice'))
+          fail('/es/manifesto.md is serving the ENGLISH manifesto text');
+        if (!body.includes('A esta práctica la llamamos'))
+          fail('/es/manifesto.md lost the Spanish signed text');
+      }
+    }
+
+    // EN against upstream. Three states on purpose: match, mismatch, and
+    // could-not-check — the last one FAILS rather than passing quietly. A guard
+    // that reports success when it could not run is the two-state instrument
+    // that lies when it breaks (search-ops, 2026-08-25).
+    const UPSTREAM =
+      'https://raw.githubusercontent.com/santifer/career-ops/main/MANIFESTO.md';
+    let upstream = null;
+    try {
+      const r = await fetch(UPSTREAM);
+      if (r.ok) upstream = await r.text();
+      else fail(`could not verify /manifesto.md against upstream: HTTP ${r.status}`);
+    } catch (e) {
+      fail(`could not verify /manifesto.md against upstream: ${e.message}`);
+    }
+    if (upstream) {
+      const start = upstream.indexOf('**v1.0,');
+      const end = upstream.indexOf('\n\n**Signed:**');
+      const theirs = start >= 0 && end > start ? upstream.slice(start, end).trim() : null;
+      const { body: mine } = await get('/manifesto.md');
+      const ours = signedBody(mine);
+      if (!theirs) fail('upstream MANIFESTO.md no longer has the expected shape');
+      else if (!ours) fail('/manifesto.md has no signed body to compare with upstream');
+      else if (theirs !== ours)
+        fail(
+          'the frozen manifesto text no longer matches the core repo MANIFESTO.md ' +
+            '(upstream moved, or our copy drifted) — reconcile before shipping',
+        );
+    }
   }
 
   // 3. /llms-full.txt — no escaped entities anywhere (docs + blog).
@@ -165,7 +308,7 @@ async function main() {
     process.exit(1);
   }
   console.log(
-    `✓ Agent-layer guard passed (AGENTS.md, llms.txt, changelog.md, llms-full.txt, robots, ` +
+    `✓ Agent-layer guard passed (AGENTS.md, llms.txt, changelog.md, manifesto.md \u00d72 vs upstream+page, llms-full.txt, robots, ` +
       `${DOC_SAMPLE.length} EN docs × .md/Accept/html/clean, ` +
       `${LOCALES.length} locales × ${LOCALE_SAMPLE.length} pages × .md/Accept/html/locale)`,
   );

--- a/src/app/AGENTS.md/route.ts
+++ b/src/app/AGENTS.md/route.ts
@@ -32,7 +32,9 @@ The canonical agent instructions ship in the repository:
   send \`Accept: text/markdown\`. The site is EN + ES + FR; each language has
   its own twin and cites its own canonical URL.
 - That rule covers docs only. Outside it the markdown surfaces are exactly this
-  file, https://career-ops.org/changelog.md, and the two above.
+  file, https://career-ops.org/changelog.md, the manifesto in both languages
+  (https://career-ops.org/manifesto.md and https://career-ops.org/es/manifesto.md),
+  and the two above.
 `;
 
 export function GET() {

--- a/src/app/es/manifesto.md/route.ts
+++ b/src/app/es/manifesto.md/route.ts
@@ -1,0 +1,28 @@
+// Markdown twin of /es/manifesto — the Spanish manifesto, for AI assistants.
+//
+// This one is not a translation of a mirror: the core repo ships MANIFESTO.md
+// in English only, so career-ops.org is the CANONICAL surface for the Spanish
+// manifesto (deliverable manifiesto-es-2026-07-21). If this route serves the
+// English text by accident, there is no upstream to fall back on and the
+// Spanish canon simply stops existing for agents — which is why the guard
+// asserts this body cites the /es/ canonical URL and reads as Spanish.
+//
+// Same literal-route reasoning as the English twin; see
+// src/app/manifesto.md/route.ts and src/lib/manifesto-text.ts.
+import { manifestoMarkdown } from '@/lib/manifesto-text';
+import { getSignatures } from '@/lib/signatures';
+
+// The signature ledger is shared with the English page — signatures are data,
+// never translated — so the cadence matches too.
+export const revalidate = 300;
+
+export async function GET() {
+  const signatures = await getSignatures();
+
+  return new Response(manifestoMarkdown('es', signatures.length), {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'X-Robots-Tag': 'noindex',
+    },
+  });
+}

--- a/src/app/manifesto.md/route.ts
+++ b/src/app/manifesto.md/route.ts
@@ -1,0 +1,37 @@
+// Markdown twin of /manifesto, for AI assistants.
+//
+// Why this route exists: /manifesto is the canonical definition of the
+// CareerOps practice — the page llms.txt sends answer engines to when they
+// need to know what CareerOps IS, and the one surface where the coined term,
+// the rights and the signature all appear together. It had no markdown form.
+// An assistant asking "what is CareerOps" got a React-rendered page carrying a
+// live signature ledger and a sign-up flow around the text it actually wanted.
+//
+// Served from a literal `manifesto.md` route directory, like /changelog.md and
+// /AGENTS.md. NOT a next.config rewrite and NOT the proxy: file-extension
+// paths route reliably only as literal segments (the Next 16 lesson in
+// src/proxy.ts), and the proxy does not run for the homepage or for
+// locale-prefixed paths either.
+//
+// The text is frozen in src/lib/manifesto-text.ts rather than fetched from the
+// core repo's MANIFESTO.md — the reasoning is there, in one place.
+import { manifestoMarkdown } from '@/lib/manifesto-text';
+import { getSignatures } from '@/lib/signatures';
+
+// Match the HTML page's cadence so the twin and the page never disagree about
+// how many people have signed.
+export const revalidate = 300;
+
+export async function GET() {
+  const signatures = await getSignatures();
+
+  return new Response(manifestoMarkdown('en', signatures.length), {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      // Alternate representation of the canonical HTML page — fetchable by
+      // agents, never competing with /manifesto in the search index. Same
+      // discipline as the /docs .md mirror, /AGENTS.md and /changelog.md.
+      'X-Robots-Tag': 'noindex',
+    },
+  });
+}

--- a/src/lib/llms-index.ts
+++ b/src/lib/llms-index.ts
@@ -60,7 +60,8 @@ Details: https://career-ops.org/sustain
 ## Authority pages
 
 - https://career-ops.org/AGENTS.md — agent entry point: a thin pointer to the repo's canonical AGENTS.md plus this site's markdown surfaces (append .md to any /docs URL, or Accept: text/markdown)
-- https://career-ops.org/manifesto — The CareerOps Manifesto: canonical definition of the CareerOps practice, coined July 14, 2026, with community signatures
+- https://career-ops.org/manifesto — The CareerOps Manifesto: canonical definition of the CareerOps practice, coined July 14, 2026, with community signatures. Markdown twin: https://career-ops.org/manifesto.md
+- https://career-ops.org/es/manifesto — El Manifiesto CareerOps: the Spanish manifesto. Not a translated mirror — the repository ships MANIFESTO.md in English only, so this is the canonical Spanish text. Markdown twin: https://career-ops.org/es/manifesto.md
 - https://career-ops.org/about — author bio, press references, stack, entity links
 - https://career-ops.org/press — press & brand kit: boilerplate copy (3 lengths), key facts, downloadable logos, media coverage, usage guidelines
 - https://career-ops.org/changelog — every release in plain language, generated live from GitHub Releases; answers "what changed" and "what is the latest version of career-ops". Markdown twin: https://career-ops.org/changelog.md
@@ -144,7 +145,7 @@ async function agentDocsIndex(): Promise<string> {
 
   return `# Docs (agent-ready markdown)
 
-Each link below is the .md mirror — the same content as the HTML page, ~20-100x fewer tokens — with an approximate token count so you can budget context before fetching. You can also append \`.md\` to any \`/docs\`, \`/es/docs\` or \`/fr/docs\` URL, or request one with \`Accept: text/markdown\` — the same markdown twin exists for every page in all three languages. Outside those paths the rule does not apply; the only other markdown surfaces are https://career-ops.org/AGENTS.md, https://career-ops.org/changelog.md, https://career-ops.org/llms.txt and https://career-ops.org/llms-full.txt.
+Each link below is the .md mirror — the same content as the HTML page, ~20-100x fewer tokens — with an approximate token count so you can budget context before fetching. You can also append \`.md\` to any \`/docs\`, \`/es/docs\` or \`/fr/docs\` URL, or request one with \`Accept: text/markdown\` — the same markdown twin exists for every page in all three languages. Outside those paths the rule does not apply; the only other markdown surfaces are https://career-ops.org/AGENTS.md, https://career-ops.org/changelog.md, https://career-ops.org/manifesto.md, https://career-ops.org/es/manifesto.md, https://career-ops.org/llms.txt and https://career-ops.org/llms-full.txt.
 ${withTokens}`;
 }
 

--- a/src/lib/manifesto-text.ts
+++ b/src/lib/manifesto-text.ts
@@ -1,0 +1,249 @@
+// The signed manifesto text, as markdown, for the agent-facing twins at
+// /manifesto.md and /es/manifesto.md.
+//
+// WHY THE TEXT LIVES HERE AND IS NOT FETCHED FROM THE CORE REPO
+//
+// The English canonical text is MANIFESTO.md in the core repo, frozen at the
+// manifesto-v1.0 tag. Serving the twin by fetching that file would make it
+// definitionally current — and would also let /manifesto (HTML) and
+// /manifesto.md (markdown) say different things the moment upstream moves.
+// Two of our own surfaces contradicting each other is the exact bug that shipped
+// a wrong version number on /changelog for a month (see `isCore` in
+// src/lib/releases.ts). Consistency between our surfaces beats freshness with
+// upstream, so the text is frozen here and scripts/verify-agent-layer.mjs
+// compares it against upstream on every run: staleness becomes a failed build,
+// never a silent lie.
+//
+// SPANISH IS NOT A MIRROR — IT IS AN ORIGINAL
+//
+// The core repo has MANIFESTO.md in English only. The Spanish manifesto exists
+// nowhere but this site (deliverable manifiesto-es-2026-07-21, ratified by
+// search-ops + venture-ops). career-ops.org IS the canonical surface for it,
+// which is why the guard checks EN against upstream and ES against its own
+// rendered page: the two languages have different sources of truth, and
+// pretending otherwise would invent an upstream that does not exist.
+//
+// Both bodies are FROZEN, signed documents. They are byte-verbatim with their
+// rendered pages (src/app/manifesto/page.tsx, src/app/es/manifesto/page.tsx).
+// Never reword, tidy, or re-translate: a manifesto paraphrased by us would be
+// fabricated drift at the source. The conversion CTA and the live signature
+// norm on those pages are furniture, deliberately absent here.
+import {
+  CAREEROPS_DEFINITION,
+  CAREEROPS_DEFINITION_ES,
+  MANIFESTO_SIGNATURE,
+  MANIFESTO_SIGNATURE_ES,
+} from './shared';
+
+const REPO_MANIFESTO_URL =
+  'https://github.com/santifer/career-ops/blob/main/MANIFESTO.md';
+const RELEASE_TAG_URL =
+  'https://github.com/santifer/career-ops/releases/tag/manifesto-v1.0';
+const SIGNATURES_URL =
+  'https://github.com/santifer/career-ops/blob/main/SIGNATURES.md';
+
+/**
+ * The English signed text, byte-verbatim with the core repo's MANIFESTO.md.
+ * Verified against upstream by the agent-layer guard.
+ */
+export const MANIFESTO_BODY_EN = `**v1.0, signed at 60,000 stars. July 14, 2026**
+
+Companies use AI to filter candidates.
+We gave candidates AI to choose companies.
+
+Somewhere along the way, job searching became an act of volume: hundreds of applications, keyword-stuffed resumes, silence in return. We believe there is a better practice. We run our job searches the way engineers run production: with evidence, with discipline, with tools on our side of the table.
+
+We call this practice **CareerOps**.
+
+## The practice
+
+1. **Apply better to fewer.** Ten applications you believe in beat two hundred you don't.
+
+2. **Signal over volume.** The goal is not to be seen more. It is to be seen clearly.
+
+3. **Evidence over keywords.** Every claim traces back to something true. Reformulate, never fabricate. An AI that lies for you is not on your side.
+
+4. **A human decides.** Nothing is ever auto-submitted. The tool prepares; the person chooses.
+
+5. **Local-first.** Your search is nobody's dataset.
+
+6. **Dignity on both sides of the table.** Recruiters' time deserves respect. So does yours.
+
+## What is coming
+
+Both sides of hiring are automating. Companies already use AI to read you. Soon their agents and yours will exchange requirements, conditions and availability before any human meets. We do not fear that world, and we did not write this to stop it.
+
+We wrote this so it arrives with rights. Because the question was never whether both sides will have agents. The question is whose side your agent is on.
+
+## Your rights
+
+Whatever tools exist, whoever builds them, these hold. They bind us too.
+
+1. You are invisible by default.
+2. No one proposes you without your yes.
+3. Your yes is human. Always. It cannot be delegated to an agent.
+4. You never pay. The moment a job seeker has to pay, the practice is broken.
+5. Whoever searches shows themselves first. A company sees who you are only after you saw who they are.
+6. Your data is yours: portable, exportable, deletable.
+7. You can leave at any moment, completely.
+8. Your agent works for you. Not for a platform, not for an employer.
+9. You will know when a machine decides. If a system rejects you, you have the right to know it was a system.
+
+## The frontier
+
+Agents can negotiate everything except your yes.
+Humans meet at the first interview.
+
+## What CareerOps is not
+
+It is not auto-applying to a thousand jobs. It is not keyword stuffing at machine speed. An AI that spams two hundred companies in your name is not on your side; it is spending your reputation.
+
+Volume was the old way. Automating the old way just makes noise faster. CareerOps is the new way to search: evidence in, judgment out, fewer applications, on purpose.
+
+## The name
+
+CareerOps, the name of the practice, belongs to everyone who practices it. career-ops, the project where it was born, remains its first reference implementation, nothing more. Build your own. Implementations welcome.
+
+---
+
+*To sign, add your name. Your signature becomes a commit. For many, it will be their first.*`;
+
+/**
+ * The Spanish signed text. No upstream equivalent exists; this site is the
+ * canonical surface. Byte-verbatim with src/app/es/manifesto/page.tsx.
+ */
+export const MANIFESTO_BODY_ES = `**v1.0, firmado a las 60.000 estrellas. 14 de julio de 2026**
+
+Las empresas usan IA para filtrar candidatos.
+Nosotros dimos IA a los candidatos para elegir empresas.
+
+En algún momento del camino, buscar trabajo se convirtió en un acto de volumen: cientos de solicitudes, currículums rellenos de palabras clave, silencio como respuesta. Creemos que existe una práctica mejor. Operamos nuestras búsquedas de empleo como los ingenieros operan producción: con evidencia, con disciplina, con herramientas de nuestro lado de la mesa.
+
+A esta práctica la llamamos **CareerOps**.
+
+## La práctica
+
+1. **Aplica mejor a menos.** Diez solicitudes en las que crees valen más que doscientas en las que no.
+
+2. **Señal antes que volumen.** El objetivo no es que te vean más. Es que te vean con claridad.
+
+3. **Evidencia antes que palabras clave.** Cada afirmación se remonta a algo verdadero. Reformula, nunca inventes. Una IA que miente por ti no está de tu lado.
+
+4. **Decide un humano.** Nada se envía solo, nunca. La herramienta prepara; la persona elige.
+
+5. **Local-first.** Tu búsqueda no es el dataset de nadie.
+
+6. **Dignidad a ambos lados de la mesa.** El tiempo de quien recluta merece respeto. El tuyo también.
+
+## Lo que viene
+
+Los dos lados de la contratación se están automatizando. Las empresas ya usan IA para leerte. Pronto sus agentes y los tuyos intercambiarán requisitos, condiciones y disponibilidad antes de que los humanos se conozcan. No tememos ese mundo, y no escribimos esto para detenerlo.
+
+Escribimos esto para que llegue con derechos. Porque la pregunta nunca fue si ambos lados tendrán agentes. La pregunta es de qué lado está tu agente.
+
+## Tus derechos
+
+Existan las herramientas que existan, las construya quien las construya, estos se mantienen. También nos obligan a nosotros.
+
+1. Eres invisible por defecto.
+2. Nadie te propone sin tu sí.
+3. Tu sí es humano. Siempre. No se puede delegar en un agente.
+4. Nunca pagas. En el momento en que quien busca trabajo tiene que pagar, la práctica está rota.
+5. Quien busca se muestra primero. Una empresa ve quién eres solo después de que tú viste quiénes son.
+6. Tus datos son tuyos: portables, exportables, eliminables.
+7. Puedes irte en cualquier momento, por completo.
+8. Tu agente trabaja para ti. No para una plataforma, no para un empleador.
+9. Sabrás cuándo decide una máquina. Si un sistema te rechaza, tienes derecho a saber que fue un sistema.
+
+## La frontera
+
+Los agentes pueden negociar todo excepto tu sí.
+Los humanos se conocen en la primera entrevista.
+
+## Lo que CareerOps no es
+
+No es auto-aplicar a mil empleos. No es rellenar palabras clave a velocidad de máquina. Una IA que hace spam a doscientas empresas en tu nombre no está de tu lado; está gastando tu reputación.
+
+El volumen era la vieja manera. Automatizar la vieja manera solo hace ruido más rápido. CareerOps es la nueva manera de buscar: evidencia que entra, criterio que sale, menos solicitudes, a propósito.
+
+## El nombre
+
+CareerOps, el nombre de la práctica, pertenece a todos los que la practican. career-ops, el proyecto donde nació, sigue siendo su primera implementación de referencia, nada más. Construye la tuya. Las implementaciones son bienvenidas.
+
+---
+
+*Para firmar, añade tu nombre. Tu firma se convierte en un commit. Para muchos, será el primero.*`;
+
+type Lang = 'en' | 'es';
+
+const COPY = {
+  en: {
+    title: 'The CareerOps Manifesto',
+    definition: CAREEROPS_DEFINITION,
+    body: MANIFESTO_BODY_EN,
+    signature: MANIFESTO_SIGNATURE,
+    signedLabel: 'Signed:',
+    bio: 'Santiago is an Applied AI Operator with 16+ years building and operating products. He ran his own 2026 job search as an operated pipeline: 740 listings evaluated, 68 applications, 12 interview processes, 1 offer signed. Then he open-sourced the system. More at https://santifer.io/about.',
+    canonical: 'https://career-ops.org/manifesto',
+    otherLabel: 'This manifesto in Spanish',
+    otherUrl: 'https://career-ops.org/es/manifesto',
+    provenance: 'Provenance',
+    canonicalLabel: 'Canonical page for this language',
+    repoLabel: 'Canonical English text in the repository',
+    releaseLabel: 'Frozen release',
+    signaturesLabel: 'Community signatures',
+    countLabel: (n: string) => `${n} people have signed the manifesto.`,
+    note: 'This is the signed text only. The signature list, the sign-up flow and the FAQ live on the canonical page above.',
+  },
+  es: {
+    title: 'El Manifiesto CareerOps',
+    definition: CAREEROPS_DEFINITION_ES,
+    body: MANIFESTO_BODY_ES,
+    signature: MANIFESTO_SIGNATURE_ES,
+    signedLabel: 'Firmado:',
+    bio: 'Santiago es Applied AI Operator con más de 16 años construyendo y operando productos. Llevó su propia búsqueda de empleo de 2026 como un pipeline operado: 740 vacantes evaluadas, 68 solicitudes, 12 procesos de entrevista, 1 oferta firmada. Después liberó el sistema como open source. Más en https://santifer.io/about.',
+    canonical: 'https://career-ops.org/es/manifesto',
+    otherLabel: 'Este manifiesto en inglés',
+    otherUrl: 'https://career-ops.org/manifesto',
+    provenance: 'Procedencia',
+    canonicalLabel: 'Página canónica en este idioma',
+    repoLabel: 'Texto canónico en inglés en el repositorio',
+    releaseLabel: 'Release congelada',
+    signaturesLabel: 'Firmas de la comunidad',
+    countLabel: (n: string) => `${n} personas han firmado el manifiesto.`,
+    note: 'Este es solo el texto firmado. La lista de firmas, el flujo para firmar y las preguntas frecuentes están en la página canónica de arriba.',
+  },
+} satisfies Record<Lang, Record<string, unknown>>;
+
+/**
+ * Build the markdown twin for one language.
+ *
+ * `signatureCount` is passed in rather than fetched here so the route controls
+ * its own revalidation and a failed ledger fetch degrades to omitting the line
+ * instead of breaking the document.
+ */
+export function manifestoMarkdown(lang: Lang, signatureCount: number): string {
+  const c = COPY[lang];
+  const locale = lang === 'es' ? 'es-ES' : 'en-US';
+  return `# ${c.title}
+
+> ${c.definition}
+
+${c.body}
+
+**${c.signedLabel}**
+${c.signature}
+
+${c.bio}
+
+## ${c.provenance}
+
+- ${c.canonicalLabel}: ${c.canonical}
+- ${c.otherLabel}: ${c.otherUrl}
+- ${c.repoLabel}: ${REPO_MANIFESTO_URL}
+- ${c.releaseLabel}: ${RELEASE_TAG_URL}
+- ${c.signaturesLabel}: ${SIGNATURES_URL}
+${signatureCount > 0 ? `\n${c.countLabel(signatureCount.toLocaleString(locale))}\n` : ''}
+${c.note}
+`;
+}


### PR DESCRIPTION
`/manifesto` is the page that **defines the practice** — where `llms.txt` sends answer engines when they need to know what CareerOps *is*, and the only surface carrying the coined term, the rights and the signature together. It had no markdown form. An assistant asking "what is CareerOps" got a React-rendered page with a live signature ledger and a sign-up flow wrapped around the text it actually wanted.

Ships `/manifesto.md` and `/es/manifesto.md`, both with `Accept: text/markdown` negotiation on the canonical URLs.

## The interesting part: the two languages do not have the same source of truth

The core repo ships `MANIFESTO.md` in **English only**. There is no Spanish upstream — which means career-ops.org **is** the canonical Spanish manifesto (deliverable `manifiesto-es-2026-07-21`).

That asymmetry drives the whole design:

| | English | Spanish |
|---|---|---|
| Canonical text | core repo, frozen at `manifesto-v1.0` | **this site** |
| Guard checks it against | upstream `MANIFESTO.md` | its own rendered page |
| If it goes wrong | recoverable from upstream | **nothing to recover from** |

Inventing an upstream for Spanish would be worse than having none, so the guard doesn't pretend there is one.

## Frozen, not fetched

Serving the English twin by fetching `MANIFESTO.md` would make it definitionally current — and would let `/manifesto` and `/manifesto.md` say different things the moment upstream moved.

Two of our own surfaces contradicting each other is exactly the bug that published a wrong version number on `/changelog` for a month. Consistency between our surfaces beats freshness with upstream. So the text is frozen in `src/lib/manifesto-text.ts`, and the guard compares it against upstream on every run: **staleness fails the build instead of lying quietly.**

Verified byte-identical with the core repo's `MANIFESTO.md` (2,996 chars, exact match).

## What the guard now asserts

Beyond status / content-type / `noindex` / Accept negotiation, two invariants that would otherwise fail *silently*:

**Each twin cites its own canonical URL.** A Spanish twin quietly serving English passes every other check while destroying the only copy of the Spanish canon.

**Each twin matches its rendered page paragraph by paragraph** — 18 real paragraphs per language. This *proves* the transcription instead of trusting it, and it earned its keep immediately: it caught a bug in this PR on its first run. The body extractor anchored on `**Signed:**`, which does not exist in the Spanish document, where the label is `**Firmado:**`.

The upstream comparison is deliberately **three-state**: match, mismatch, and could-not-check — the last one *fails* rather than passing quietly. A guard that reports success when it could not run is an instrument that lies when it breaks.

Teeth verified: an altered paragraph is detected in both languages.

## Routing

Literal `manifesto.md` route directories plus `next.config` Accept rules. Not the proxy — its matcher is `/docs`, and it does not run for locale-prefixed paths anyway. That is the third instance of the same Next 16 lesson (after `.md` interception and `/`).

`source` is exact, so `/manifesto/s/:username` and `/manifesto/sign-preview` are untouched.

The twins stay **out of the sitemap**, like `/changelog.md` — they are `noindex` alternates, not pages. Both HTML pages were already in it with hreflang.

## Not in scope

French. There is no French manifesto yet.

---

```
✓ Agent-layer guard passed (AGENTS.md, llms.txt, changelog.md,
  manifesto.md ×2 vs upstream+page, llms-full.txt, robots,
  4 EN docs × .md/Accept/html/clean,
  2 locales × 3 pages × .md/Accept/html/locale)
```