### PR TITLE
feat(schema): stamp the software node with the date its counters were fetched

### DIFF
--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -239,6 +239,25 @@ const PERSON_SUBJECT_OF = [
 
 export async function siteSchema() {
   const stats = await getProjectStats();
+  // The live counters below (stars, forks, Discord) are the most literally
+  // parsed figures we publish: JSON-LD is the most structured surface we have,
+  // so an engine trusts it more and freezes it harder than prose. A bare
+  // number there is the same problem llms.txt had, in the place it weighs most.
+  //
+  // dateModified stamps the node, which is where schema.org puts freshness —
+  // InteractionCounter takes no date of its own. It doubles as an E-E-A-T
+  // freshness signal we were not emitting on this node at all.
+  //
+  // Emitted ONLY when the figures came from a live fetch. If the API is down
+  // we serve last-known-good floors, and a floor wearing today's date is worse
+  // than a floor wearing none: it borrows the authority the date exists to
+  // give. Same rule as llms.txt — the date belongs to the fetch that produced
+  // the number, never to the build. (search-ops GEO playbook §16.b.)
+  const countersLive =
+    stats.live.stars && stats.live.forks && stats.live.discordMembers;
+  const softwareDateModified = countersLive
+    ? { dateModified: new Date().toISOString().slice(0, 10) }
+    : {};
   return {
     '@context': 'https://schema.org',
     '@graph': [


### PR DESCRIPTION
The last unfixed instance of the figure-without-a-date problem — in the place it weighs most.

`SoftwareSourceCode` carries live counters (69,713 stars, 13,183 forks, 4,670 Discord) and had **no `dateModified` at all**. JSON-LD is the most structured surface we publish, so an engine trusts it more and freezes it harder than prose. A bare number there is exactly what we just regulated out of `llms.txt`, sitting where it costs most.

`dateModified` stamps the node, which is where schema.org puts freshness — `InteractionCounter` takes no date of its own.

It also **buys something we did not have**: an E-E-A-T freshness signal this node was not emitting at all. The fix is not merely the absence of a problem.

## Emitted only when the counters are live

During an API outage we serve last-known-good floors, and a floor wearing today's date is worse than a floor wearing none: it borrows the exact authority the date exists to confer. Same rule as `llms.txt` — the date belongs to the fetch that produced the number, never to the build.

Verified on the degraded path, which this machine happens to be in (`403` unauthenticated):

```
dateModified: AUSENTE     ← correct, these are floors
GitHub stars: 69000       ← the floor still renders, as it must
```

The floor still appears, because the alternative in schema is a zero or a missing node. It just does not get dated.

Found by search-ops — who also flagged their own near-miss while reporting it: their first grep cut at the blank line after the heading and returned an empty block, one step from filing a production regression that did not exist.