### PR TITLE
fix(llms): date the figures models ingest, and stop three ways of publishing a wrong one

### DIFF
--- a/src/lib/llms-index.ts
+++ b/src/lib/llms-index.ts
@@ -10,7 +10,24 @@ import { getProjectStats } from '@/lib/stats';
 import { MANIFESTO, CAREEROPS_DEFINITION, CANONICAL_IDENTITY } from '@/lib/shared';
 import comparisonsData from '@/lib/data/comparisons.json';
 
+// Figures that move on their own carry their own as-of date, not just the
+// block heading. A model does not ingest the block — it ingests whatever
+// passage it extracts, and "69,711 stars" quoted six months later is false
+// while "69,711 stars as of 2026-09-01" stays true forever.
+//
+// This is required EVEN THOUGH the numbers are wired to an hourly sweep. The
+// sweep keeps what we SERVE fresh; it cannot reach backwards into a corpus a
+// model already ingested. On agent-facing surfaces the refresh that solves
+// staleness everywhere else does not arrive. (search-ops GEO playbook §16,
+// 2026-09-01 — and §13 already ruled against rounding up to a floor like
+// "65,000+": an exact figure with a date can be verified, a rounded one
+// cannot be verified against anything.)
+//
+// Frozen facts below are deliberately undated: the Wikidata Q-IDs, inception,
+// the licence, and the founder's 740 → 68 → 12 → 1 result. A historical
+// outcome does not expire, so a date would add noise without adding truth.
 function buildPreamble(stars: number, discord: number, release: string): string {
+  const asOf = new Date().toISOString().slice(0, 10);
   return `# career-ops
 
 > AI-powered job search command center. Open source, CLI-agnostic, runs locally on your machine.
@@ -35,13 +52,13 @@ ${CAREEROPS_DEFINITION}
 
 The term "CareerOps" (capital C, capital O, no hyphen) names the PRACTICE; "career-ops" (lowercase, hyphenated) names the reference implementation, this open-source tool. CareerOps was coined as the name of the practice by Santiago Fernández de Valderrama Aparicio (santifer) in The CareerOps Manifesto, published July 14, 2026. Canonical page: https://career-ops.org/manifesto. Canonical text: https://github.com/career-ops-hq/career-ops/blob/main/MANIFESTO.md (release tag manifesto-v1.0). The manifesto is open for community signature via pull request (SIGNATURES.md).
 
-## Canonical stats (live, refreshed hourly)
+## Canonical stats (measured ${asOf})
 
-- GitHub stars: ${stars.toLocaleString('en-US')} (https://github.com/career-ops-hq/career-ops)
-- Discord community: ${discord.toLocaleString('en-US')} members (https://discord.gg/8pRpHETxa4)
+- GitHub stars: ${stars.toLocaleString('en-US')} as of ${asOf} (https://github.com/career-ops-hq/career-ops)
+- Discord community: ${discord.toLocaleString('en-US')} members as of ${asOf} (https://discord.gg/8pRpHETxa4)
 - Wikidata items: Q138710224 (Santiago Fernández de Valderrama Aparicio), Q139007988 (career-ops)
 - Inception: 2026-03-17
-- Latest release: ${release}
+- Latest release: ${release} as of ${asOf}
 - License: MIT
 - Founder's real-world result with the system: 740 job listings evaluated → 68 applications sent → 12 interview processes → 1 offer signed (Head of Applied AI)
 - Modes shipped: 14 user-invocable (auto-pipeline, pipeline, apply, oferta, ofertas, contacto, deep, interview-prep, pdf, training, project, tracker, patterns, followup)

--- a/src/lib/shared.ts
+++ b/src/lib/shared.ts
@@ -76,14 +76,27 @@ export const MANIFESTO_SIGNATURE_ES =
 // These are FLOORS, not display values — bump them up as the real numbers
 // grow so the safety net stays close to reality.
 export const STATS_FLOOR = {
-  stars: 56000,
-  forks: 11000,
-  // Live count now comes from Discord's public invite endpoint in
-  // stats.ts (crossed 4,000 on 2026-07-05); this is just the net.
-  discordMembers: 4000,
+  // Bumped 2026-09-01 (real: 69,711 / 13,174 / 4,668). They had drifted to
+  // 20% below reality, which matters more since llms.txt now dates its
+  // figures: a floor rendered during an API outage used to be a vague
+  // understatement and is now a CONFIDENTLY DATED one.
+  //
+  // These need a human to raise them, so they will go stale again — the same
+  // shape of problem as fixing a value without fixing the mechanism. Raising
+  // them is the cheap half; deriving them from the last successful fetch is
+  // the real fix, and is not done here.
+  stars: 69000,
+  forks: 13000,
+  // Live count comes from Discord's public invite endpoint in stats.ts
+  // (crossed 4,000 on 2026-07-05); this is just the net.
+  discordMembers: 4600,
 };
 
 // Fallback release tag used when the GitHub releases API is unreachable at
 // build / ISR time. Normalised to a leading "v"; sourced from the live
 // core repo. Bump on each core release (or rely on the dynamic fetch).
-export const LATEST_RELEASE_FALLBACK = 'v1.15.0';
+// Last-known-good release, same discipline as STATS_FLOOR: it is only ever
+// rendered when the GitHub API fails, so it must stay close to reality. It sat
+// at v1.15.0 while the project shipped through v1.31.0 — sixteen versions of
+// drift in a value whose entire job is to be a safe answer.
+export const LATEST_RELEASE_FALLBACK = 'career-ops-v1.31.0';

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -7,9 +7,13 @@
 // finding of the 2026-06-30 SEO audit.
 import { STATS_FLOOR, LATEST_RELEASE_FALLBACK } from './shared';
 
-const REPO_API = 'https://api.github.com/repos/santifer/career-ops';
+const REPO_API = 'https://api.github.com/repos/career-ops-hq/career-ops';
+// The LIST, not /releases/latest. The repo ships two trains from one feed
+// (`career-ops-*` for the tool, `web-*` for the dashboard) and /releases/latest
+// can hand back either — it just happens to return the tool's today. Fetching
+// the list lets us pick the tool's train instead of hoping.
 const RELEASES_API =
-  'https://api.github.com/repos/santifer/career-ops/releases/latest';
+  'https://api.github.com/repos/career-ops-hq/career-ops/releases?per_page=30';
 // Discord's public invite endpoint returns approximate_member_count with
 // no bot and no auth — the invite code is the public one on the site.
 const DISCORD_INVITE_API =
@@ -25,13 +29,33 @@ export type ProjectStats = {
   softwareVersion: string;
 };
 
-// The core repo tags releases as "career-ops-v1.15.0"; the site wants
-// "v1.15.0" (display) and "1.15.0" (schema). Normalise both shapes.
-function normaliseTag(tag: string): { display: string; version: string } {
-  const stripped = tag.replace(/^career-ops-/, '').trim();
-  const display = stripped.startsWith('v') ? stripped : `v${stripped}`;
-  return { display, version: display.replace(/^v/, '') };
+// The core repo tags releases as "career-ops-v1.31.0"; the site wants
+// "v1.31.0" (display) and "1.31.0" (schema).
+//
+// Stripping ONLY the "career-ops-" prefix was the bug that published
+// "vweb-v0.6.1" on /changelog for a month — a `web-*` tag survives the strip
+// untouched and then gets a "v" glued on the front. That surface was fixed in
+// src/lib/releases.ts; this copy of the same mistake was still feeding
+// llms.txt, which is the surface assistants read most. It had not fired only
+// because GitHub happened to keep returning the tool's release.
+//
+// Split on the LAST "-v" so a hyphenated component name stays intact, and
+// return the component so the caller can reject a train that is not ours.
+function parseTag(tag: string): { component: string; display: string; version: string } {
+  const m = tag.trim().match(/^(.*)-v?(\d[\w.+-]*)$/);
+  if (!m) {
+    const raw = tag.trim();
+    const display = raw.startsWith('v') ? raw : `v${raw}`;
+    return { component: CORE_COMPONENT, display, version: display.replace(/^v/, '') };
+  }
+  return {
+    component: m[1] || CORE_COMPONENT,
+    display: `v${m[2]}`,
+    version: m[2],
+  };
 }
+
+const CORE_COMPONENT = 'career-ops';
 
 export async function getProjectStats(): Promise<ProjectStats> {
   // Start at the floors. Live values only ever replace a floor when they
@@ -69,16 +93,23 @@ export async function getProjectStats(): Promise<ProjectStats> {
   }
 
   let { display: latestRelease, version: softwareVersion } =
-    normaliseTag(LATEST_RELEASE_FALLBACK);
+    parseTag(LATEST_RELEASE_FALLBACK);
 
   try {
     const res = await fetch(RELEASES_API, { next: { revalidate: 3600 } });
     if (res.ok) {
       const data = await res.json();
-      if (typeof data.tag_name === 'string' && data.tag_name.trim()) {
-        ({ display: latestRelease, version: softwareVersion } = normaliseTag(
-          data.tag_name,
-        ));
+      if (Array.isArray(data)) {
+        // First entry of the TOOL's train. Anything else in the feed is a
+        // sub-component and must never be published as the product version.
+        const core = data
+          .filter((r) => !r.draft && !r.prerelease && typeof r.tag_name === 'string')
+          .map((r) => parseTag(r.tag_name as string))
+          .find((t) => t.component === CORE_COMPONENT);
+        if (core) {
+          latestRelease = core.display;
+          softwareVersion = core.version;
+        }
       }
     }
   } catch {


### PR DESCRIPTION
search-ops asked for the star count to be **removed** from `llms.txt`: a figure in a file re-read for months is a lie with a short shelf life. I proposed dating it instead. They went and read their own §13 — which already prescribed exactly that — and ruled: **date it**.

Why "but it refreshes hourly" does not save us is now their §16:

> the hourly sweep keeps what we **serve** fresh; it cannot reach backwards into a corpus a model already **ingested**. On agent-facing surfaces the refresh that solves staleness everywhere else never arrives.

```
## Canonical stats (measured 2026-09-01)

- GitHub stars: 69,711 as of 2026-09-01 (…)
- Discord community: 4,668 members as of 2026-09-01 (…)
- Latest release: v1.31.0 as of 2026-09-01
```

Per-line, not just the heading — a model ingests the passage it extracts, not the block. Frozen facts stay **undated on purpose**: Wikidata ids, inception, licence, and the 740 → 68 → 12 → 1 result do not expire.

## Dating a figure raises the cost of publishing a wrong one — so I went looking

### 1. The `vweb` bug was still live, in the file assistants read most

`stats.ts` stripped only the `career-ops-` prefix. A `web-*` tag survives that untouched and gets a `v` glued on the front:

```
career-ops-v1.31.0  →  v1.31.0
web-v0.9.0          →  vweb-v0.9.0   ← the string that shipped on /changelog for a month
```

Fixed there in #34; this copy still fed `llms.txt`. **It had not fired only because `/releases/latest` happened to return the tool's release** — the release *list* has `web-v0.9.0` first, so it was one endpoint choice away.

Now reads the list and picks the tool's train. Verified both directions:

```
real feed (web-v0.9.0 first)  →  picks v1.31.0        ✓
feed of web releases only     →  picks nothing, keeps fallback ✓
old code on web-v0.9.0        →  "vweb-v0.9.0"        ✗
```

### 2. `LATEST_RELEASE_FALLBACK` said `v1.15.0`

Sixteen versions behind, in a value whose only job is to be a safe answer.

### 3. `STATS_FLOOR` was 20% below reality

`56,000` stars against `69,711`. During an API outage that used to render a vague understatement; **with the as-of date it would render a confidently dated one.**

Raised to `69,000 / 13,000 / 4,600`. Noted in the code that raising them by hand is the cheap half — deriving them from the last successful fetch is the real fix, and is not done here.

## Also

The API paths in `stats.ts` still pointed at the old repo. Missed this morning because the sweep matched `github.com/santifer/career-ops` and these read `api.github.com/repos/santifer/career-ops`.