### PR TITLE
fix(docs): point the edit-on-GitHub links at the org repo

### DIFF
--- a/src/lib/shared.ts
+++ b/src/lib/shared.ts
@@ -8,7 +8,7 @@ export const docsContentRoute = '/llms.mdx/docs';
 // `career-ops` repo (that mismatch shipped 404 links on all docs pages
 // until 2026-07-06).
 export const gitConfig = {
-  user: 'santifer',
+  user: 'career-ops-hq',
   repo: 'career-ops-docs',
   branch: 'main',
 };


### PR DESCRIPTION
The docs repo moved to `career-ops-hq/career-ops-docs` today. Every docs page carries an **Edit on GitHub** link built from `gitConfig`, which still named the old owner.

GitHub redirects transferred repos today, but that redirect dies the moment anyone recreates `santifer/career-ops-docs` — the same squatter shape already seen with the core org. And the comment above `gitConfig` records that a wrong owner here once 404'd every docs page.

Text/config only. No visual change.

**Not merging yet:** the Vercel GitHub App is not installed on `career-ops-hq`, so a push to `main` would not deploy. This PR is the deploy test once it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BcPLgMFMs2B4SJv3vfq8jv