### PR TITLE
fix(schema): the Organization was claiming the person's X account and a package that does not exist

### DIFF
--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -48,8 +48,18 @@ const ORGANIZATION_SAMEAS = [
   'https://github.com/santifer/career-ops',
   'https://www.wikidata.org/wiki/Q139007988',
   'https://discord.gg/8pRpHETxa4',
-  'https://x.com/santifer',
-  'https://www.npmjs.com/package/career-ops',
+  // The ORG's account, not the person's. x.com/santifer belongs in
+  // PERSON_SAMEAS below and stays there — these are two entities and keeping
+  // them apart is the whole point of the handle existing. Verified against
+  // the source that cannot drift: `gh api orgs/career-ops-hq` reports
+  // twitter_username `careeropshq`. (search-ops entity-graph audit, 2026-09-01.)
+  'https://x.com/careeropshq',
+  // Scoped package. The unscoped `career-ops` name does not exist on npm:
+  // registry.npmjs.org/career-ops returns {"error":"Not found"}, while
+  // @santifer/career-ops is real (1.31.0, 23 versions). A sameAs that
+  // resolves to nothing is not harmless — it is a graph edge into the void.
+  // Check the REGISTRY, never npmjs.com, which 403s bots and looks alive.
+  'https://www.npmjs.com/package/@santifer/career-ops',
 ];
 
 // sameAs URLs — Santiago's verified profiles across the web. Matches the


### PR DESCRIPTION
Two broken edges in `Organization.sameAs`, from search-ops' entity-graph audit. Both verified independently before changing anything.

## The X handle was the person's, not the project's

```
Organization.sameAs → https://x.com/santifer     ← Santiago's account
```

Publishing the founder's handle under `Organization` fuses the two entities in exactly the graph that exists to keep them apart — and it does it while the project is being moved into its own org for that same reason.

Verified against the source that cannot drift:

```
gh api orgs/career-ops-hq  →  twitter_username: careeropshq
gh api users/santifer      →  twitter_username: santifer
```

`Person.sameAs` **keeps** `x.com/santifer`. Two entities, two accounts — that is the point, not an oversight.

## The npm package does not exist

```
registry.npmjs.org/career-ops         →  {"error":"Not found"}
registry.npmjs.org/@santifer/career-ops →  1.31.0, 23 versions   ← the real one
```

A `sameAs` that resolves to nothing is not a harmless extra: it is a graph edge into the void.

Worth recording *how* this hid: `npmjs.com` returns 403 to bots, so the package page looks alive from a browser and dead to anything automated. **Check the registry, never the website.**

## What is deliberately NOT changed

The four GitHub anchors (`WebSite.sameAs`, `Organization.sameAs`, `SoftwareSourceCode.sameAs`, `codeRepository`) still point at `santifer/career-ops`.

```
career-ops-hq/career-ops   web 200  ·  git ls-remote 403
santifer/career-ops        web 301
```

The new repo answers on the web but not on git. Moving a canonical anchor onto an object in an anomalous state is worse than leaving it on one that redirects. search-ops signals when git breathes, and owns the matching Wikidata P1324/P1401 update under the same condition.

## Verified in the rendered JSON-LD

```
Organization.sameAs → …/x.com/careeropshq
                      …/npmjs.com/package/@santifer/career-ops
Person.sameAs       → …/x.com/santifer          (unchanged)
```