### PR TITLE
revert(home): restore the hero to yesterday's state

### DIFF
--- a/src/app/(home)/home-content.tsx
+++ b/src/app/(home)/home-content.tsx
@@ -97,20 +97,10 @@ export async function HomeContent({ dict }: { dict: HomeDict }) {
             against the muted h1: both under WCAG AA's 4.5:1. The veil is tuned
             per theme (dark text is translucent and needs a stronger plateau) and
             fades out before the right half so the shaders keep their punch where
-            nothing needs reading.
-
-            The mobile fallback is a FLAT GRADIENT, not a background-color, and
-            that is not cosmetic. background-color and background-image are
-            different properties: they do not override each other, they stack.
-            A colour fallback plus a gradient at md meant the gradient's own
-            "transparent" end still had the flat 97% veil painted underneath, so
-            the backdrop stayed hidden exactly where this comment promises it
-            shows. Measured before the fix: 14% of the artwork's peak luminance
-            survived on the right half; after, 91%. Keep both breakpoints on
-            background-image and the collision cannot come back. */}
+            nothing needs reading. */}
         <div
           aria-hidden="true"
-          className="pointer-events-none absolute inset-0 z-1 bg-[linear-gradient(color-mix(in_srgb,var(--color-fd-background)_90%,transparent),color-mix(in_srgb,var(--color-fd-background)_90%,transparent))] md:bg-[linear-gradient(90deg,color-mix(in_srgb,var(--color-fd-background)_90%,transparent)_0%,color-mix(in_srgb,var(--color-fd-background)_90%,transparent)_46%,color-mix(in_srgb,var(--color-fd-background)_80%,transparent)_56%,color-mix(in_srgb,var(--color-fd-background)_45%,transparent)_66%,transparent_78%)] dark:bg-[linear-gradient(color-mix(in_srgb,var(--color-fd-background)_97%,transparent),color-mix(in_srgb,var(--color-fd-background)_97%,transparent))] dark:md:bg-[linear-gradient(90deg,color-mix(in_srgb,var(--color-fd-background)_97%,transparent)_0%,color-mix(in_srgb,var(--color-fd-background)_97%,transparent)_46%,color-mix(in_srgb,var(--color-fd-background)_92%,transparent)_56%,color-mix(in_srgb,var(--color-fd-background)_60%,transparent)_66%,transparent_78%)]"
+          className="pointer-events-none absolute inset-0 z-1 bg-[color-mix(in_srgb,var(--color-fd-background)_90%,transparent)] md:bg-[linear-gradient(90deg,color-mix(in_srgb,var(--color-fd-background)_90%,transparent)_0%,color-mix(in_srgb,var(--color-fd-background)_90%,transparent)_46%,color-mix(in_srgb,var(--color-fd-background)_80%,transparent)_56%,color-mix(in_srgb,var(--color-fd-background)_45%,transparent)_66%,transparent_78%)] dark:bg-[color-mix(in_srgb,var(--color-fd-background)_97%,transparent)] dark:md:bg-[linear-gradient(90deg,color-mix(in_srgb,var(--color-fd-background)_97%,transparent)_0%,color-mix(in_srgb,var(--color-fd-background)_97%,transparent)_46%,color-mix(in_srgb,var(--color-fd-background)_92%,transparent)_56%,color-mix(in_srgb,var(--color-fd-background)_60%,transparent)_66%,transparent_78%)]"
         />
         <div className="flex flex-col z-2 px-4 size-full md:p-12 max-md:items-center max-md:text-center">
           <p

--- a/src/app/(home)/home-content.tsx
+++ b/src/app/(home)/home-content.tsx
@@ -89,27 +89,14 @@ export async function HomeContent({ dict }: { dict: HomeDict }) {
           className="absolute top-[58%] left-[25%] max-w-[1400px] rounded-xl block [animation:fade-in-delayed_700ms_ease_400ms_both] [mask-image:linear-gradient(to_right,transparent_0%,black_8%)]"
           priority
         />
-        {/* Readability scrim between the animated backdrop and the copy column.
-            The corner grain-gradient sweeps saturated green (dark) / yellow-orange
-            (light) behind the text, and the terminal screenshot's dark chrome
-            reaches into it from the right; measured worst case without this layer
-            was 1.2:1 (dark, green sweep) and 3.0:1 (light, screenshot overlap)
-            against the muted h1: both under WCAG AA's 4.5:1. The veil is tuned
-            per theme (dark text is translucent and needs a stronger plateau) and
-            fades out before the right half so the shaders keep their punch where
-            nothing needs reading. */}
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute inset-0 z-1 bg-[color-mix(in_srgb,var(--color-fd-background)_90%,transparent)] md:bg-[linear-gradient(90deg,color-mix(in_srgb,var(--color-fd-background)_90%,transparent)_0%,color-mix(in_srgb,var(--color-fd-background)_90%,transparent)_46%,color-mix(in_srgb,var(--color-fd-background)_80%,transparent)_56%,color-mix(in_srgb,var(--color-fd-background)_45%,transparent)_66%,transparent_78%)] dark:bg-[color-mix(in_srgb,var(--color-fd-background)_97%,transparent)] dark:md:bg-[linear-gradient(90deg,color-mix(in_srgb,var(--color-fd-background)_97%,transparent)_0%,color-mix(in_srgb,var(--color-fd-background)_97%,transparent)_46%,color-mix(in_srgb,var(--color-fd-background)_92%,transparent)_56%,color-mix(in_srgb,var(--color-fd-background)_60%,transparent)_66%,transparent_78%)]"
-        />
         <div className="flex flex-col z-2 px-4 size-full md:p-12 max-md:items-center max-md:text-center">
           <p
             aria-hidden="true"
-            className={`${instrumentSerifRegular.className} text-5xl mt-12 mb-6 leading-[1.05] xl:text-7xl xl:mb-8 [text-shadow:0_0_30px_var(--color-fd-background)]`}
+            className={`${instrumentSerifRegular.className} text-5xl mt-12 mb-6 leading-[1.05] xl:text-7xl xl:mb-8`}
           >
             {dict.heroHook}
           </p>
-          <h1 className="mb-8 max-w-xl text-base font-normal text-fd-muted-foreground md:text-lg [text-shadow:0_1px_14px_var(--color-fd-background),0_0_36px_var(--color-fd-background)]">
+          <h1 className="mb-8 max-w-xl text-base font-normal text-fd-muted-foreground md:text-lg">
             {dict.heroH1}
           </h1>
           <div className="flex flex-row items-center gap-4 flex-wrap w-fit">


### PR DESCRIPTION
Reverts #37 and #54. Nobody authorised touching the hero. The scrim washed out the terminal window and the backdrop, and the owner of the site rejected it on sight.

The only difference from yesterday's hero after this revert is the filename rename from #39 (`buffalo-dither.png` → `longhorn-dither.png`), which is the same image bytes and not visual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BcPLgMFMs2B4SJv3vfq8jv