### PR TITLE
fix(funding): list the manifest under github.com too, not only the raw host

### DIFF
--- a/public/.well-known/funding-manifest-urls
+++ b/public/.well-known/funding-manifest-urls
@@ -1,1 +1,2 @@
+https://github.com/santifer/career-ops/blob/main/funding.json
 https://raw.githubusercontent.com/santifer/career-ops/main/funding.json


### PR DESCRIPTION
The `dir.floss.fund` validator **rejects `*.githubusercontent.com`** and wants the `github.com` path. Ours listed only the raw URL, so verification fails at submit time — which is the one moment this file exists for.

```
https://github.com/santifer/career-ops/blob/main/funding.json
https://raw.githubusercontent.com/santifer/career-ops/main/funding.json
```

Both forms, one per line, `github.com` first. The spec takes a list, so covering both costs nothing and removes any guess about which one the validator resolves.

`Content-Type: text/plain; charset=utf-8`, no BOM, single trailing newline — unchanged.

Confirmed both targets now return `200`: `funding.json` has landed in the core repo since yesterday, so the URLs resolve rather than 404 as they did when this file was first published.

Blocking a live submit — Santiago is on the form.