### PR TITLE
fix(schema): actually emit dateModified, and turn on the check that would have caught it

### DIFF
--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -318,6 +318,7 @@ export async function siteSchema() {
       {
         '@type': 'SoftwareSourceCode',
         '@id': 'https://career-ops.org/#software',
+        ...softwareDateModified,
         name: 'career-ops',
         alternateName: ALTERNATE_NAMES,
         url: 'https://career-ops.org',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,17 @@
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
+    // Enabled 2026-09-01 after an unused const shipped to production. A
+    // conditional `dateModified` was computed and then never spread into the
+    // node, because the string replacement that was meant to insert it did not
+    // match and failed silently. Everything downstream passed: typecheck,
+    // build, CI, and the guard. The only symptom was a field missing from a
+    // JSON-LD node that nobody diffs, and it took an outside agent probing
+    // production to notice.
+    //
+    // The codebase had ZERO unused locals when this was turned on, so it costs
+    // nothing today and closes that path for good.
+    "noUnusedLocals": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,


### PR DESCRIPTION
#52 computed a conditional `dateModified` and **never used it**. The replacement meant to spread it into the `SoftwareSourceCode` node did not match — my replacement string carried two extra spaces of indentation, copied from output I had myself reformatted for display — and it **failed silently**, because that one replacement had no assertion while the other did.

Everything downstream passed: typecheck, build, CI, the agent-layer guard. The only symptom was a field missing from a JSON-LD node nobody diffs.

## How it surfaced, and how I nearly buried it

search-ops probed production, saw no `dateModified`, and **refused to accept the comfortable explanation** — from outside, "deployed but cached" and "not deployed" look identical, so they handed that question back to me.

I nearly answered it wrong. My first check compared the cache entry against the deploy time and printed "consistent" — using Vercel timestamps read as UTC when they are **local**. Redone correctly:

```
deploy #52 (UTC)        : 15:45:24
cached entry created    : 15:46:15   ← 51s AFTER the deploy
```

That killed the cache theory and pointed straight at the code. A broken comparison had confirmed exactly what I already believed.

## The mechanism, not just the instance

`noUnusedLocals` is now on. It flags this exact shape:

```
TS6133: 'softwareDateModified' is declared but its value is never read.
```

Verified by reintroducing the bug and watching typecheck fail on it by name.

The codebase had **zero** unused locals, so enabling it cost nothing and closes the path instead of patching the one occurrence.