### PR TITLE
fix(funding): lead with the github.com /raw/ form, the one that serves JSON

### DIFF
--- a/public/.well-known/funding-manifest-urls
+++ b/public/.well-known/funding-manifest-urls
@@ -1,2 +1,3 @@
+https://github.com/santifer/career-ops/raw/main/funding.json
 https://github.com/santifer/career-ops/blob/main/funding.json
 https://raw.githubusercontent.com/santifer/career-ops/main/funding.json


### PR DESCRIPTION
The validator rejects `*.githubusercontent.com`, so the manifest must be claimed under `github.com`. But `/blob/` is GitHub's **file viewer**, not the file:

```
github.com/.../blob/main/funding.json   →  200  text/html
github.com/.../raw/main/funding.json    →  200  text/plain
raw.githubusercontent.com/...           →  200  text/plain
```

`github.com/.../raw/...` satisfies the host restriction **and** resolves to the JSON, so it leads the list. It is the URL Santiago pastes into the form.

The other two stay. The spec takes a list, and naming every form we control costs nothing while removing the guess about which one a validator follows.

Found by cv-santiago, who hit the same restriction on santifer.io — theirs already carries this form live.

`text/plain; charset=utf-8`, no BOM, one URL per line, trailing newline. Unblocking a live submit.