### PR TITLE
fix(llms): only date a figure that came from a live fetch, and drop the ones that cannot

### DIFF
--- a/src/lib/llms-index.ts
+++ b/src/lib/llms-index.ts
@@ -6,7 +6,7 @@
 // (search-ops verdict, 2026-08-10 — Cloudflare agent-ready scan follow-up.)
 import { source, normalizeAgentMarkdown, getLLMText } from '@/lib/source';
 import { llms } from 'fumadocs-core/source';
-import { getProjectStats } from '@/lib/stats';
+import { getProjectStats, type ProjectStats } from '@/lib/stats';
 import { MANIFESTO, CAREEROPS_DEFINITION, CANONICAL_IDENTITY } from '@/lib/shared';
 import comparisonsData from '@/lib/data/comparisons.json';
 
@@ -26,8 +26,21 @@ import comparisonsData from '@/lib/data/comparisons.json';
 // Frozen facts below are deliberately undated: the Wikidata Q-IDs, inception,
 // the licence, and the founder's 740 → 68 → 12 → 1 result. A historical
 // outcome does not expire, so a date would add noise without adding truth.
-function buildPreamble(stars: number, discord: number, release: string): string {
+function buildPreamble(
+  stars: number,
+  discord: number,
+  release: string,
+  live: ProjectStats['live'],
+): string {
   const asOf = new Date().toISOString().slice(0, 10);
+  // A figure is published here ONLY if it came from a live fetch. When the API
+  // is down we hold a last-known-good floor, and that floor does not know when
+  // it is from — so it cannot carry an as-of date, and an undated or
+  // falsely-dated figure has no place on a surface written to be ingested.
+  // Omitting the line degrades to silence; keeping it would degrade to a
+  // confident lie. (search-ops §16.b.) The floors still feed the schema
+  // counters and the home chips, where the alternative is rendering zero.
+  const stat = (ok: boolean, line: string) => (ok ? `\n${line}` : '');
   return `# career-ops
 
 > AI-powered job search command center. Open source, CLI-agnostic, runs locally on your machine.
@@ -53,12 +66,9 @@ ${CAREEROPS_DEFINITION}
 The term "CareerOps" (capital C, capital O, no hyphen) names the PRACTICE; "career-ops" (lowercase, hyphenated) names the reference implementation, this open-source tool. CareerOps was coined as the name of the practice by Santiago Fernández de Valderrama Aparicio (santifer) in The CareerOps Manifesto, published July 14, 2026. Canonical page: https://career-ops.org/manifesto. Canonical text: https://github.com/career-ops-hq/career-ops/blob/main/MANIFESTO.md (release tag manifesto-v1.0). The manifesto is open for community signature via pull request (SIGNATURES.md).
 
 ## Canonical stats (measured ${asOf})
-
-- GitHub stars: ${stars.toLocaleString('en-US')} as of ${asOf} (https://github.com/career-ops-hq/career-ops)
-- Discord community: ${discord.toLocaleString('en-US')} members as of ${asOf} (https://discord.gg/8pRpHETxa4)
+${stat(live.stars, `- GitHub stars: ${stars.toLocaleString('en-US')} as of ${asOf} (https://github.com/career-ops-hq/career-ops)`)}${stat(live.discordMembers, `- Discord community: ${discord.toLocaleString('en-US')} members as of ${asOf} (https://discord.gg/8pRpHETxa4)`)}
 - Wikidata items: Q138710224 (Santiago Fernández de Valderrama Aparicio), Q139007988 (career-ops)
-- Inception: 2026-03-17
-- Latest release: ${release} as of ${asOf}
+- Inception: 2026-03-17${stat(live.latestRelease, `- Latest release: ${release} as of ${asOf}`)}
 - License: MIT
 - Founder's real-world result with the system: 740 job listings evaluated → 68 applications sent → 12 interview processes → 1 offer signed (Head of Applied AI)
 - Modes shipped: 14 user-invocable (auto-pipeline, pipeline, apply, oferta, ofertas, contacto, deep, interview-prep, pdf, training, project, tracker, patterns, followup)
@@ -169,7 +179,7 @@ ${withTokens}`;
 export async function buildLlmsTxt(): Promise<string> {
   const stats = await getProjectStats();
   return (
-    buildPreamble(stats.stars, stats.discordMembers, stats.latestRelease) +
+    buildPreamble(stats.stars, stats.discordMembers, stats.latestRelease, stats.live) +
     (await agentDocsIndex())
   );
 }

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -27,6 +27,28 @@ export type ProjectStats = {
   latestRelease: string;
   /** Same release without the "v" prefix, for schema softwareVersion. */
   softwareVersion: string;
+  /**
+   * Which figures came from a LIVE fetch rather than the last-known-good
+   * floor. Agent-facing surfaces must consult this before dating anything.
+   *
+   * An as-of date belongs to the fetch that produced the number, never to the
+   * build. Stamping a months-old floor with today's date lends it exactly the
+   * authority the date exists to confer — "56,000 stars as of 2026-09-01" is
+   * worse than the bare "56,000", because it is confidently, verifiably wrong
+   * instead of merely vague. A backup value that does not know when it is
+   * from cannot carry a date; and on a surface written to be ingested by a
+   * model, a figure that cannot carry a date should not be published at all.
+   * (search-ops GEO playbook §16.b, 2026-09-01.)
+   *
+   * The floors still serve the schema counters and the home chips, where the
+   * alternative is rendering zero. This flag is about llms.txt and its kin.
+   */
+  live: {
+    stars: boolean;
+    forks: boolean;
+    discordMembers: boolean;
+    latestRelease: boolean;
+  };
 };
 
 // The core repo tags releases as "career-ops-v1.31.0"; the site wants
@@ -63,21 +85,28 @@ export async function getProjectStats(): Promise<ProjectStats> {
   // to zero.
   let stars = STATS_FLOOR.stars;
   let forks = STATS_FLOOR.forks;
+  let starsLive = false;
+  let forksLive = false;
 
   try {
     const res = await fetch(REPO_API, { next: { revalidate: 3600 } });
     if (res.ok) {
       const data = await res.json();
-      if (typeof data.stargazers_count === 'number' && data.stargazers_count > stars)
+      if (typeof data.stargazers_count === 'number' && data.stargazers_count > stars) {
         stars = data.stargazers_count;
-      if (typeof data.forks_count === 'number' && data.forks_count > forks)
+        starsLive = true;
+      }
+      if (typeof data.forks_count === 'number' && data.forks_count > forks) {
         forks = data.forks_count;
+        forksLive = true;
+      }
     }
   } catch {
     // keep floors — fail silent so the page still renders real-ish numbers
   }
 
   let discordMembers = STATS_FLOOR.discordMembers;
+  let discordLive = false;
   try {
     const res = await fetch(DISCORD_INVITE_API, { next: { revalidate: 3600 } });
     if (res.ok) {
@@ -85,8 +114,10 @@ export async function getProjectStats(): Promise<ProjectStats> {
       if (
         typeof data.approximate_member_count === 'number' &&
         data.approximate_member_count > discordMembers
-      )
+      ) {
         discordMembers = data.approximate_member_count;
+        discordLive = true;
+      }
     }
   } catch {
     // keep the floor
@@ -94,6 +125,7 @@ export async function getProjectStats(): Promise<ProjectStats> {
 
   let { display: latestRelease, version: softwareVersion } =
     parseTag(LATEST_RELEASE_FALLBACK);
+  let releaseLive = false;
 
   try {
     const res = await fetch(RELEASES_API, { next: { revalidate: 3600 } });
@@ -109,6 +141,7 @@ export async function getProjectStats(): Promise<ProjectStats> {
         if (core) {
           latestRelease = core.display;
           softwareVersion = core.version;
+          releaseLive = true;
         }
       }
     }
@@ -122,5 +155,11 @@ export async function getProjectStats(): Promise<ProjectStats> {
     discordMembers,
     latestRelease,
     softwareVersion,
+    live: {
+      stars: starsLive,
+      forks: forksLive,
+      discordMembers: discordLive,
+      latestRelease: releaseLive,
+    },
   };
 }


### PR DESCRIPTION
Yesterday's change dated the figures in `llms.txt` (#50). search-ops then found that **the rule as written makes the failure case worse** — and they are right.

When the GitHub API is down we serve a last-known-good floor. Stamping a months-old floor with today's date lends it exactly the authority the date exists to confer:

| | |
|---|---|
| `56,000 as of 2026-09-01` | ❌ confidently, verifiably wrong |
| `56,000` | ❌ vague, but not deceiving |
| `69,712 as of 2026-09-01` | ✅ figure and date from the same fetch |

Their **§16.b**: the as-of date belongs to the **fetch that produced the number**, never to the build. A backup value does not know when it is from, so it cannot carry a date — and on a surface written to be ingested, a figure that cannot carry a date should not be published at all.

## What changed

`getProjectStats()` now reports which figures came from a live fetch. `llms.txt` omits the ones that did not. **Degrading to silence beats degrading to a confident lie.**

The floors stay everywhere else. They exist so the schema counters and the home chips never render zero during an outage — the highest-severity finding of the 2026-06-30 audit. This flag is about agent-facing surfaces only.

## Verified on the degraded path, which is the one that matters

This machine happens to be in it: the GitHub API answers `403` unauthenticated here, so the floors fire naturally.

```
## Canonical stats (measured 2026-09-01)

- Discord community: 4,668 members as of 2026-09-01 (…)
- Wikidata items: Q138710224 …
- Inception: 2026-03-17
- License: MIT
```

Stars and latest release **drop out** rather than appear with a borrowed date. Discord survives on its own working endpoint. Meanwhile the schema still carries `"userInteractionCount":69000`, exactly as intended.

The healthy path is verified in production, where the token is.