### PR TITLE
feat(funding): publish the FLOSS/fund domain verification file

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -154,6 +154,30 @@ const config = {
         headers: [{ key: 'X-Robots-Tag', value: 'noindex' }],
       },
       {
+        // FLOSS/fund domain verification. The spec requires text/plain, and
+        // this file has NO EXTENSION — neither Vercel nor Next infers a type
+        // for it, so it ships as application/octet-stream by default.
+        //
+        // That failure is silent in the worst way: the URL returns 200, the
+        // body is correct, and a browser renders it perfectly. Only the
+        // fundingjson validator objects, at submit time. Verify with
+        // `curl -sI`, never with a browser. (Trap hit and documented by
+        // cv-santiago on santifer.io, 2026-08-27.)
+        //
+        // `X-Content-Type-Options: nosniff` from securityHeaders makes getting
+        // this right MORE important, not less: nothing downstream will guess.
+        //
+        // Ordering note: cv-santiago's warning to place this before any
+        // catch-all applies to vercel.json, where the first match wins. Next's
+        // headers() applies every matching rule, and securityHeaders sets no
+        // Content-Type, so there is nothing to collide with here. Do not
+        // "fix" the position.
+        source: '/.well-known/funding-manifest-urls',
+        headers: [
+          { key: 'Content-Type', value: 'text/plain; charset=utf-8' },
+        ],
+      },
+      {
         // Email-signature assets. The URL travels inside every message sent
         // from the domain, so it is fetched by mail clients on machines we do
         // not control and must stay stable for years, not months.

--- a/public/.well-known/funding-manifest-urls
+++ b/public/.well-known/funding-manifest-urls
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/santifer/career-ops/main/funding.json


### PR DESCRIPTION
Assignment from **venture-ops**: publish `https://career-ops.org/.well-known/funding-manifest-urls` so FLOSS/fund can verify we control the domain the funding manifest claims.

```
https://raw.githubusercontent.com/santifer/career-ops/main/funding.json
```

72 bytes. One line, trailing newline, no BOM.

## The whole point of this PR is one header

The file has **no extension**. Neither Vercel nor Next infers a type for it, so by default it ships as `application/octet-stream` — and the spec requires `text/plain`.

That failure hides unusually well:

| | |
|---|---|
| Status | `200` ✅ |
| Body | correct ✅ |
| Browser | renders perfectly ✅ |
| fundingjson validator | **rejects** ❌ — at submit time |

cv-santiago hit exactly this on santifer.io today and passed on the recipe. **Verify with `curl -sI`, never a browser** — a browser paints the text either way and shows you nothing about the MIME type.

`securityHeaders` already sends `X-Content-Type-Options: nosniff`, which makes the explicit type *necessary* rather than merely correct: nothing downstream is going to guess.

### Ordering: their warning does not apply here, on purpose

cv-santiago warned to place the specific entry **before any catch-all**, because in `vercel.json` the first match wins. In Next's `headers()` every matching rule applies, and `securityHeaders` sets no `Content-Type`, so there is nothing to collide with. Noted in the code so nobody "fixes" the position later.

## The URL inside 404s right now, deliberately

`funding.json` is written and validated but lives on an unpushed branch; it reaches the core repo through a PR the maintainer merges. That is fine and it was the instruction — the verification file must be live **before** the submit, and nothing resolves these URLs until the form is actually submitted.

Confirmed independently: the core repo tree is 1,448 files (`truncated: false`) and the only "funding" match is `.github/FUNDING.yml`, which is the GitHub Sponsors button config, a different format for a different purpose.

## Verified locally against a production build

```
$ curl -sI localhost:3999/.well-known/funding-manifest-urls
HTTP/1.1 200 OK
X-Content-Type-Options: nosniff
Content-Type: text/plain; charset=utf-8

$ curl -s ... | python3 -c "import sys; print(repr(sys.stdin.buffer.read()))"
b'https://raw.githubusercontent.com/santifer/career-ops/main/funding.json\n'
```