### PR TITLE
fix(canon): name the scoring scale "1-5", keep the decimal thresholds

### DIFF
--- a/content/blog/the-complete-ai-job-search-guide.mdx
+++ b/content/blog/the-complete-ai-job-search-guide.mdx
@@ -35,7 +35,7 @@ This is where the wheat-from-chaff happens. Every listing gets scored against an
 
 A useful rubric covers at minimum five dimensions, plus one overall score: match (does your background actually fit the role), north-star alignment (does the role move you toward your stated career direction), comp (is the comp band realistic and in your acceptable range), cultural signals (culture, growth stage, stability, remote policy), and red flags (legal, ethical, or operational blockers). The global score is not a sixth dimension — it is the model's holistic judgement across those five, weighing everything together into a single number.
 
-Score on 1.0–5.0. Set a threshold — career-ops uses 4.0 — and reject everything below it. In practice, on a scan of 100 listings, roughly 8–12 will clear a 4.0 threshold against a well-defined archetype. The rest are off-archetype, under-leveled, mispriced, or carry flags severe enough that applying is wasted time.
+Score on 1-5. Set a threshold — career-ops uses 4.0 — and reject everything below it. In practice, on a scan of 100 listings, roughly 8–12 will clear a 4.0 threshold against a well-defined archetype. The rest are off-archetype, under-leveled, mispriced, or carry flags severe enough that applying is wasted time.
 
 The cost of this step before LLMs was thirty minutes of careful reading per listing, which meant most people skipped the step. With LLMs, the cost per evaluation is under a minute and a few cents of tokens. The economics shifted; the discipline did not.
 

--- a/content/docs/reference/glossary.es.mdx
+++ b/content/docs/reference/glossary.es.mdx
@@ -1,6 +1,6 @@
 ---
 title: Glosario
-description: El vocabulario de una búsqueda de empleo con IA, definido — ATS, la puntuación global 1.0–5.0, Data Contract, spray-and-pray, liveness check, tailoring, zero-token scan, historias STAR+R y todos los términos que usa career-ops.
+description: El vocabulario de una búsqueda de empleo con IA, definido — ATS, la puntuación global 1-5, Data Contract, spray-and-pray, liveness check, tailoring, zero-token scan, historias STAR+R y todos los términos que usa career-ops.
 seoTitle: "Glosario de career-ops — términos de la búsqueda de empleo con IA, definidos"
 icon: BookOpen
 translationHash: 3d0e7dc65eb36dbf
@@ -17,7 +17,7 @@ Todos los términos que usa career-ops, definidos en un solo lugar. Cada términ
 
 El software que usan las empresas para recibir, almacenar y filtrar candidaturas — [Greenhouse](/es/docs/reference/portals/greenhouse), [Ashby](/es/docs/reference/portals/ashby) y [Lever](/es/docs/reference/portals/lever) son ejemplos habituales. career-ops lee sus APIs públicas de empleo para descubrir vacantes y puede prerrellenar sus formularios de solicitud, pero nunca envía nada automáticamente.
 
