### PR TITLE
fix(home): the hero scrim was hiding the backdrop it promised to spare

### DIFF
--- a/src/app/(home)/home-content.tsx
+++ b/src/app/(home)/home-content.tsx
@@ -97,10 +97,20 @@ export async function HomeContent({ dict }: { dict: HomeDict }) {
             against the muted h1: both under WCAG AA's 4.5:1. The veil is tuned
             per theme (dark text is translucent and needs a stronger plateau) and
             fades out before the right half so the shaders keep their punch where
-            nothing needs reading. */}
+            nothing needs reading.
+
+            The mobile fallback is a FLAT GRADIENT, not a background-color, and
+            that is not cosmetic. background-color and background-image are
+            different properties: they do not override each other, they stack.
+            A colour fallback plus a gradient at md meant the gradient's own
+            "transparent" end still had the flat 97% veil painted underneath, so
+            the backdrop stayed hidden exactly where this comment promises it
+            shows. Measured before the fix: 14% of the artwork's peak luminance
+            survived on the right half; after, 91%. Keep both breakpoints on
+            background-image and the collision cannot come back. */}
         <div
           aria-hidden="true"
-          className="pointer-events-none absolute inset-0 z-1 bg-[color-mix(in_srgb,var(--color-fd-background)_90%,transparent)] md:bg-[linear-gradient(90deg,color-mix(in_srgb,var(--color-fd-background)_90%,transparent)_0%,color-mix(in_srgb,var(--color-fd-background)_90%,transparent)_46%,color-mix(in_srgb,var(--color-fd-background)_80%,transparent)_56%,color-mix(in_srgb,var(--color-fd-background)_45%,transparent)_66%,transparent_78%)] dark:bg-[color-mix(in_srgb,var(--color-fd-background)_97%,transparent)] dark:md:bg-[linear-gradient(90deg,color-mix(in_srgb,var(--color-fd-background)_97%,transparent)_0%,color-mix(in_srgb,var(--color-fd-background)_97%,transparent)_46%,color-mix(in_srgb,var(--color-fd-background)_92%,transparent)_56%,color-mix(in_srgb,var(--color-fd-background)_60%,transparent)_66%,transparent_78%)]"
+          className="pointer-events-none absolute inset-0 z-1 bg-[linear-gradient(color-mix(in_srgb,var(--color-fd-background)_90%,transparent),color-mix(in_srgb,var(--color-fd-background)_90%,transparent))] md:bg-[linear-gradient(90deg,color-mix(in_srgb,var(--color-fd-background)_90%,transparent)_0%,color-mix(in_srgb,var(--color-fd-background)_90%,transparent)_46%,color-mix(in_srgb,var(--color-fd-background)_80%,transparent)_56%,color-mix(in_srgb,var(--color-fd-background)_45%,transparent)_66%,transparent_78%)] dark:bg-[linear-gradient(color-mix(in_srgb,var(--color-fd-background)_97%,transparent),color-mix(in_srgb,var(--color-fd-background)_97%,transparent))] dark:md:bg-[linear-gradient(90deg,color-mix(in_srgb,var(--color-fd-background)_97%,transparent)_0%,color-mix(in_srgb,var(--color-fd-background)_97%,transparent)_46%,color-mix(in_srgb,var(--color-fd-background)_92%,transparent)_56%,color-mix(in_srgb,var(--color-fd-background)_60%,transparent)_66%,transparent_78%)]"
         />
         <div className="flex flex-col z-2 px-4 size-full md:p-12 max-md:items-center max-md:text-center">
           <p


### PR DESCRIPTION
Follow-up to #37, which is good work with one bug that defeated its own stated design.

The scrim's gradient fades out before the right half **"so the shaders keep their punch where nothing needs reading"**. It did not do that — the artwork stayed hidden across the whole hero.

## Not a tuning problem: a property collision

`background-color` and `background-image` are **different properties**. They stack; they do not override.

```
bg-[color-mix(…)]              → background-color: 97% veil     (all breakpoints)
md:bg-[linear-gradient(…)]     → background-image: the gradient (md and up)
```

So the gradient's own `transparent 78%` end still had the flat 97% veil painted underneath it. No adjustment of the gradient stops could ever reveal anything.

Both breakpoints now use `background-image`, with the mobile fallback written as a flat two-stop gradient. One property, nothing to collide with.

## Measured

Peak luminance, right half of the hero, dark mode, same frame:

| | peak | |
|---|---|---|
| `main` before #37 | 155.0 | |
| #37 as merged | 22.0 | **14%** — the backdrop is gone |
| with this fix | 140.9 | **91%** |

The copy stays veiled where it needs to be. This only restores the half the scrim was already meant to release.

## What is NOT verified here

The contrast figures in #37 come from the author's per-frame sampler. **A single screenshot cannot confirm or refute them** — the grain sweep animates and the worst frame is the one that matters. Those numbers are taken on their evidence, not re-derived by me.

---

Found while reviewing #37, which sat 11 days because the originating report (`career-ops#3189`) was labelled `area:web` and routed to the wrong agent's queue. The delay was ours, not the contributor's.