-## Puntuación global (1.0–5.0)
+## Puntuación global (1-5)
 
 El juicio holístico del LLM sobre una oferta a partir de cinco dimensiones (encaje con el CV, alineación con tu north star, compensación, señales culturales y red flags), que produce una puntuación de 1.0 a 5.0. Con 4.5 o más el agente recomienda presentar la candidatura de inmediato; por debajo de 4.0 recomienda no hacerlo. No hay fórmula cerrada de ponderación: la puntuación es el juicio del LLM guiado por la rúbrica, que es pública en la [página de metodología](https://career-ops.org/methodology).
 

--- a/content/docs/reference/glossary.fr.mdx
+++ b/content/docs/reference/glossary.fr.mdx
@@ -1,6 +1,6 @@
 ---
 title: Glossaire
-description: Le vocabulaire de la recherche d'emploi assistée par IA, défini — ATS, le score global 1.0–5.0, Data Contract, spray-and-pray, liveness check, tailoring, scan zéro token, histoires STAR+R, et chaque terme utilisé par career-ops.
+description: Le vocabulaire de la recherche d'emploi assistée par IA, défini — ATS, le score global 1-5, Data Contract, spray-and-pray, liveness check, tailoring, scan zéro token, histoires STAR+R, et chaque terme utilisé par career-ops.
 seoTitle: "Glossaire career-ops — les termes de la recherche d'emploi assistée par IA, définis"
 icon: BookOpen
 translationHash: 3d0e7dc65eb36dbf
@@ -17,7 +17,7 @@ Chaque terme utilisé par career-ops, défini en un seul endroit. Les termes ren
 
 Le logiciel que les entreprises utilisent pour recevoir, stocker et filtrer les candidatures — [Greenhouse](/docs/reference/portals/greenhouse), [Ashby](/docs/reference/portals/ashby) et [Lever](/docs/reference/portals/lever) en sont des exemples courants. career-ops lit leurs API publiques d'offres pour découvrir les postes ouverts et peut pré-remplir leurs formulaires de candidature, mais ne soumet jamais rien automatiquement.
 
-## Score global (1.0–5.0)
+## Score global (1-5)
 
 Le jugement holistique du LLM sur une offre d'emploi, selon cinq dimensions (correspondance avec le CV, alignement avec votre north star, rémunération, signaux culturels et red flags), qui produit un score de 1.0 à 5.0. À partir de 4.5, l'agent recommande de postuler immédiatement ; en dessous de 4.0, il recommande de ne pas le faire. Il n'existe pas de formule de pondération fermée : le score est le jugement du LLM guidé par la grille, publique sur la [page méthodologie](https://career-ops.org/methodology).
 

--- a/content/docs/reference/glossary.mdx
+++ b/content/docs/reference/glossary.mdx
@@ -1,6 +1,6 @@
 ---
 title: Glossary
-description: The vocabulary of an AI-powered job search, defined — ATS, the 1.0–5.0 global score, Data Contract, spray-and-pray, liveness check, tailoring, zero-token scan, STAR+R stories, and every term career-ops uses.
+description: The vocabulary of an AI-powered job search, defined — ATS, the 1-5 global score, Data Contract, spray-and-pray, liveness check, tailoring, zero-token scan, STAR+R stories, and every term career-ops uses.
 seoTitle: "career-ops glossary — AI-powered job search terms, defined"
 icon: BookOpen
 ---
@@ -14,7 +14,7 @@ Every term career-ops uses, defined in one place. Terms link to the deeper refer
 
 The software companies use to receive, store, and filter job applications — [Greenhouse](/docs/reference/portals/greenhouse), [Ashby](/docs/reference/portals/ashby), and [Lever](/docs/reference/portals/lever) are common examples. career-ops reads their public job APIs to discover openings and can pre-fill their application forms, but never auto-submits.
 
-## Global score (1.0–5.0)
+## Global score (1-5)
 
 The LLM's holistic judgement of a job listing across five dimensions (match, north-star alignment, comp, cultural signals, red flags), producing a score from 1.0 to 5.0. At 4.5+ the agent recommends applying immediately; below 4.0 it recommends against applying. There is no closed-form weighting formula: the score is the LLM's judgement given the rubric, which is public on the [methodology page](https://career-ops.org/methodology).
 

--- a/src/app/(home)/home-dict.tsx
+++ b/src/app/(home)/home-dict.tsx
@@ -106,7 +106,7 @@ export const homeEn: HomeDict = {
       locally on your machine inside any AI coding CLI — Claude Code, OpenCode,
       Codex, GitHub Copilot, and more. It evaluates job listings against your CV
       using a five-dimension rubric plus a holistic global score, scoring
-      1.0–5.0, generates ATS-optimized PDF resumes tailored per role, drafts
+      1-5, generates ATS-optimized PDF resumes tailored per role, drafts
       answers to open-ended application questions on Greenhouse, Ashby and Lever
       forms, scans 150+ company portals zero-token, and tracks the pipeline in a
       Go-based terminal dashboard. Everything lives on your machine:{' '}
@@ -212,7 +212,7 @@ export const homeEn: HomeDict = {
         <>
           career-ops uses a rubric-guided LLM evaluation across five dimensions —
           match, north-star alignment, comp, cultural signals, red flags —
-          producing a holistic 1.0–5.0 global score with citations to specific CV
+          producing a holistic 1-5 global score with citations to specific CV
           lines and JD requirements. Anything below 4.0 the agent recommends
           against applying. No closed-form formula, no spray-and-pray. The full
           rubric is published at{' '}

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -158,7 +158,7 @@ export default function AboutPage() {
           </p>
           <p>
             career-ops grew out of a personal job search in early 2026. After the exit, instead
-            of spraying applications, he wrote a structured evaluator: five dimensions, a 1.0–5.0
+            of spraying applications, he wrote a structured evaluator: five dimensions, a 1-5
             score, and a hard floor at 4.0 below which the system refuses to recommend applying.
             740 listings evaluated, 68 applications sent, 12 interview processes, one offer
             signed. The funnel data lives at{' '}

--- a/src/lib/data/comparisons.json
+++ b/src/lib/data/comparisons.json
@@ -130,7 +130,7 @@
         },
         {
           "name": "Match-mode scoring",
-          "careerOps": "Yes — five scoring dimensions plus a holistic 1.0–5.0 global score, recommendations gated at 4.0. Cited evidence per dimension.",
+          "careerOps": "Yes — five scoring dimensions plus a holistic 1-5 global score, recommendations gated at 4.0. Cited evidence per dimension.",
           "competitor": "Yes — match score against a single job description. Algorithm not disclosed."
         },
         {
@@ -559,7 +559,7 @@
       "features": [
         {
           "name": "Application model",
-          "careerOps": "Score-gated apply. Listings scored 1.0–5.0 against a rubric of five scoring dimensions plus a holistic global score; only those above 4.0 are recommended. Tailored per listing. You submit.",
+          "careerOps": "Score-gated apply. Listings scored 1-5 against a rubric of five scoring dimensions plus a holistic global score; only those above 4.0 are recommended. Tailored per listing. You submit.",
           "competitor": "Spray-and-pray. The bot clicks Easy Apply on every listing matching a keyword filter, hundreds per day. Generic submissions, no tailoring depth."
         },
         {

--- a/src/lib/glossary-data.ts
+++ b/src/lib/glossary-data.ts
@@ -13,7 +13,7 @@ export const GLOSSARY_TERMS: GlossaryTerm[] = [
       'The software companies use to receive, store, and filter job applications — Greenhouse, Ashby, and Lever are common examples. career-ops reads their public job APIs to discover openings and can pre-fill their application forms, but never auto-submits.',
   },
   {
-    term: 'Global score (1.0–5.0)',
+    term: 'Global score (1-5)',
     definition:
       "The LLM's holistic judgement of a job listing across five dimensions (match, north-star alignment, comp, cultural signals, red flags), producing a score from 1.0 to 5.0. At 4.5+ the agent recommends applying immediately; below 4.0 it recommends against applying. There is no closed-form weighting formula: the score is the LLM's judgement given the rubric, which is public on the methodology page.",
   },

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -923,7 +923,7 @@ function homeFaqGraph(id: string, lang: string, entries: HomeFaqQA[]) {
 const HOME_FAQ_EN: HomeFaqQA[] = [
   {
     q: 'How does career-ops score job listings?',
-    a: 'career-ops uses a rubric-guided LLM evaluation across five dimensions — match, north-star alignment, comp, cultural signals, red flags — producing a holistic 1.0–5.0 global score with citations to specific CV lines and JD requirements. Anything below 4.0 the agent recommends against applying. No closed-form formula, no spray-and-pray. The full rubric is published at career-ops.org/methodology.',
+    a: 'career-ops uses a rubric-guided LLM evaluation across five dimensions — match, north-star alignment, comp, cultural signals, red flags — producing a holistic 1-5 global score with citations to specific CV lines and JD requirements. Anything below 4.0 the agent recommends against applying. No closed-form formula, no spray-and-pray. The full rubric is published at career-ops.org/methodology.',
   },
   {
     q: 'Does career-ops apply to jobs for me?',


### PR DESCRIPTION
The scale was written `1.0–5.0` in **fourteen places** while the core canon (`modes/_shared.md:77`) says *"one global score of 1-5"*. Google's AI Overview for `career-ops` now reproduces the old form verbatim, **citing career-ops.org as its source** — so every day it stays is another copy.

## The rule (maintainer + cv-santiago, 2026-09-01, doctrine §15)

The **name** of the scale is `1-5`. Decimal **values** stay.

```
## Global score (1-5)                          ← name
Score on a 1-5 scale. Set a threshold — career-ops uses 4.0   ← value untouched
```

Verified on every changed line that `4.0` survived.

## Applied everywhere, not only where it was spotted

search-ops saw five lines in the rendered `llms-full.txt`. The source had **fourteen**: the same string also lived in the home dictionary, the about page, the ES and FR glossaries, `comparisons.json`, `glossary-data.ts` and the FAQ schema. Fixing five and leaving nine would have manufactured a new pair of surfaces that disagree — the bug class this repo keeps finding.

## translationHash did not move, and that is correct

The two glossary occurrences sit in the frontmatter `description` and a `##` heading. Both are excluded from the hash by design (it hashes prose body only). Not a blind spot — deliberate scope.

**Text-only. No visual change.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BcPLgMFMs2B4SJv3vfq8jv